### PR TITLE
js-legacy: Fix variable-size encoding of COptionPubkey

### DIFF
--- a/clients/js-legacy/src/extensions/transferFee/instructions.ts
+++ b/clients/js-legacy/src/extensions/transferFee/instructions.ts
@@ -70,7 +70,7 @@ export function createInitializeTransferFeeConfigInstruction(
     }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
-    const data = Buffer.alloc(initializeTransferFeeConfigInstructionData.span);
+    const data = Buffer.alloc(78); // worst-case size
     initializeTransferFeeConfigInstructionData.encode(
         {
             instruction: TokenInstruction.TransferFeeExtension,
@@ -83,7 +83,11 @@ export function createInitializeTransferFeeConfigInstruction(
         data,
     );
 
-    return new TransactionInstruction({ keys, programId, data });
+    return new TransactionInstruction({
+        keys,
+        programId,
+        data: data.subarray(0, initializeTransferFeeConfigInstructionData.getSpan(data)),
+    });
 }
 
 /** A decoded, valid InitializeTransferFeeConfig instruction */
@@ -115,7 +119,7 @@ export function decodeInitializeTransferFeeConfigInstruction(
     programId: PublicKey,
 ): DecodedInitializeTransferFeeConfigInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
-    if (instruction.data.length !== initializeTransferFeeConfigInstructionData.span)
+    if (instruction.data.length !== initializeTransferFeeConfigInstructionData.getSpan(instruction.data))
         throw new TokenInvalidInstructionDataError();
 
     const {

--- a/clients/js-legacy/src/instructions/initializeMint.ts
+++ b/clients/js-legacy/src/instructions/initializeMint.ts
@@ -51,7 +51,7 @@ export function createInitializeMintInstruction(
         { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
     ];
 
-    const data = Buffer.alloc(initializeMintInstructionData.span);
+    const data = Buffer.alloc(67); // worst-case size
     initializeMintInstructionData.encode(
         {
             instruction: TokenInstruction.InitializeMint,
@@ -62,7 +62,11 @@ export function createInitializeMintInstruction(
         data,
     );
 
-    return new TransactionInstruction({ keys, programId, data });
+    return new TransactionInstruction({
+        keys,
+        programId,
+        data: data.subarray(0, initializeMintInstructionData.getSpan(data)),
+    });
 }
 
 /** A decoded, valid InitializeMint instruction */
@@ -93,7 +97,8 @@ export function decodeInitializeMintInstruction(
     programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeMintInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
-    if (instruction.data.length !== initializeMintInstructionData.span) throw new TokenInvalidInstructionDataError();
+    if (instruction.data.length !== initializeMintInstructionData.getSpan(instruction.data))
+        throw new TokenInvalidInstructionDataError();
 
     const {
         keys: { mint, rent },

--- a/clients/js-legacy/src/instructions/initializeMint2.ts
+++ b/clients/js-legacy/src/instructions/initializeMint2.ts
@@ -48,7 +48,7 @@ export function createInitializeMint2Instruction(
 ): TransactionInstruction {
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
-    const data = Buffer.alloc(initializeMint2InstructionData.span);
+    const data = Buffer.alloc(67); // worst-case size
     initializeMint2InstructionData.encode(
         {
             instruction: TokenInstruction.InitializeMint2,
@@ -59,7 +59,11 @@ export function createInitializeMint2Instruction(
         data,
     );
 
-    return new TransactionInstruction({ keys, programId, data });
+    return new TransactionInstruction({
+        keys,
+        programId,
+        data: data.subarray(0, initializeMint2InstructionData.getSpan(data)),
+    });
 }
 
 /** A decoded, valid InitializeMint2 instruction */
@@ -89,7 +93,8 @@ export function decodeInitializeMint2Instruction(
     programId = TOKEN_PROGRAM_ID,
 ): DecodedInitializeMint2Instruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
-    if (instruction.data.length !== initializeMint2InstructionData.span) throw new TokenInvalidInstructionDataError();
+    if (instruction.data.length !== initializeMint2InstructionData.getSpan(instruction.data))
+        throw new TokenInvalidInstructionDataError();
 
     const {
         keys: { mint },

--- a/clients/js-legacy/src/instructions/initializeMintCloseAuthority.ts
+++ b/clients/js-legacy/src/instructions/initializeMintCloseAuthority.ts
@@ -43,7 +43,7 @@ export function createInitializeMintCloseAuthorityInstruction(
     }
     const keys = [{ pubkey: mint, isSigner: false, isWritable: true }];
 
-    const data = Buffer.alloc(initializeMintCloseAuthorityInstructionData.span);
+    const data = Buffer.alloc(34); // worst-case size
     initializeMintCloseAuthorityInstructionData.encode(
         {
             instruction: TokenInstruction.InitializeMintCloseAuthority,
@@ -52,7 +52,11 @@ export function createInitializeMintCloseAuthorityInstruction(
         data,
     );
 
-    return new TransactionInstruction({ keys, programId, data });
+    return new TransactionInstruction({
+        keys,
+        programId,
+        data: data.subarray(0, initializeMintCloseAuthorityInstructionData.getSpan(data)),
+    });
 }
 
 /** A decoded, valid InitializeMintCloseAuthority instruction */
@@ -80,7 +84,7 @@ export function decodeInitializeMintCloseAuthorityInstruction(
     programId: PublicKey,
 ): DecodedInitializeMintCloseAuthorityInstruction {
     if (!instruction.programId.equals(programId)) throw new TokenInvalidInstructionProgramError();
-    if (instruction.data.length !== initializeMintCloseAuthorityInstructionData.span)
+    if (instruction.data.length !== initializeMintCloseAuthorityInstructionData.getSpan(instruction.data))
         throw new TokenInvalidInstructionDataError();
 
     const {

--- a/clients/js-legacy/src/serialization.ts
+++ b/clients/js-legacy/src/serialization.ts
@@ -34,6 +34,6 @@ export class COptionPublicKeyLayout extends Layout<PublicKey | null> {
             const option = buffer[offset];
             return option === 0 ? 1 : 1 + this.publicKeyLayout.span;
         }
-        return 1 + this.publicKeyLayout.span;
+        throw new RangeError('Buffer must be provided');
     }
 }

--- a/clients/js-legacy/test/unit/transferfee.test.ts
+++ b/clients/js-legacy/test/unit/transferfee.test.ts
@@ -3,7 +3,8 @@ import {
     calculateEpochFee,
     ONE_IN_BASIS_POINTS,
     createInitializeTransferFeeConfigInstruction,
-    decodeInitializeTransferFeeConfigInstructionUnchecked,
+    decodeInitializeTransferFeeConfigInstruction,
+    TOKEN_2022_PROGRAM_ID,
 } from '../../src';
 import { expect } from 'chai';
 import { Keypair, PublicKey } from '@solana/web3.js';
@@ -21,7 +22,8 @@ describe('transferFee', () => {
                 100,
                 100n,
             );
-            const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
+            expect(instruction.data.length).to.eql(78);
+            const decoded = decodeInitializeTransferFeeConfigInstruction(instruction, TOKEN_2022_PROGRAM_ID);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(transferFeeConfigAuthority);
             expect(decoded.data.withdrawWithheldAuthority).to.eql(withdrawWithheldAuthority);
             expect(decoded.data.transferFeeBasisPoints).to.eql(100);
@@ -37,7 +39,8 @@ describe('transferFee', () => {
                 100,
                 100n,
             );
-            const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
+            expect(instruction.data.length).to.eql(46);
+            const decoded = decodeInitializeTransferFeeConfigInstruction(instruction, TOKEN_2022_PROGRAM_ID);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(null);
             expect(decoded.data.withdrawWithheldAuthority).to.eql(withdrawWithheldAuthority);
             expect(decoded.data.transferFeeBasisPoints).to.eql(100);
@@ -53,7 +56,8 @@ describe('transferFee', () => {
                 100,
                 100n,
             );
-            const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
+            expect(instruction.data.length).to.eql(46);
+            const decoded = decodeInitializeTransferFeeConfigInstruction(instruction, TOKEN_2022_PROGRAM_ID);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(transferFeeConfigAuthority);
             expect(decoded.data.withdrawWithheldAuthority).to.eql(null);
             expect(decoded.data.transferFeeBasisPoints).to.eql(100);
@@ -62,7 +66,8 @@ describe('transferFee', () => {
         it('should encode and decode with no authorities', () => {
             const mint = Keypair.generate().publicKey;
             const instruction = createInitializeTransferFeeConfigInstruction(mint, null, null, 100, 100n);
-            const decoded = decodeInitializeTransferFeeConfigInstructionUnchecked(instruction);
+            expect(instruction.data.length).to.eql(14);
+            const decoded = decodeInitializeTransferFeeConfigInstruction(instruction, TOKEN_2022_PROGRAM_ID);
             expect(decoded.data.transferFeeConfigAuthority).to.eql(null);
             expect(decoded.data.withdrawWithheldAuthority).to.eql(null);
             expect(decoded.data.transferFeeBasisPoints).to.eql(100);


### PR DESCRIPTION
#### Problem

The JS library encodes and decodes `COption<Pubkey>` improperly. During encoding, it overallocates the instruction data buffer to always include the additional 32 bytes, even when the value is `null`. During decoding, it assumes the worst-case size for the instruction data length.

#### Summary of changes

buffer-layout actually contains the way to do this right, by properly implementing `getSpan` to return an error if it's ever used without a buffer:

https://github.com/solana-labs/buffer-layout/blob/ee6cdb8074265b04c884485bb46738cdbc077e41/src/Layout.ts#L282

So this properly fixes the encoding and decoding at the same time:

* during encoding, overallocate to the worst case, then truncate down
* correctly return an error during `getSpan`
* during decoding, use the input buffer with `getSpan` to dynamically calculate the expected length
* test the behavior for transfer fee encoding / decoding

Fixes #68