### PR TITLE
publish: Update JS job for multiple packages

### DIFF
--- a/.github/workflows/publish-js-client.yml
+++ b/.github/workflows/publish-js-client.yml
@@ -6,7 +6,11 @@ on:
       package_path:
         description: Path to directory with package to release
         required: true
-        type: string
+        default: 'clients/js'
+        type: choice
+        options:
+          - clients/js
+          - clients/js-legacy
       level:
         description: Version level
         required: true
@@ -20,14 +24,6 @@ on:
           - prepatch
           - preminor
           - premajor
-      npm_org:
-        description: NPM Organization
-        required: true
-        default: solana
-        type: choice
-        options:
-          - solana
-          - solana-program
       tag:
         description: NPM Tag (and preid for pre-releases)
         required: true
@@ -88,32 +84,37 @@ jobs:
       - name: Ensure SOLANA_NPM_TOKEN variable is set
         env:
           token: ${{ secrets.SOLANA_NPM_TOKEN }}
-        if: ${{ env.token == '' }} && ${{ inputs.npm_org == 'solana' }}
+        if: ${{ env.token == '' }}
         run: |
           echo "The SOLANA_NPM_TOKEN secret variable is not set"
           echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
           exit 1
 
-      - name: Solana NPM Authentication
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
-        if: ${{ inputs.npm_org == 'solana' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.SOLANA_NPM_TOKEN }}
-
       - name: Ensure SOLANA_PROGRAM_NPM_TOKEN variable is set
         env:
           token: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
-        if: ${{ env.token == '' }} && ${{ inputs.npm_org == 'solana-program' }}
+        if: ${{ env.token == '' }}
         run: |
           echo "The SOLANA_PROGRAM_NPM_TOKEN secret variable is not set"
           echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
           exit 1
 
-      - name: Solana-program NPM Authentication
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
-        if: ${{ inputs.npm_org == 'solana-program' }}
+      - name: NPM Authentication
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
+          SOLANA_NPM_TOKEN: ${{ secrets.SOLANA_NPM_TOKEN }}
+          SOLANA_PROGRAM_NPM_TOKEN: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
+        shell: bash
+        run: |
+          cd "${{ inputs.package_path }}"
+          org="$(jq '.name|split("/")|.[0]' package.json)"
+          if [[ $org == "\"@solana-program\"" ]] then
+            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_PROGRAM_NPM_TOKEN}"
+          elif [[ $org == "\"@solana\"" ]] then
+            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_NPM_TOKEN}"
+          else
+            echo "Unknown organization: $org"
+            exit 1
+          fi
 
       - name: Set Git Author
         run: |

--- a/.github/workflows/publish-js-client.yml
+++ b/.github/workflows/publish-js-client.yml
@@ -3,6 +3,10 @@ name: Publish JS Client
 on:
   workflow_dispatch:
     inputs:
+      package_path:
+        description: Path to directory with package to release
+        required: true
+        type: string
       level:
         description: Version level
         required: true
@@ -16,6 +20,14 @@ on:
           - prepatch
           - preminor
           - premajor
+      npm_org:
+        description: NPM Organization
+        required: true
+        default: solana
+        type: choice
+        options:
+          - solana
+          - solana-program
       tag:
         description: NPM Tag (and preid for pre-releases)
         required: true
@@ -28,8 +40,8 @@ on:
         default: true
 
 jobs:
-  test_js:
-    name: Test JS client
+  test:
+    name: Test JS package
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -39,42 +51,69 @@ jobs:
         uses: ./.github/actions/setup
         with:
           solana: true
+          cargo-cache-key: cargo-js-test-publish-${{ inputs.package_path }}
+          cargo-cache-fallback-key: cargo-js-test-publish
 
-      - name: Format JS Client
-        run: pnpm clients:js:format
+      - name: Format
+        run: pnpm zx ./scripts/js/format.mjs "${{ inputs.package_path }}"
 
-      - name: Lint JS Client
-        run: pnpm clients:js:lint
+      - name: Lint
+        run: pnpm zx ./scripts/js/lint.mjs "${{ inputs.package_path }}"
 
-      - name: Test JS Client
-        run: pnpm clients:js:test
+      - name: Build Token-2022
+        run: pnpm programs:build
 
