### PR TITLE
CI: Update rust publish script to work for all packages

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -1,8 +1,12 @@
-name: Publish Rust Client
+name: Publish Rust Crate
 
 on:
   workflow_dispatch:
     inputs:
+      package_path:
+        description: Path to directory with package to release
+        required: true
+        type: string
       level:
         description: Level
         required: true
@@ -18,7 +22,7 @@ on:
           - release
           - version
       version:
-        description: Version
+        description: Version (used with level "version")
         required: false
         type: string
       dry_run:
@@ -33,8 +37,8 @@ on:
         default: true
 
 jobs:
-  test_rust:
-    name: Test Rust client
+  test:
+    name: Test Rust Crate
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -43,37 +47,47 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-rust-client
           clippy: true
           rustfmt: true
           solana: true
+          cli: true
+          purge: true
+          cargo-cache-key: cargo-test-publish-${{ inputs.package_path }}
+          cargo-cache-fallback-key: cargo-test-publish
 
-      - name: Format Rust Client
-        run: pnpm clients:rust:format
+      - name: Format
+        run: pnpm zx ./scripts/rust/format.mjs "${{ inputs.package_path }}"
 
-      - name: Lint Rust Client
-        run: pnpm clients:rust:lint
+      - name: Lint
+        run: pnpm zx ./scripts/rust/lint.mjs "${{ inputs.package_path }}"
 
-      - name: Test Rust Client
-        run: pnpm clients:rust:test
+      - name: Build Token-2022
+        run: pnpm programs:build
 
-  publish_rust:
-    name: Publish Rust Client
+      - name: Build ElGamal Registry
+        run: pnpm confidential-transfer:elgamal-registry:build
+
+      - name: Test
+        run: pnpm zx ./scripts/rust/test.mjs "${{ inputs.package_path }}"
+
+  publish:
+    name: Publish Rust Crate
     runs-on: ubuntu-latest
-    needs: test_rust
+    needs: test
     permissions:
       contents: write
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cargo-cache-key: cargo-publish-rust-client
-          cargo-cache-fallback-key: cargo-rust-client
-          clippy: true
-          rustfmt: true
+          cli: true
+          cargo-cache-key: cargo-publish-${{ inputs.package_path }}
+          cargo-cache-fallback-key: cargo-publish
 
       - name: Install Cargo Release
         run: which cargo-release || cargo install cargo-release
@@ -92,7 +106,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - name: Publish Rust Client
+      - name: Publish Crate
         id: publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -109,14 +123,25 @@ jobs:
             OPTIONS=""
           fi
 
-          pnpm clients:rust:publish $LEVEL $OPTIONS
+          pnpm rust:publish "${{ inputs.package_path }}" $LEVEL $OPTIONS
 
-      - name: Push Commit and Tag
-        if: github.event.inputs.dry_run != 'true'
-        run: git push origin --follow-tags
+      - name: Generate a changelog
+        if: github.event.inputs.create_release == 'true'
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: "scripts/cliff.toml"
+          args: |
+            "${{ steps.publish.outputs.old_git_tag }}"..master
+            --include-path "${{ inputs.package_path }}/**"
+            --github-repo "${{ github.repository }}"
+        env:
+          OUTPUT: TEMP_CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub release
         if: github.event.inputs.create_release == 'true' && github.event.inputs.dry_run != 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: rust@v${{ steps.publish.outputs.new_version }}
