### PR TITLE
CI: Purge even more packages

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -42,6 +42,8 @@ runs:
       if: ${{ inputs.purge == 'true' }}
       shell: bash
       run: |
+        # If there are still disk space issues, try to add more packages from
+        # https://github.com/jlumbroso/free-disk-space
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /usr/share/swift
         sudo rm -rf /usr/share/mysql
@@ -56,6 +58,8 @@ runs:
         sudo rm -rf /usr/local/lib/android
         sudo rm -rf /usr/local/lib/heroku
         sudo rm -rf /imagegeneration
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo docker image prune --all --force
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
#### Problem

The Test Client Rust Legacy job is failing due to running out of disk space on my fork:
https://github.com/joncinque/token-2022/actions/runs/12768125169/job/35587971585

#### Summary of changes

Purge the agent tools cache and all docker images stored on the runner. This should give a lot more space.