### PR TITLE
Add more helpers to get init instructions for extensions

### DIFF
--- a/clients/js/src/getInitializeInstructionsForExtensions.ts
+++ b/clients/js/src/getInitializeInstructionsForExtensions.ts
@@ -6,7 +6,12 @@ import {
   getInitializeTransferFeeConfigInstruction,
 } from './generated';
 
-export function getInitializeInstructionsForMintExtensions(
+/**
+ * Given a mint address and a list of mint extensions, returns a list of
+ * instructions that MUST be run _before_ the `initializeMint` instruction
+ * to properly initialize the given extensions on the mint account.
+ */
+export function getPreInitializeInstructionsForMintExtensions(
   mint: Address,
   extensions: ExtensionArgs[]
 ): IInstruction[] {
@@ -37,6 +42,40 @@ export function getInitializeInstructionsForMintExtensions(
             maximumFee: extension.newerTransferFee.maximumFee,
           }),
         ];
+      default:
+        return [];
+    }
+  });
+}
+
+/**
+ * Given a mint address and a list of mint extensions, returns a list of
+ * instructions that MUST be run _after_ the `initializeMint` instruction
+ * to properly initialize the given extensions on the mint account.
+ */
+export function getPostInitializeInstructionsForMintExtensions(
+  _mint: Address,
+  extensions: ExtensionArgs[]
+): IInstruction[] {
+  return extensions.flatMap((extension) => {
+    switch (extension.__kind) {
+      default:
+        return [];
+    }
+  });
+}
+
+/**
+ * Given a token address and a list of token extensions, returns a list of
+ * instructions that MUST be run _after_ the `initializeAccount` instruction
+ * to properly initialize the given extensions on the token account.
+ */
+export function getPostInitializeInstructionsForTokenExtensions(
+  _token: Address,
+  extensions: ExtensionArgs[]
+): IInstruction[] {
+  return extensions.flatMap((extension) => {
+    switch (extension.__kind) {
       default:
         return [];
     }

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,5 +1,5 @@
 export * from './generated';
 
-export * from './getInitializeInstructionsForMintExtensions';
+export * from './getInitializeInstructionsForExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';

--- a/clients/js/test/extensions/defaultAccountState/initializeDefaultAccountState.test.ts
+++ b/clients/js/test/extensions/defaultAccountState/initializeDefaultAccountState.test.ts
@@ -1,4 +1,4 @@
-import { Account, address, generateKeyPairSigner, some } from '@solana/web3.js';
+import { Account, generateKeyPairSigner, some } from '@solana/web3.js';
 import test from 'ava';
 import {
   AccountState,
@@ -65,8 +65,9 @@ test('it initializes a mint account with a default account state extension', asy
 test('it initializes a token account with the default state defined on the mint account', async (t) => {
   // Given some signer accounts.
   const client = createDefaultSolanaClient();
-  const [authority, freezeAuthority] = await Promise.all([
+  const [authority, freezeAuthority, owner] = await Promise.all([
     generateKeyPairSignerWithSol(client),
+    generateKeyPairSigner(),
     generateKeyPairSigner(),
   ]);
 
@@ -82,12 +83,7 @@ test('it initializes a token account with the default state defined on the mint 
   });
 
   // When we create a new token account for the mint.
-  const token = await createToken({
-    client,
-    mint,
-    owner: address('HHS1XymmkBpYAkg3XTbZLxgHa5n11PAWUCWdiVtRmzzS'),
-    payer: authority,
-  });
+  const token = await createToken({ client, mint, owner, payer: authority });
 
   // Then we expect the token account to have the default state defined on the mint account.
   const tokenAccount = await fetchToken(client.rpc, token);

--- a/clients/js/test/extensions/memoTransfers/disableMemoTransfers.test.ts
+++ b/clients/js/test/extensions/memoTransfers/disableMemoTransfers.test.ts
@@ -5,7 +5,6 @@ import {
   extension,
   fetchToken,
   getDisableMemoTransfersInstruction,
-  getEnableMemoTransfersInstruction,
 } from '../../../src';
 import {
   createDefaultSolanaClient,
@@ -84,9 +83,6 @@ test('it disables an active memo transfers extension', async (t) => {
     owner,
     payer: authority,
   });
-  await sendAndConfirmInstructions(client, authority, [
-    getEnableMemoTransfersInstruction({ token, owner }),
-  ]);
 
   // When we disable the memo transfers extension.
   await sendAndConfirmInstructions(client, authority, [

--- a/clients/js/test/extensions/memoTransfers/disableMemoTransfers.test.ts
+++ b/clients/js/test/extensions/memoTransfers/disableMemoTransfers.test.ts
@@ -81,7 +81,7 @@ test('it disables an active memo transfers extension', async (t) => {
       extension('MemoTransfer', { requireIncomingTransferMemos: true }),
     ],
     mint,
-    owner: owner.address,
+    owner,
     payer: authority,
   });
   await sendAndConfirmInstructions(client, authority, [

--- a/clients/js/test/extensions/memoTransfers/enableMemoTransfers.test.ts
+++ b/clients/js/test/extensions/memoTransfers/enableMemoTransfers.test.ts
@@ -81,7 +81,7 @@ test('it enables an disabled memo transfers extension', async (t) => {
       extension('MemoTransfer', { requireIncomingTransferMemos: false }),
     ],
     mint,
-    owner: owner.address,
+    owner,
     payer: authority,
   });
   await sendAndConfirmInstructions(client, authority, [

--- a/clients/js/test/extensions/memoTransfers/enableMemoTransfers.test.ts
+++ b/clients/js/test/extensions/memoTransfers/enableMemoTransfers.test.ts
@@ -4,7 +4,6 @@ import {
   Token,
   extension,
   fetchToken,
-  getDisableMemoTransfersInstruction,
   getEnableMemoTransfersInstruction,
 } from '../../../src';
 import {
@@ -84,9 +83,6 @@ test('it enables an disabled memo transfers extension', async (t) => {
     owner,
     payer: authority,
   });
-  await sendAndConfirmInstructions(client, authority, [
-    getDisableMemoTransfersInstruction({ token, owner }),
-  ]);
 
   // When we enable the memo transfers extension.
   await sendAndConfirmInstructions(client, authority, [

--- a/clients/js/test/extensions/reallocate.test.ts
+++ b/clients/js/test/extensions/reallocate.test.ts
@@ -33,7 +33,7 @@ test('it reallocates token accounts to fit the provided extensions', async (t) =
   const token = await createToken({
     client,
     mint,
-    owner: owner.address,
+    owner,
     payer: authority,
   });
   t.is(await getAccountLength(client, token), 165);

--- a/clients/js/test/mintTo.test.ts
+++ b/clients/js/test/mintTo.test.ts
@@ -28,12 +28,7 @@ test('it mints tokens to a token account', async (t) => {
     payer,
     authority: mintAuthority.address,
   });
-  const token = await createToken({
-    client,
-    payer,
-    mint,
-    owner: owner.address,
-  });
+  const token = await createToken({ client, payer, mint, owner });
 
   // When the mint authority mints tokens to the token account.
   const mintTo = getMintToInstruction({

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -37,10 +37,10 @@ test('it transfers tokens from one account to another', async (t) => {
       payer,
       mintAuthority,
       mint,
-      owner: ownerA.address,
+      owner: ownerA,
       amount: 100n,
     }),
-    createToken({ client, payer, mint, owner: ownerB.address }),
+    createToken({ client, payer, mint, owner: ownerB }),
   ]);
 
   // When owner A transfers 50 tokens to owner B.


### PR DESCRIPTION
This PR renames the `getInitializeInstructionsForMintExtensions` function to `getPreInitializeInstructionsForMintExtensions` and adds two new helper functions:
- `getPostInitializeInstructionsForMintExtensions` for extensions that needs initializing after the mint account was initialized.
- `getPostInitializeInstructionsForTokenExtensions` for getting initialize instructions for token extensions (which must always be used _after_ the token accounts was initialized). 