### PR TITLE
CI: Purge runner before more jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
           clippy: true
           rustfmt: true
           cli: true
+          purge: true
           cargo-cache-key: cargo-cli-lint
           cargo-cache-fallback-key: cargo-cli
 
@@ -120,6 +121,7 @@ jobs:
         with:
           clippy: true
           rustfmt: true
+          purge: true
           cargo-cache-key: cargo-client-rust-legacy-lint
           cargo-cache-fallback-key: cargo-client-rust-legacy
 


### PR DESCRIPTION
#### Problem

There was a CI failure for a JS change due to "No space left on device" at https://github.com/solana-program/token-2022/actions/runs/12767682207/job/35586538482?pr=59

#### Summary of changes

Purge the runner for the linting steps too.