### PR TITLE
publish: Use the tag name as the release title

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -145,4 +145,3 @@ jobs:
         with:
           tag: ${{ steps.publish.outputs.new_git_tag }}
           bodyFile: TEMP_CHANGELOG.md
-          name: ${{ steps.publish.outputs.release_title }}

--- a/scripts/rust/publish.mjs
+++ b/scripts/rust/publish.mjs
@@ -33,11 +33,9 @@ if (dryRun) {
 const newVersion = getCargo(folder).package.version;
 const newGitTag = `${tagName}@v${newVersion}`;
 const oldGitTag = `${tagName}@v${oldVersion}`;
-const releaseTitle = `${packageName} - v${newVersion}`;
 
 // Expose the new version to CI if needed.
 if (process.env.CI) {
   await $`echo "new_git_tag=${newGitTag}" >> $GITHUB_OUTPUT`;
   await $`echo "old_git_tag=${oldGitTag}" >> $GITHUB_OUTPUT`;
-  await $`echo "release_title=${releaseTitle}" >> $GITHUB_OUTPUT`;
 }


### PR DESCRIPTION
#### Problem

The release name came out slightly gross.

#### Summary of changes

Keep things simple, and have the tool default to the tag name.