### PR TITLE
Add `getInitializeInstructionsForMintExtensions` helper

### DIFF
--- a/clients/js/src/getInitializeInstructionsForMintExtensions.ts
+++ b/clients/js/src/getInitializeInstructionsForMintExtensions.ts
@@ -1,0 +1,44 @@
+import { Address, IInstruction } from '@solana/web3.js';
+import {
+  ExtensionArgs,
+  getInitializeConfidentialTransferMintInstruction,
+  getInitializeDefaultAccountStateInstruction,
+  getInitializeTransferFeeConfigInstruction,
+} from './generated';
+
+export function getInitializeInstructionsForMintExtensions(
+  mint: Address,
+  extensions: ExtensionArgs[]
+): IInstruction[] {
+  return extensions.flatMap((extension) => {
+    switch (extension.__kind) {
+      case 'ConfidentialTransferMint':
+        return [
+          getInitializeConfidentialTransferMintInstruction({
+            mint,
+            ...extension,
+          }),
+        ];
+      case 'DefaultAccountState':
+        return [
+          getInitializeDefaultAccountStateInstruction({
+            mint,
+            state: extension.state,
+          }),
+        ];
+      case 'TransferFeeConfig':
+        return [
+          getInitializeTransferFeeConfigInstruction({
+            mint,
+            transferFeeConfigAuthority: extension.transferFeeConfigAuthority,
+            withdrawWithheldAuthority: extension.withdrawWithheldAuthority,
+            transferFeeBasisPoints:
+              extension.newerTransferFee.transferFeeBasisPoints,
+            maximumFee: extension.newerTransferFee.maximumFee,
+          }),
+        ];
+      default:
+        return [];
+    }
+  });
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,4 +1,5 @@
 export * from './generated';
 
+export * from './getInitializeInstructionsForMintExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -28,6 +28,7 @@ import {
   ExtensionArgs,
   TOKEN_2022_PROGRAM_ADDRESS,
   getInitializeAccountInstruction,
+  getInitializeInstructionsForMintExtensions,
   getInitializeMintInstruction,
   getMintSize,
   getMintToInstruction,
@@ -163,8 +164,18 @@ export const createMint = async (
   input: Omit<Parameters<typeof getCreateMintInstructions>[0], 'mint'>
 ): Promise<Address> => {
   const mint = await generateKeyPairSigner();
-  const instructions = await getCreateMintInstructions({ ...input, mint });
-  await sendAndConfirmInstructions(input.client, input.payer, instructions);
+  const [createAccount, initMint] = await getCreateMintInstructions({
+    ...input,
+    mint,
+  });
+  await sendAndConfirmInstructions(input.client, input.payer, [
+    createAccount,
+    ...getInitializeInstructionsForMintExtensions(
+      mint.address,
+      input.extensions ?? []
+    ),
+    initMint,
+  ]);
   return mint.address;
 };
 


### PR DESCRIPTION
Given an array of extensions, give an array of instructions that should be used when initializing the mint account.