+          tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: TEMP_CHANGELOG.md
+          name: ${{ steps.publish.outputs.release_title }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,8 @@ lint = "nightly-2024-08-08"
 
 [workspace.metadata.spellcheck]
 config = "scripts/spellcheck.toml"
+
+[workspace.metadata.release]
+pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
+tag-message = "Publish {{crate_name}} v{{version}}"
+consolidate-commits = false

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "template:upgrade": "zx ./scripts/upgrade-template.mjs",
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
-    "rust:semver": "cargo semver-checks"
+    "rust:semver": "cargo semver-checks",
+    "rust:publish": "zx ./scripts/rust/publish.mjs"
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.0.0",

--- a/scripts/cliff.toml
+++ b/scripts/cliff.toml
@@ -1,0 +1,58 @@
+# git-cliff configuration file
+# https://git-cliff.org/docs/configuration
+#
+# Lines starting with "#" are comments.
+# Configuration options are organized into tables and keys.
+# See documentation for more information on available options.
+
+[changelog]
+header = """
+## What's new
+"""
+# template for the changelog body
+# https://tera.netlify.app/docs
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}\
+    {% for commit in commits %}
+        - {{ commit.message | upper_first | split(pat="\n") | first | trim }}\
+        {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+    {% endfor %}\
+{% endfor %}
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+footer = """
+"""
+postprocessors = [ ]
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = []
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^build\\(deps\\)", skip = true },
+    { message = "^build\\(deps-dev\\)", skip = true },
+    { message = "^ci", skip = true },
+    { body = ".*", group = "Changes" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = ""
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"
+# limit the number of commits included in the changelog.
+# limit_commits = 42

--- a/scripts/rust/publish.mjs
+++ b/scripts/rust/publish.mjs
@@ -3,18 +3,25 @@ import 'zx/globals';
 import { cliArguments, getCargo, workingDirectory } from '../utils.mjs';
 
 const dryRun = argv['dry-run'] ?? false;
-const [level] = cliArguments();
+const [folder, level] = cliArguments();
+if (!folder) {
+  throw new Error('A path to a directory with a Rust package — e.g. "clients/cli" — must be provided.');
+}
 if (!level) {
-  throw new Error('A version level — e.g. "path" — must be provided.');
+  throw new Error('A version level — e.g. "patch" — must be provided.');
 }
 
-// Go to the client directory and install the dependencies.
-cd(path.join(workingDirectory, 'clients', 'rust'));
+cd(path.join(workingDirectory, folder));
 
-// Publish the new version.
+const packageToml = getCargo(folder).package;
+const oldVersion = packageToml.version;
+const packageName = packageToml.name;
+const tagName = packageName.replace('spl-', '');
+
+// Publish the new version, commit the repo change, tag it, and push it all.
 const releaseArgs = dryRun
   ? []
-  : ['--no-push', '--no-tag', '--no-confirm', '--execute'];
+  : ['--tag-name', `${tagName}-v{{version}}`, '--no-confirm', '--execute'];
 await $`cargo release ${level} ${releaseArgs}`;
 
 // Stop here if this is a dry run.
@@ -23,18 +30,14 @@ if (dryRun) {
 }
 
 // Get the new version.
-const newVersion = getCargo(path.join('clients', 'rust')).package.version;
+const newVersion = getCargo(folder).package.version;
+const newGitTag = `${tagName}-v${newVersion}`;
+const oldGitTag = `${tagName}-v${oldVersion}`;
+const releaseTitle = `SPL ${tagName} - v${newVersion}`;
 
 // Expose the new version to CI if needed.
 if (process.env.CI) {
-  await $`echo "new_version=${newVersion}" >> $GITHUB_OUTPUT`;
+  await $`echo "new_git_tag=${newGitTag}" >> $GITHUB_OUTPUT`;
+  await $`echo "old_git_tag=${oldGitTag}" >> $GITHUB_OUTPUT`;
+  await $`echo "release_title=${releaseTitle}" >> $GITHUB_OUTPUT`;
 }
-
-// Soft reset the last commit so we can create our own commit and tag.
-await $`git reset --soft HEAD~1`;
-
-// Commit the new version.
-await $`git commit -am "Publish Rust client v${newVersion}"`;
-
-// Tag the new version.
-await $`git tag -a rust@v${newVersion} -m "Rust client v${newVersion}"`;


### PR DESCRIPTION
#### Problem

The publish script only works with the rust client, but we have many rust packages in the repo that need to be deployed.

#### Summary of changes

Update the publish script to take in a folder, and update the workflow to align with the SPL version, which also generates a changelog.