### PR TITLE
CI: Use PAT for publish job

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.ANZA_TEAM_PAT }}
           fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment


### PR DESCRIPTION
#### Problem

The main branch requires pull requests to make changes, but the publish job needs to push a commit and a tag.

#### Summary of changes

Use the ANZA_TEAM_PAT.