### PR TITLE
CI: Update tag name to match the repo

### DIFF
--- a/scripts/rust/publish.mjs
+++ b/scripts/rust/publish.mjs
@@ -16,12 +16,12 @@ cd(path.join(workingDirectory, folder));
 const packageToml = getCargo(folder).package;
 const oldVersion = packageToml.version;
 const packageName = packageToml.name;
-const tagName = packageName.replace('spl-', '');
+const tagName = path.basename(folder);
 
 // Publish the new version, commit the repo change, tag it, and push it all.
 const releaseArgs = dryRun
   ? []
-  : ['--tag-name', `${tagName}-v{{version}}`, '--no-confirm', '--execute'];
+  : ['--tag-name', `${tagName}@v{{version}}`, '--no-confirm', '--execute'];
 await $`cargo release ${level} ${releaseArgs}`;
 
 // Stop here if this is a dry run.
@@ -31,9 +31,9 @@ if (dryRun) {
 
 // Get the new version.
 const newVersion = getCargo(folder).package.version;
-const newGitTag = `${tagName}-v${newVersion}`;
-const oldGitTag = `${tagName}-v${oldVersion}`;
-const releaseTitle = `SPL ${tagName} - v${newVersion}`;
+const newGitTag = `${tagName}@v${newVersion}`;
+const oldGitTag = `${tagName}@v${oldVersion}`;
+const releaseTitle = `${packageName} - v${newVersion}`;
 
 // Expose the new version to CI if needed.
 if (process.env.CI) {


### PR DESCRIPTION
#### Problem

The tag names from SPL contained nearly the full name of the package, which made sense because there were many packages. The program-specific repos, however, take a different format, and only keep the basename of the directory. Also, they use `@` to separate the name from the version.

#### Summary of changes

Use the basename and separate with `@`!