### PR TITLE
cli: Fix multisig parsing

### DIFF
--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -48,9 +48,9 @@ fn signers_of(
     name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<SignersOf>, Box<dyn std::error::Error>> {
-    if let Some(values) = matches.try_get_many(name).ok().flatten() {
+    if let Some(values) = matches.try_get_many::<String>(name).ok().flatten() {
         let mut results = Vec::new();
-        for (i, value) in values.copied().enumerate() {
+        for (i, value) in values.enumerate() {
             let name = format!("{}-{}", name, i.saturating_add(1));
             let signer = signer_from_path(matches, value, &name, wallet_manager)?;
             let signer_pubkey = signer.pubkey();

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -48,9 +48,9 @@ fn signers_of(
     name: &str,
     wallet_manager: &mut Option<Rc<RemoteWalletManager>>,
 ) -> Result<Option<SignersOf>, Box<dyn std::error::Error>> {
-    if let Some(values) = matches.values_of(name) {
+    if let Some(values) = matches.try_get_many(name).ok().flatten() {
         let mut results = Vec::new();
-        for (i, value) in values.enumerate() {
+        for (i, value) in values.copied().enumerate() {
             let name = format!("{}-{}", name, i.saturating_add(1));
             let signer = signer_from_path(matches, value, &name, wallet_manager)?;
             let signer_pubkey = signer.pubkey();


### PR DESCRIPTION
#### Problem

As pointed out in #58, the CLI currently fails when just running `create-account <MINT_ADDRESS>`, because a multisig argument is expected during all commands. Clap v3's version of `values_of` gives an error if the arg is not configured in the command.

This was probably missed during the port over to clap v3.

#### Summary of changes

Do the same thing as elsewhere, and change `values_of` to `try_get_many(...).ok().flatten()`.

This is the last place using `values_of` in the CLI that could fail.

Closes #58