### PR TITLE
[rust-legacy-cli] Add pausable extension

### DIFF
--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -169,6 +169,8 @@ pub enum CommandName {
     UpdateGroupAddress,
     UpdateMemberAddress,
     UpdateUiAmountMultiplier,
+    Pause,
+    Resume,
 }
 impl fmt::Display for CommandName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -241,6 +243,7 @@ pub enum CliAuthorityType {
     GroupMemberPointer,
     Group,
     ScaledUiAmount,
+    Pause,
 }
 impl TryFrom<CliAuthorityType> for AuthorityType {
     type Error = Error;
@@ -272,6 +275,7 @@ impl TryFrom<CliAuthorityType> for AuthorityType {
                 Err("Group update authority does not map to a token authority type".into())
             }
             CliAuthorityType::ScaledUiAmount => Ok(AuthorityType::ScaledUiAmount),
+            CliAuthorityType::Pause => Ok(AuthorityType::Pause),
         }
     }
 }
@@ -904,6 +908,14 @@ pub fn app<'a>(
                             "Specify the UI multiplier. \
                             Multiplier authority defaults to the mint authority."
                         ),
+                )
+                .arg(
+                    Arg::with_name("pausable")
+                        .long("pausable")
+                        .takes_value(false)
+                        .help(
+                            "Enable the mint authority to pause mint, burn, and transfer for this mint"
+                        )
                 )
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
@@ -2740,6 +2752,58 @@ pub fn app<'a>(
                     .takes_value(true)
                     .help(
                         "Specify the multiplier authority keypair. \
+                        Defaults to the client keypair address."
+                    )
+                )
+                .arg(multisig_signer_arg())
+                .nonce_args(true)
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::Pause.into())
+                .about("Pause mint, burn, and transfer")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(|s| is_valid_pubkey(s))
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .index(1)
+                        .required(true)
+                        .help("The pausable token address"),
+                )
+                .arg(
+                    Arg::with_name("pause_authority")
+                    .long("pause-authority")
+                    .validator(|s| is_valid_signer(s))
+                    .value_name("SIGNER")
+                    .takes_value(true)
+                    .help(
+                        "Specify the pause authority keypair. \
+                        Defaults to the client keypair address."
+                    )
+                )
+                .arg(multisig_signer_arg())
+                .nonce_args(true)
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::Resume.into())
+                .about("Resume mint, burn, and transfer")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(|s| is_valid_pubkey(s))
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .index(1)
+                        .required(true)
+                        .help("The pausable token address"),
+                )
+                .arg(
+                    Arg::with_name("pause_authority")
+                    .long("pause-authority")
+                    .validator(|s| is_valid_signer(s))
+                    .value_name("SIGNER")
+                    .takes_value(true)
+                    .help(
+                        "Specify the pause authority keypair. \
                         Defaults to the client keypair address."
                     )
                 )

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -910,8 +910,8 @@ pub fn app<'a>(
                         ),
                 )
                 .arg(
-                    Arg::with_name("pausable")
-                        .long("pausable")
+                    Arg::with_name("enable_pause")
+                        .long("enable-pause")
                         .takes_value(false)
                         .help(
                             "Enable the mint authority to pause mint, burn, and transfer for this mint"
@@ -2773,6 +2773,7 @@ pub fn app<'a>(
                 .arg(
                     Arg::with_name("pause_authority")
                     .long("pause-authority")
+                    .alias("owner")
                     .validator(|s| is_valid_signer(s))
                     .value_name("SIGNER")
                     .takes_value(true)
@@ -2799,6 +2800,7 @@ pub fn app<'a>(
                 .arg(
                     Arg::with_name("pause_authority")
                     .long("pause-authority")
+                    .alias("owner")
                     .validator(|s| is_valid_signer(s))
                     .value_name("SIGNER")
                     .takes_value(true)

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -3801,7 +3801,7 @@ pub async fn process_command<'a>(
                 arg_matches.is_present("enable_group"),
                 arg_matches.is_present("enable_member"),
                 ui_multiplier,
-                arg_matches.is_present("pausable"),
+                arg_matches.is_present("enable_pause"),
                 bulk_signers,
             )
             .await

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -52,6 +52,7 @@ use {
             memo_transfer::MemoTransfer,
             metadata_pointer::MetadataPointer,
             mint_close_authority::MintCloseAuthority,
+            pausable::PausableConfig,
             permanent_delegate::PermanentDelegate,
             scaled_ui_amount::ScaledUiAmountConfig,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
@@ -268,6 +269,7 @@ async fn command_create_token(
     enable_group: bool,
     enable_member: bool,
     ui_multiplier: Option<f64>,
+    pausable: bool,
     bulk_signers: Vec<Arc<dyn Signer>>,
 ) -> CommandResult {
     println_display(
@@ -400,6 +402,10 @@ async fn command_create_token(
             authority: Some(authority),
             member_address,
         });
+    }
+
+    if pausable {
+        extensions.push(ExtensionInitializationParams::PausableConfig { authority });
     }
 
     let res = token
@@ -1107,6 +1113,16 @@ async fn command_authorize(
                         Err(format!("Mint `{}` does not support UI multiplier", account))
                     }
                 }
+                CliAuthorityType::Pause => {
+                    if let Ok(extension) = mint.get_extension::<PausableConfig>() {
+                        Ok(Option::<Pubkey>::from(extension.authority))
+                    } else {
+                        Err(format!(
+                            "Mint `{}` does not support pause or resume",
+                            account
+                        ))
+                    }
+                }
             }?;
 
             Ok((account, previous_authority))
@@ -1149,7 +1165,8 @@ async fn command_authorize(
                 | CliAuthorityType::GroupPointer
                 | CliAuthorityType::Group
                 | CliAuthorityType::GroupMemberPointer
-                | CliAuthorityType::ScaledUiAmount => Err(format!(
+                | CliAuthorityType::ScaledUiAmount
+                | CliAuthorityType::Pause => Err(format!(
                     "Authority type `{auth_str}` not supported for SPL Token accounts",
                 )),
                 CliAuthorityType::Owner => {
@@ -3625,6 +3642,67 @@ async fn command_update_multiplier(
     })
 }
 
+async fn command_pause_resume(
+    config: &Config<'_>,
+    token_pubkey: Pubkey,
+    pause_authority: Pubkey,
+    bulk_signers: Vec<Arc<dyn Signer>>,
+    allow_mint_burn_transfer: bool,
+) -> CommandResult {
+    if !config.sign_only {
+        let mint_account = config.get_account_checked(&token_pubkey).await?;
+
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(mint_account.data)
+            .map_err(|_| format!("Could not deserialize token mint {}", token_pubkey))?;
+
+        if let Ok(pausable_config) = mint_state.get_extension::<PausableConfig>() {
+            let pause_authority_pubkey = Option::<Pubkey>::from(pausable_config.authority);
+
+            if pause_authority_pubkey != Some(pause_authority) {
+                return Err(format!(
+                    "Mint {} has pause authority {}, but {} was provided",
+                    token_pubkey,
+                    pause_authority_pubkey
+                        .map(|pubkey| pubkey.to_string())
+                        .unwrap_or_else(|| "disabled".to_string()),
+                    pause_authority
+                )
+                .into());
+            }
+        } else {
+            return Err(format!("Mint {} is not pausable", token_pubkey).into());
+        }
+    }
+
+    let res = if allow_mint_burn_transfer {
+        println_display(
+            config,
+            format!("Resuming mint, burn, and transfer for {}", token_pubkey,),
+        );
+
+        let token = token_client_from_config(config, &token_pubkey, None)?;
+        token.resume(&pause_authority, &bulk_signers).await?
+    } else {
+        println_display(
+            config,
+            format!("Pausing mint, burn, and transfer for {}", token_pubkey,),
+        );
+
+        let token = token_client_from_config(config, &token_pubkey, None)?;
+        token.pause(&pause_authority, &bulk_signers).await?
+    };
+
+    let tx_return = finish_tx(config, &res, false).await?;
+    Ok(match tx_return {
+        TransactionReturnData::CliSignature(signature) => {
+            config.output_format.formatted_string(&signature)
+        }
+        TransactionReturnData::CliSignOnlyData(sign_only_data) => {
+            config.output_format.formatted_string(&sign_only_data)
+        }
+    })
+}
+
 struct ConfidentialTransferArgs {
     sender_elgamal_keypair: ElGamalKeypair,
     sender_aes_key: AeKey,
@@ -3723,6 +3801,7 @@ pub async fn process_command<'a>(
                 arg_matches.is_present("enable_group"),
                 arg_matches.is_present("enable_member"),
                 ui_multiplier,
+                arg_matches.is_present("pausable"),
                 bulk_signers,
             )
             .await
@@ -4791,6 +4870,29 @@ pub async fn process_command<'a>(
                 new_multiplier,
                 new_multiplier_effective_timestamp,
                 bulk_signers,
+            )
+            .await
+        }
+        (c @ CommandName::Pause, arg_matches) | (c @ CommandName::Resume, arg_matches) => {
+            let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let (pause_authority_signer, pause_authority_pubkey) =
+                config.signer_or_default(arg_matches, "pause_authority", &mut wallet_manager);
+            let bulk_signers = vec![pause_authority_signer];
+
+            let allow_mint_burn_transfer = match c {
+                CommandName::Pause => false,
+                CommandName::Resume => true,
+                _ => panic!("Instruction not supported"),
+            };
+
+            command_pause_resume(
+                config,
+                token_pubkey,
+                pause_authority_pubkey,
+                bulk_signers,
+                allow_mint_burn_transfer,
             )
             .await
         }

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -4419,7 +4419,7 @@ async fn pause(test_validator: &TestValidator, payer: &Keypair) {
             "spl-token",
             CommandName::CreateToken.into(),
             token_keypair_file.path().to_str().unwrap(),
-            "--pausable",
+            "--enable-pause",
         ],
     )
     .await

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -4480,4 +4480,9 @@ async fn pause(test_validator: &TestValidator, payer: &Keypair) {
     )
     .await
     .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<PausableConfig>().unwrap();
+    assert_eq!(Option::<Pubkey>::from(extension.authority), None,);
 }

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -27,6 +27,7 @@ use {
             memo_transfer::MemoTransfer,
             metadata_pointer::MetadataPointer,
             non_transferable::NonTransferable,
+            pausable::PausableConfig,
             scaled_ui_amount::ScaledUiAmountConfig,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
             transfer_hook::TransferHook,
@@ -146,6 +147,7 @@ async fn main() {
         async_trial!(confidential_transfer_with_fee, test_validator, payer),
         async_trial!(compute_budget, test_validator, payer),
         async_trial!(scaled_ui_amount, test_validator, payer),
+        async_trial!(pause, test_validator, payer),
         // GC messes with every other test, so have it on its own test validator
         async_trial!(gc, gc_test_validator, gc_payer),
     ];
@@ -4400,4 +4402,82 @@ async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
     let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
     let extension = test_mint.get_extension::<ScaledUiAmountConfig>().unwrap();
     assert_eq!(Option::<Pubkey>::from(extension.authority), None,);
+}
+
+async fn pause(test_validator: &TestValidator, payer: &Keypair) {
+    let config = test_config_with_default_signer(test_validator, payer, &spl_token_2022::id());
+
+    // create token with pausable extension
+    let token = Keypair::new();
+    let token_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&token, &token_keypair_file).unwrap();
+    let token_pubkey = token.pubkey();
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::CreateToken.into(),
+            token_keypair_file.path().to_str().unwrap(),
+            "--pausable",
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<PausableConfig>().unwrap();
+    assert!(!bool::from(extension.paused));
+
+    // pause the mint
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Pause.into(),
+            &token_pubkey.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<PausableConfig>().unwrap();
+    assert!(bool::from(extension.paused));
+
+    // resume the mint
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Resume.into(),
+            &token_pubkey.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<PausableConfig>().unwrap();
+    assert!(!bool::from(extension.paused));
+
+    // disable pause
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Authorize.into(),
+            &token_pubkey.to_string(),
+            "pause",
+            "--disable",
+        ],
+    )
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
#### Problem
The rust legacy cli does not yet have support for the pausable extension.

#### Summary of Changes
Added support for the pausable extension. I think the changes should be pretty straightforward. However, I realized that the solana account-decoder in the monorepo does not yet have support for the pausable extension, so I wasn't able to add changes to print out the pausable extension. I can wait until the the pausable extension is supported or I can create an issue for this and then follow-up on a subsequent PR.