### PR TITLE
feat: add multisig signer arg to CreateAccount command

### DIFF
--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -1229,6 +1229,7 @@ pub fn app<'a>(
                         ),
                 )
                 .arg(owner_address_arg())
+                .arg(multisig_signer_arg())
                 .nonce_args(true)
         )
         .subcommand(


### PR DESCRIPTION
Add support for multisig accounts to the CreateAccount command by including the multisig_signer_arg() argument.