### PR TITLE
program: Mark test module as `pub(crate)`

### DIFF
--- a/program/src/pod.rs
+++ b/program/src/pod.rs
@@ -262,7 +262,7 @@ impl TryFrom<PodCOption<Pubkey>> for OptionalNonZeroPubkey {
 }
 
 #[cfg(test)]
-pub mod test {
+pub(crate) mod test {
     use {
         super::*,
         crate::state::{


### PR DESCRIPTION
#### Problem

The downstream agave jobs are failing after the upgrade to Rust 1.84, because the lint for public modules needing documentation is getting tripped.

#### Summary of changes

Mark the test module as `pub(crate)` since it shouldn't be used outside.