### PR TITLE
[js-legacy] Add confidential transfer `InitializeMint` and `UpdateMint`

### DIFF
--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -56,6 +56,7 @@
         "@solana/buffer-layout-utils": "^0.2.0",
         "@solana/spl-token-group": "^0.0.7",
         "@solana/spl-token-metadata": "^0.1.6",
+        "@solana/zk-sdk": "0.1.0",
         "buffer": "^6.0.3"
     },
     "devDependencies": {

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@solana/spl-token-metadata':
         specifier: ^0.1.6
         version: 0.1.6(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.7.3)
+      '@solana/zk-sdk':
+        specifier: 0.1.0
+        version: 0.1.0
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -291,6 +294,9 @@ packages:
 
   '@solana/web3.js@1.98.0':
     resolution: {integrity: sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==}
+
+  '@solana/zk-sdk@0.1.0':
+    resolution: {integrity: sha512-5iWTokAx6sOLSJVj7wABhhHtJ2KifXP1yjefBwXhd/BNwl+ZmI5KwQEGPYHGJEDabhqwam2Kwly7N+k0Bj7Bng==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1729,6 +1735,8 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
+
+  '@solana/zk-sdk@0.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/clients/js-legacy/src/extensions/confidentialTransfer/actions.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/actions.ts
@@ -1,0 +1,41 @@
+import type { ConfirmOptions, Connection, PublicKey, Signer, TransactionSignature } from '@solana/web3.js';
+import { sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';
+import { createConfidentialTransferUpdateMintInstruction } from './instructions.js';
+import type { PodElGamalPubkey } from '@solana/zk-sdk';
+
+/**
+ * Update confidential transfer mint
+ *
+ * @param connection                Connection to use
+ * @param payer                     Payer of the transaction fees
+ * @param mint                      The token mint
+ * @param autoApproveNewAccounts    New auto-approve account policy
+ * @param auditorElGamalPubkey      New Auditor ElGamal public key
+ * @param confirmOptions            Options for confirming the transaction
+ * @param programId                 SPL Token program account
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function updateMint(
+    connection: Connection,
+    payer: Signer,
+    mint: PublicKey,
+    autoApproveNewAccounts: boolean,
+    auditorElGamalPubkey: PodElGamalPubkey | null,
+    authority: Signer,
+    confirmOptions?: ConfirmOptions,
+    programId = TOKEN_2022_PROGRAM_ID,
+): Promise<TransactionSignature> {
+    const transaction = new Transaction().add(
+        createConfidentialTransferUpdateMintInstruction(
+            mint,
+            authority.publicKey,
+            autoApproveNewAccounts,
+            auditorElGamalPubkey,
+            programId,
+        ),
+    );
+
+    return await sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions);
+}

--- a/clients/js-legacy/src/extensions/confidentialTransfer/actions.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/actions.ts
@@ -12,6 +12,7 @@ import type { PodElGamalPubkey } from '@solana/zk-sdk';
  * @param mint                      The token mint
  * @param autoApproveNewAccounts    New auto-approve account policy
  * @param auditorElGamalPubkey      New Auditor ElGamal public key
+ * @param authority                 Confidential transfer authority of the mint
  * @param confirmOptions            Options for confirming the transaction
  * @param programId                 SPL Token program account
  *

--- a/clients/js-legacy/src/extensions/confidentialTransfer/elgamal.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/elgamal.ts
@@ -23,7 +23,7 @@ export const elgamalPublicKey = (property?: string): Layout<PodElGamalPubkey> =>
 };
 
 export const elgamalCiphertext = (property?: string): Layout<PodElGamalCiphertext> => {
-    const layout = blob(32, property);
+    const layout = blob(64, property);
     const { encode, decode } = encodeDecode(layout);
 
     const elgamalCiphertextLayout = layout as Layout<unknown> as Layout<PodElGamalCiphertext>;

--- a/clients/js-legacy/src/extensions/confidentialTransfer/elgamal.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/elgamal.ts
@@ -1,0 +1,61 @@
+import { blob } from '@solana/buffer-layout';
+import type { Layout } from '@solana/buffer-layout';
+import { encodeDecode } from '@solana/buffer-layout-utils';
+import { PodElGamalPubkey, PodElGamalCiphertext, PodAeCiphertext } from '@solana/zk-sdk';
+
+export const elgamalPublicKey = (property?: string): Layout<PodElGamalPubkey> => {
+    const layout = blob(32, property);
+    const { encode, decode } = encodeDecode(layout);
+
+    const elgamalPublicKeyLayout = layout as Layout<unknown> as Layout<PodElGamalPubkey>;
+
+    elgamalPublicKeyLayout.decode = (buffer: Buffer, offset: number) => {
+        const src = decode(buffer, offset);
+        return new PodElGamalPubkey(src);
+    };
+
+    elgamalPublicKeyLayout.encode = (elgamalPublicKey: PodElGamalPubkey, buffer: Buffer, offset: number) => {
+        const src = elgamalPublicKey.toBytes();
+        return encode(src, buffer, offset);
+    };
+
+    return elgamalPublicKeyLayout;
+};
+
+export const elgamalCiphertext = (property?: string): Layout<PodElGamalCiphertext> => {
+    const layout = blob(32, property);
+    const { encode, decode } = encodeDecode(layout);
+
+    const elgamalCiphertextLayout = layout as Layout<unknown> as Layout<PodElGamalCiphertext>;
+
+    elgamalCiphertextLayout.decode = (buffer: Buffer, offset: number) => {
+        const src = decode(buffer, offset);
+        return new PodElGamalCiphertext(src);
+    };
+
+    elgamalCiphertextLayout.encode = (elgamalCiphertext: PodElGamalCiphertext, buffer: Buffer, offset: number) => {
+        const src = elgamalCiphertext.toBytes();
+        return encode(src, buffer, offset);
+    };
+
+    return elgamalCiphertextLayout;
+};
+
+export const aeCiphertext = (property?: string): Layout<PodAeCiphertext> => {
+    const layout = blob(36, property);
+    const { encode, decode } = encodeDecode(layout);
+
+    const aeCiphertextLayout = layout as Layout<unknown> as Layout<PodAeCiphertext>;
+
+    aeCiphertextLayout.decode = (buffer: Buffer, offset: number) => {
+        const src = decode(buffer, offset);
+        return new PodAeCiphertext(src);
+    };
+
+    aeCiphertextLayout.encode = (aeCiphertext: PodAeCiphertext, buffer: Buffer, offset: number) => {
+        const src = aeCiphertext.toBytes();
+        return encode(src, buffer, offset);
+    };
+
+    return aeCiphertextLayout;
+};

--- a/clients/js-legacy/src/extensions/confidentialTransfer/index.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/index.ts
@@ -1,0 +1,3 @@
+export * from './actions.js';
+export * from './instructions.js';
+export * from './state.js';

--- a/clients/js-legacy/src/extensions/confidentialTransfer/instructions.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/instructions.ts
@@ -29,7 +29,7 @@ export const initializeMintData = struct<InitializeMintData>([
 ]);
 
 /**
- * Construct an InitializeConfidentialTransferInitializeMint instruction
+ * Construct a ConfidentialTransferInitializeMint instruction
  *
  * @param mint                              Token mint account
  * @param confidentialTransferMintAuthority Authority that can update confidential transfer mint

--- a/clients/js-legacy/src/extensions/confidentialTransfer/instructions.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/instructions.ts
@@ -1,0 +1,122 @@
+import { struct, u8 } from '@solana/buffer-layout';
+import { bool, publicKey } from '@solana/buffer-layout-utils';
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID } from '../../constants.js';
+import { TokenUnsupportedInstructionError } from '../../errors.js';
+import { TokenInstruction } from '../../instructions/types.js';
+import { elgamalPublicKey } from './elgamal.js';
+import { PodElGamalPubkey } from '@solana/zk-sdk';
+
+export enum ConfidentialTransferInstruction {
+    InitializeMint = 0,
+    UpdateMint = 1,
+}
+
+export interface InitializeMintData {
+    instruction: TokenInstruction.ConfidentialTransferExtension;
+    confidentialTransferInstruction: ConfidentialTransferInstruction.InitializeMint;
+    confidentialTransferMintAuthority: PublicKey | null;
+    autoApproveNewAccounts: boolean;
+    auditorElGamalPubkey: PodElGamalPubkey | null;
+}
+
+export const initializeMintData = struct<InitializeMintData>([
+    u8('instruction'),
+    u8('confidentialTransferInstruction'),
+    publicKey('confidentialTransferMintAuthority'),
+    bool('autoApproveNewAccounts'),
+    elgamalPublicKey('auditorElGamalPubkey'),
+]);
+
+/**
+ * Construct an InitializeConfidentialTransferInitializeMint instruction
+ *
+ * @param mint                              Token mint account
+ * @param confidentialTransferMintAuthority Authority that can update confidential transfer mint
+ * @param autoApproveNewAccounts            Auto-approve account policy
+ * @param auditorElGamalPubkey              Optional auditor ElGamal public key
+ * @param programId                         SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createConfidentialTransferInitializeMintInstruction(
+    mint: PublicKey,
+    confidentialTransferMintAuthority: PublicKey | null,
+    autoApproveNewAccounts: boolean,
+    auditorElGamalPubkey: PodElGamalPubkey | null,
+    programId = TOKEN_2022_PROGRAM_ID,
+): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
+    const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
+
+    const data = Buffer.alloc(initializeMintData.span);
+
+    initializeMintData.encode(
+        {
+            instruction: TokenInstruction.ConfidentialTransferExtension,
+            confidentialTransferInstruction: ConfidentialTransferInstruction.InitializeMint,
+            confidentialTransferMintAuthority: confidentialTransferMintAuthority ?? PublicKey.default,
+            autoApproveNewAccounts: autoApproveNewAccounts,
+            auditorElGamalPubkey: auditorElGamalPubkey ?? PodElGamalPubkey.zeroed(),
+        },
+        data,
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+export interface UpdateMintData {
+    instruction: TokenInstruction.ConfidentialTransferExtension;
+    confidentialTransferInstruction: ConfidentialTransferInstruction.UpdateMint;
+    autoApproveNewAccounts: boolean;
+    auditorElGamalPubkey: PodElGamalPubkey | null;
+}
+
+export const updateMintData = struct<UpdateMintData>([
+    u8('instruction'),
+    u8('confidentialTransferInstruction'),
+    bool('autoApproveNewAccounts'),
+    elgamalPublicKey('auditorElGamalPubkey'),
+]);
+
+/**
+ * Construct an UpdateMint instruction
+ *
+ * @param mint                              Token mint account
+ * @param confidentialTransferMintAuthority Authority that can update confidential transfer mint
+ * @param autoApproveNewAccounts            New auto-approve account policy
+ * @param auditorElGamalPubkey              New auditor ElGamal public key
+ * @param programId                         SPL Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createConfidentialTransferUpdateMintInstruction(
+    mint: PublicKey,
+    confidentialTransferMintAuthority: PublicKey,
+    autoApproveNewAccounts: boolean,
+    auditorElGamalPubkey: PodElGamalPubkey | null,
+    programId = TOKEN_2022_PROGRAM_ID,
+): TransactionInstruction {
+    if (!programSupportsExtensions(programId)) {
+        throw new TokenUnsupportedInstructionError();
+    }
+    const keys = [
+        { pubkey: mint, isSigner: false, isWritable: true },
+        { pubkey: confidentialTransferMintAuthority, isSigner: true, isWritable: false },
+    ];
+
+    const data = Buffer.alloc(updateMintData.span);
+    updateMintData.encode(
+        {
+            instruction: TokenInstruction.ConfidentialTransferExtension,
+            confidentialTransferInstruction: ConfidentialTransferInstruction.UpdateMint,
+            autoApproveNewAccounts: autoApproveNewAccounts,
+            auditorElGamalPubkey: auditorElGamalPubkey ?? PodElGamalPubkey.zeroed(),
+        },
+        data,
+    );
+
+    return new TransactionInstruction({ keys, programId, data });
+}

--- a/clients/js-legacy/src/extensions/confidentialTransfer/state.ts
+++ b/clients/js-legacy/src/extensions/confidentialTransfer/state.ts
@@ -1,0 +1,76 @@
+import { struct } from '@solana/buffer-layout';
+import { publicKey, bool, u64 } from '@solana/buffer-layout-utils';
+import type { PublicKey } from '@solana/web3.js';
+import type { Mint } from '../../state/mint.js';
+import type { Account } from '../../state/account.js';
+import { ExtensionType, getExtensionData } from '../extensionType.js';
+import type { PodElGamalPubkey, PodElGamalCiphertext, PodAeCiphertext } from '@solana/zk-sdk';
+import { elgamalPublicKey, elgamalCiphertext, aeCiphertext } from './elgamal.js';
+
+/** ConfidentialTransferMint as stored by the program */
+export interface ConfidentialTransferMint {
+    confidentialTransferMintAuthority: PublicKey;
+    autoApproveNewAccounts: boolean;
+    auditorElGamalPubkey: PodElGamalPubkey;
+}
+
+/** Buffer layout for de/serializing a confidential transfer mint */
+export const ConfidentialTransferMintLayout = struct<ConfidentialTransferMint>([
+    publicKey('confidentialTransferMintAuthority'),
+    bool('autoApproveNewAccounts'),
+    elgamalPublicKey('auditorElGamalPubkey'),
+]);
+
+export const CONFIDENTIAL_TRANSFER_MINT_SIZE = ConfidentialTransferMintLayout.span;
+
+export function getConfidentialTransferMint(mint: Mint): ConfidentialTransferMint | null {
+    const extensionData = getExtensionData(ExtensionType.ConfidentialTransferMint, mint.tlvData);
+    if (extensionData !== null) {
+        return ConfidentialTransferMintLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}
+
+/** ConfidentialTransferAccount as stored by the program */
+export interface ConfidentialTransferAccount {
+    approved: boolean;
+    elgamalPubkey: PodElGamalPubkey;
+    pendingBalanceLo: PodElGamalCiphertext;
+    pendingBalanceHi: PodElGamalCiphertext;
+    availableBalance: PodElGamalCiphertext;
+    decryptableAvailableBalance: PodAeCiphertext;
+    allowConfidentialCredits: boolean;
+    allowNonConfidentialCredits: boolean;
+    pendingBalanceCreditCounter: bigint;
+    maximumPendingBalanceCreditCounter: bigint;
+    expectedPendingBalanceCreditCounter: bigint;
+    actualPendingBalanceCreditCounter: bigint;
+}
+
+/** Buffer layout for de/serializing a confidential transfer account */
+export const ConfidentialTransferAccountLayout = struct<ConfidentialTransferAccount>([
+    bool('approved'),
+    elgamalPublicKey('elgamalPubkey'),
+    elgamalCiphertext('pendingBalanceLo'),
+    elgamalCiphertext('pendingBalanceLo'),
+    elgamalCiphertext('availableBalance'),
+    aeCiphertext('decryptableAvailableBalance'),
+    bool('allowConfidentialCredits'),
+    bool('allowNonConfidentialCredits'),
+    u64('pendingBalanceCreditCounter'),
+    u64('maximumPendingBalanceCreditCounter'),
+    u64('expectedPendingBalanceCreditCounter'),
+    u64('actualPendingBalanceCreditCounter'),
+]);
+
+export const CONFIDENTIAL_TRANSFER_ACCOUNT_SIZE = ConfidentialTransferAccountLayout.span;
+
+export function getConfidentialTransferAccount(account: Account): ConfidentialTransferAccount | null {
+    const extensionData = getExtensionData(ExtensionType.ConfidentialTransferAccount, account.tlvData);
+    if (extensionData !== null) {
+        return ConfidentialTransferAccountLayout.decode(extensionData);
+    } else {
+        return null;
+    }
+}

--- a/clients/js-legacy/src/extensions/extensionType.ts
+++ b/clients/js-legacy/src/extensions/extensionType.ts
@@ -6,6 +6,7 @@ import { MINT_SIZE, unpackMint } from '../state/mint.js';
 import { MULTISIG_SIZE } from '../state/multisig.js';
 import { ACCOUNT_TYPE_SIZE } from './accountType.js';
 import { CPI_GUARD_SIZE } from './cpiGuard/index.js';
+import { CONFIDENTIAL_TRANSFER_MINT_SIZE, CONFIDENTIAL_TRANSFER_ACCOUNT_SIZE } from './confidentialTransfer/index.js';
 import { DEFAULT_ACCOUNT_STATE_SIZE } from './defaultAccountState/index.js';
 import { TOKEN_GROUP_SIZE, TOKEN_GROUP_MEMBER_SIZE } from './tokenGroup/index.js';
 import { GROUP_MEMBER_POINTER_SIZE } from './groupMemberPointer/state.js';
@@ -81,9 +82,9 @@ export function getTypeLen(e: ExtensionType): number {
         case ExtensionType.MintCloseAuthority:
             return MINT_CLOSE_AUTHORITY_SIZE;
         case ExtensionType.ConfidentialTransferMint:
-            return 65;
+            return CONFIDENTIAL_TRANSFER_MINT_SIZE;
         case ExtensionType.ConfidentialTransferAccount:
-            return 295;
+            return CONFIDENTIAL_TRANSFER_ACCOUNT_SIZE;
         case ExtensionType.CpiGuard:
             return CPI_GUARD_SIZE;
         case ExtensionType.DefaultAccountState:

--- a/clients/js-legacy/src/extensions/index.ts
+++ b/clients/js-legacy/src/extensions/index.ts
@@ -1,5 +1,6 @@
 export * from './accountType.js';
 export * from './cpiGuard/index.js';
+export * from './confidentialTransfer/index.js';
 export * from './defaultAccountState/index.js';
 export * from './extensionType.js';
 export * from './groupMemberPointer/index.js';

--- a/clients/js-legacy/test/e2e-2022/confidentialTransfer.test.ts
+++ b/clients/js-legacy/test/e2e-2022/confidentialTransfer.test.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import type { PublicKey } from '@solana/web3.js';
+import { Keypair, SystemProgram, Transaction, sendAndConfirmTransaction } from '@solana/web3.js';
+import { TEST_PROGRAM_ID, newAccountWithLamports, getConnection } from '../common';
+
+import {
+    createInitializeMintInstruction,
+    createConfidentialTransferInitializeMintInstruction,
+    ExtensionType,
+    getConfidentialTransferMint,
+    getMint,
+    getMintLen,
+    updateMint,
+} from '../../src';
+
+import { ElGamalKeypair, PodElGamalPubkey } from '@solana/zk-sdk';
+
+const TEST_TOKEN_DECIMALS = 2;
+const MINT_EXTENSIONS = [ExtensionType.ConfidentialTransferMint];
+
+describe('confidentialTransfer', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let mint: PublicKey;
+    let mintAuthority: Keypair;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+    });
+
+    async function setupConfidentialTransferMint(
+        confidentialTransferMintAuthority: PublicKey | null,
+        autoApproveNewAccounts: boolean,
+        auditorPubkey: PodElGamalPubkey | null,
+    ) {
+        const mintKeypair = Keypair.generate();
+        mint = mintKeypair.publicKey;
+        mintAuthority = Keypair.generate();
+        const mintLen = getMintLen(MINT_EXTENSIONS);
+
+        const mintLamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+        const mintTransaction = new Transaction().add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: mint,
+                space: mintLen,
+                lamports: mintLamports,
+                programId: TEST_PROGRAM_ID,
+            }),
+            createConfidentialTransferInitializeMintInstruction(
+                mint,
+                confidentialTransferMintAuthority,
+                autoApproveNewAccounts,
+                auditorPubkey,
+            ),
+            createInitializeMintInstruction(mint, TEST_TOKEN_DECIMALS, mintAuthority.publicKey, null, TEST_PROGRAM_ID),
+        );
+
+        await sendAndConfirmTransaction(connection, mintTransaction, [payer, mintKeypair], undefined);
+    }
+
+    describe('with authorities and auto approve', () => {
+        let confidentialTransferMintAuthority: Keypair;
+        let autoApproveNewAccounts: boolean;
+        let auditorKeypair: ElGamalKeypair;
+        let auditorPubkey: PodElGamalPubkey;
+        beforeEach(async () => {
+            confidentialTransferMintAuthority = Keypair.generate();
+            autoApproveNewAccounts = true;
+            auditorKeypair = ElGamalKeypair.newRand();
+            auditorPubkey = PodElGamalPubkey.encode(auditorKeypair.pubkey_owned());
+
+            await setupConfidentialTransferMint(
+                confidentialTransferMintAuthority.publicKey,
+                autoApproveNewAccounts,
+                auditorPubkey,
+            );
+        });
+
+        it('initialize mint', async () => {
+            const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
+            const confidentialTransferMint = getConfidentialTransferMint(mintInfo);
+            expect(confidentialTransferMint).to.not.equal(null);
+            if (confidentialTransferMint !== null) {
+                expect(confidentialTransferMint.confidentialTransferMintAuthority).to.eql(
+                    confidentialTransferMintAuthority.publicKey,
+                );
+                expect(confidentialTransferMint.autoApproveNewAccounts).to.eql(autoApproveNewAccounts);
+                expect(confidentialTransferMint.auditorElGamalPubkey.equals(auditorPubkey));
+            }
+        });
+
+        it('update mint', async () => {
+            const newAutoApproveNewAccounts = false;
+            const newAuditorElGamalKeypair = ElGamalKeypair.newRand();
+            const newAuditorElGamalPubkey = PodElGamalPubkey.encode(newAuditorElGamalKeypair.pubkey_owned());
+
+            await updateMint(
+                connection,
+                payer,
+                mint,
+                newAutoApproveNewAccounts,
+                newAuditorElGamalPubkey,
+                confidentialTransferMintAuthority,
+            );
+
+            const mintInfo = await getMint(connection, mint, undefined, TEST_PROGRAM_ID);
+            const confidentialTransferMint = getConfidentialTransferMint(mintInfo);
+            expect(confidentialTransferMint).to.not.equal(null);
+            if (confidentialTransferMint !== null) {
+                expect(confidentialTransferMint.autoApproveNewAccounts).to.eql(newAutoApproveNewAccounts);
+                expect(confidentialTransferMint.auditorElGamalPubkey.equals(newAuditorElGamalPubkey));
+            }
+        });
+    });
+});


### PR DESCRIPTION
#### Problem
The confidential transfer extension has not been added to the js-legacy client yet.

#### Summary of Changes
The confidential transfer extension will be added to the js client in a sequence of PRs. In this PR, the `InitializeMint` and `UpdateMint` instructions are added.