### PR TITLE
toml: Update everything to new repo + Anza

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,13 @@ members = [
   "program",
 ]
 
+[workspace.package]
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+repository = "https://github.com/solana-program/token-2022"
+homepage = "https://solana-program.com"
+license = "Apache-2.0"
+edition = "2021"
+
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-description = "SPL-Token Command-line Utility"
-edition = "2021"
-homepage = "https://spl.solana.com/token"
-license = "Apache-2.0"
 name = "spl-token-cli"
-repository = "https://github.com/solana-labs/solana-program-library"
 version = "5.0.0"
+description = "SPL-Token Command-line Utility"
+documentation = "https://docs.rs/spl-token-cli"
+readme = "README.md"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [build-dependencies]
 walkdir = "2"

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-description = "SPL-Token Rust Client"
-edition = "2021"
-license = "Apache-2.0"
 name = "spl-token-client"
-repository = "https://github.com/solana-labs/solana-program-library"
 version = "0.13.0"
+description = "SPL-Token Rust Client"
+documentation = "https://docs.rs/spl-token-client"
+readme = "README.md"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [features]
 default = ["display"]

--- a/confidential-transfer/ciphertext-arithmetic/Cargo.toml
+++ b/confidential-transfer/ciphertext-arithmetic/Cargo.toml
@@ -2,10 +2,11 @@
 name = "spl-token-confidential-transfer-ciphertext-arithmetic"
 version = "0.2.0"
 description = "Solana Program Library Confidential Transfer Ciphertext Arithmetic"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
-license = "Apache-2.0"
-edition = "2021"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 base64 = "0.22.1"

--- a/confidential-transfer/elgamal-registry/Cargo.toml
+++ b/confidential-transfer/elgamal-registry/Cargo.toml
@@ -2,10 +2,11 @@
 name = "spl-elgamal-registry"
 version = "0.1.0"
 description = "Solana ElGamal Registry Program"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
-license = "Apache-2.0"
-edition = "2021"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [features]
 no-entrypoint = []

--- a/confidential-transfer/proof-extraction/Cargo.toml
+++ b/confidential-transfer/proof-extraction/Cargo.toml
@@ -2,10 +2,11 @@
 name = "spl-token-confidential-transfer-proof-extraction"
 version = "0.2.0"
 description = "Solana Program Library Confidential Transfer Proof Extraction"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
-license = "Apache-2.0"
-edition = "2021"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 bytemuck = "1.21.0"

--- a/confidential-transfer/proof-generation/Cargo.toml
+++ b/confidential-transfer/proof-generation/Cargo.toml
@@ -2,10 +2,11 @@
 name = "spl-token-confidential-transfer-proof-generation"
 version = "0.2.0"
 description = "Solana Program Library Confidential Transfer Proof Generation"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
-license = "Apache-2.0"
-edition = "2021"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [dependencies]
 curve25519-dalek = "4.1.3"

--- a/confidential-transfer/proof-tests/Cargo.toml
+++ b/confidential-transfer/proof-tests/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "spl-token-confidential-transfer-proof-test"
 version = "0.0.1"
-description = "Solana Program Library Confidential Transfer Proof Test"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
-license = "Apache-2.0"
-edition = "2021"
+publish = false
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [dev-dependencies]
 curve25519-dalek = "4.1.3"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -2,11 +2,13 @@
 name = "spl-token-2022"
 version = "6.0.0"
 description = "Solana Program Library Token 2022"
-authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
-repository = "https://github.com/solana-labs/solana-program-library"
-license = "Apache-2.0"
-edition = "2021"
-exclude = ["js/**"]
+documentation = "https://docs.rs/spl-token-2022"
+readme = "README.md"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [features]
 no-entrypoint = []

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -27,13 +27,12 @@ security_txt! {
     // Required fields
     name: "SPL Token-2022",
     project_url: "https://spl.solana.com/token-2022",
-    contacts: "link:https://github.com/solana-labs/solana-program-library/security/advisories/new,mailto:security@solana.com,discord:https://solana.com/discord",
-    policy: "https://github.com/solana-labs/solana-program-library/blob/master/SECURITY.md",
+    contacts: "link:https://github.com/solana-program/token-2022/security/advisories/new,mailto:security@anza.xyz,discord:https://solana.com/discord",
+    policy: "https://github.com/solana-program/token-2022/blob/master/SECURITY.md",
 
     // Optional Fields
     preferred_languages: "en",
-    source_code: "https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022",
-    source_revision: "070934ae4f2975d602caa6bd1e88b2c010e4cab5",
-    source_release: "token-2022-v5.0.2",
-    auditors: "https://github.com/solana-labs/security-audits#token-2022"
+    source_code: "https://github.com/solana-program/token-2022/tree/master/program",
+    source_release: "token-2022-v7.0.0",
+    auditors: "https://github.com/anza-xyz/security-audits#token-2022"
 }


### PR DESCRIPTION
#### Problem

The crates all point to the SPL repo and Labs maintainers, but that isn't the case anymore.

Also, the security.txt info in Token-2022 is incorrect for the future release.

#### Summary of changes

Update all Cargo.toml files to specify the new repo, Anza maintenance, and license.

Also, update the security.txt for the new token-2022 info.