-  publish_js:
-    name: Publish JS client
+      - name: Build ElGamal Registry
+        run: pnpm confidential-transfer:elgamal-registry:build
+
+      - name: Test
+        run: pnpm zx ./scripts/js/test.mjs "${{ inputs.package_path }}"
+
+  publish:
+    name: Publish JS package
     runs-on: ubuntu-latest
-    needs: test_js
+    needs: test
     permissions:
       contents: write
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ANZA_TEAM_PAT }}
+          fetch-depth: 0 # get the whole history for git-cliff
 
       - name: Setup Environment
         uses: ./.github/actions/setup
 
-      - name: Ensure NPM_TOKEN variable is set
+      - name: Ensure SOLANA_NPM_TOKEN variable is set
         env:
-          token: ${{ secrets.NPM_TOKEN }}
-        if: ${{ env.token == '' }}
+          token: ${{ secrets.SOLANA_NPM_TOKEN }}
+        if: ${{ env.token == '' }} && ${{ inputs.npm_org == 'solana' }}
         run: |
-          echo "The NPM_TOKEN secret variable is not set"
+          echo "The SOLANA_NPM_TOKEN secret variable is not set"
           echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
           exit 1
 
-      - name: NPM Authentication
+      - name: Solana NPM Authentication
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        if: ${{ inputs.npm_org == 'solana' }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.SOLANA_NPM_TOKEN }}
+
+      - name: Ensure SOLANA_PROGRAM_NPM_TOKEN variable is set
+        env:
+          token: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
+        if: ${{ env.token == '' }} && ${{ inputs.npm_org == 'solana-program' }}
+        run: |
+          echo "The SOLANA_PROGRAM_NPM_TOKEN secret variable is not set"
+          echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+          exit 1
+
+      - name: Solana-program NPM Authentication
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        if: ${{ inputs.npm_org == 'solana-program' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
 
       - name: Set Git Author
         run: |
@@ -83,13 +122,27 @@ jobs:
 
       - name: Publish JS Client
         id: publish
-        run: pnpm clients:js:publish ${{ inputs.level }} ${{ inputs.tag }}
+        run: pnpm js:publish "${{ inputs.package_path }}" ${{ inputs.level }} ${{ inputs.tag }}
 
       - name: Push Commit and Tag
         run: git push origin --follow-tags
+
+      - name: Generate a changelog
+        if: github.event.inputs.create_release == 'true'
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: "scripts/cliff.toml"
+          args: |
+            "${{ steps.publish.outputs.old_git_tag }}"..main
+            --include-path "${{ inputs.package_path }}/**"
+            --github-repo "${{ github.repository }}"
+        env:
+          OUTPUT: TEMP_CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub release
         if: github.event.inputs.create_release == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: js@v${{ steps.publish.outputs.new_version }}
+          tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: TEMP_CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "validator:stop": "zx ./scripts/stop-validator.mjs",
     "clients:js:format": "zx ./scripts/js/format.mjs clients/js",
     "clients:js:lint": "zx ./scripts/js/lint.mjs clients/js",
-    "clients:js:publish": "zx ./scripts/js/publish.mjs",
     "clients:js:test": "zx ./scripts/js/test.mjs clients/js",
     "clients:js-legacy:format": "zx ./scripts/js/format.mjs clients/js-legacy",
     "clients:js-legacy:lint": "zx ./scripts/js/lint.mjs clients/js-legacy",
@@ -45,7 +44,8 @@
     "rust:spellcheck": "cargo spellcheck --code 1",
     "rust:audit": "zx ./scripts/rust/audit.mjs",
     "rust:semver": "cargo semver-checks",
-    "rust:publish": "zx ./scripts/rust/publish.mjs"
+    "rust:publish": "zx ./scripts/rust/publish.mjs",
+    "js:publish": "zx ./scripts/js/publish.mjs"
   },
   "devDependencies": {
     "@codama/renderers-js": "^1.0.0",

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -124,3 +124,12 @@ export async function getInstalledSolanaVersion() {
     return '';
   }
 }
+
+export function getPackageJson(folder) {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(workingDirectory, folder ? folder : '.', 'package.json'),
+      'utf8'
+    )
+  );
+}


### PR DESCRIPTION
#### Problem

The repo now contains multiple JS packages, but the publish job only works with one of them.

#### Summary of changes

Update the publish script to get things in line with Rust:

* take in a package path to test
* change testing to work for any JS package
* publish to either `@solana-program` or `@solana` using different org secrets -- we'll need to update this afterwards
* generate a changelog