### PR TITLE
[rust-legacy-cli] Add scaled ui amount extension

### DIFF
--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -2729,7 +2729,7 @@ pub fn app<'a>(
                         .takes_value(true)
                         .index(3)
                         .required(true)
-                        .help("The effective time for the new multiplier",)
+                        .help("The effective time for the new multiplier, given as a UNIX timestamp",)
                 )
                 .arg(
                     Arg::with_name("multiplier_authority")

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -2728,8 +2728,8 @@ pub fn app<'a>(
                         .value_name("TIMESTAMP")
                         .takes_value(true)
                         .index(3)
-                        .required(true)
-                        .help("The effective time for the new multiplier, given as a UNIX timestamp",)
+                        .help("The effective time for the new multiplier, given as a UNIX timestamp \
+                            [default: current time]",)
                 )
                 .arg(
                     Arg::with_name("ui_multiplier_authority")

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -168,7 +168,7 @@ pub enum CommandName {
     ApplyPendingBalance,
     UpdateGroupAddress,
     UpdateMemberAddress,
-    UpdateUiMultiplier,
+    UpdateUiAmountMultiplier,
 }
 impl fmt::Display for CommandName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -741,7 +741,7 @@ pub fn app<'a>(
                         .long("interest-rate")
                         .value_name("RATE_BPS")
                         .takes_value(true)
-                        .conflicts_with("ui_multiplier")
+                        .conflicts_with("ui_amount_multiplier")
                         .help(
                             "Specify the interest rate in basis points. \
                             Rate authority defaults to the mint authority."
@@ -895,9 +895,9 @@ pub fn app<'a>(
                         .help("Enables group member configurations in the mint. The mint authority must initialize the member."),
                 )
                 .arg(
-                    Arg::with_name("ui_multiplier")
-                        .long("ui-multiplier")
-                        .value_name("UI_MULTIPLIER")
+                    Arg::with_name("ui_amount_multiplier")
+                        .long("ui-amount-multiplier")
+                        .value_name("MULTIPLIER")
                         .takes_value(true)
                         .conflicts_with("interest_rate")
                         .help(
@@ -2704,7 +2704,7 @@ pub fn app<'a>(
                 .nonce_args(true)
         )
         .subcommand(
-            SubCommand::with_name(CommandName::UpdateUiMultiplier.into())
+            SubCommand::with_name(CommandName::UpdateUiAmountMultiplier.into())
                 .about("Update UI multiplier")
                 .arg(
                     Arg::with_name("token")
@@ -2716,7 +2716,7 @@ pub fn app<'a>(
                         .help("The token address with scaled UI amount multiplier"),
                 )
                 .arg(
-                    Arg::with_name("ui-multiplier")
+                    Arg::with_name("multiplier")
                         .value_name("MULTIPLIER")
                         .takes_value(true)
                         .index(2)

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -2732,8 +2732,8 @@ pub fn app<'a>(
                         .help("The effective time for the new multiplier, given as a UNIX timestamp",)
                 )
                 .arg(
-                    Arg::with_name("multiplier_authority")
-                    .long("multiplier-authority")
+                    Arg::with_name("ui_multiplier_authority")
+                    .long("ui-multiplier-authority")
                     .validator(|s| is_valid_signer(s))
                     .value_name("SIGNER")
                     .takes_value(true)

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -2734,6 +2734,7 @@ pub fn app<'a>(
                 .arg(
                     Arg::with_name("ui_multiplier_authority")
                     .long("ui-multiplier-authority")
+                    .alias("owner")
                     .validator(|s| is_valid_signer(s))
                     .value_name("SIGNER")
                     .takes_value(true)

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -168,6 +168,7 @@ pub enum CommandName {
     ApplyPendingBalance,
     UpdateGroupAddress,
     UpdateMemberAddress,
+    UpdateUiMultiplier,
 }
 impl fmt::Display for CommandName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -239,6 +240,7 @@ pub enum CliAuthorityType {
     GroupPointer,
     GroupMemberPointer,
     Group,
+    ScaledUiAmount,
 }
 impl TryFrom<CliAuthorityType> for AuthorityType {
     type Error = Error;
@@ -269,6 +271,7 @@ impl TryFrom<CliAuthorityType> for AuthorityType {
             CliAuthorityType::Group => {
                 Err("Group update authority does not map to a token authority type".into())
             }
+            CliAuthorityType::ScaledUiAmount => Ok(AuthorityType::ScaledUiAmount),
         }
     }
 }
@@ -738,6 +741,7 @@ pub fn app<'a>(
                         .long("interest-rate")
                         .value_name("RATE_BPS")
                         .takes_value(true)
+                        .conflicts_with("ui_multiplier")
                         .help(
                             "Specify the interest rate in basis points. \
                             Rate authority defaults to the mint authority."
@@ -889,6 +893,17 @@ pub fn app<'a>(
                         .conflicts_with("member_address")
                         .takes_value(false)
                         .help("Enables group member configurations in the mint. The mint authority must initialize the member."),
+                )
+                .arg(
+                    Arg::with_name("ui_multiplier")
+                        .long("ui-multiplier")
+                        .value_name("UI_MULTIPLIER")
+                        .takes_value(true)
+                        .conflicts_with("interest_rate")
+                        .help(
+                            "Specify the UI multiplier. \
+                            Multiplier authority defaults to the mint authority."
+                        ),
                 )
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
@@ -2684,6 +2699,48 @@ pub fn app<'a>(
                 )
                 .arg(
                     owner_address_arg()
+                )
+                .arg(multisig_signer_arg())
+                .nonce_args(true)
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::UpdateUiMultiplier.into())
+                .about("Update UI multiplier")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(|s| is_valid_pubkey(s))
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .index(1)
+                        .required(true)
+                        .help("The token address with scaled UI amount multiplier"),
+                )
+                .arg(
+                    Arg::with_name("ui-multiplier")
+                        .value_name("MULTIPLIER")
+                        .takes_value(true)
+                        .index(2)
+                        .required(true)
+                        .help("The new multiplier"),
+                )
+                .arg(
+                    Arg::with_name("timestamp")
+                        .value_name("TIMESTAMP")
+                        .takes_value(true)
+                        .index(3)
+                        .required(true)
+                        .help("The effective time for the new multiplier",)
+                )
+                .arg(
+                    Arg::with_name("multiplier_authority")
+                    .long("multiplier-authority")
+                    .validator(|s| is_valid_signer(s))
+                    .value_name("SIGNER")
+                    .takes_value(true)
+                    .help(
+                        "Specify the multiplier authority keypair. \
+                        Defaults to the client keypair address."
+                    )
                 )
                 .arg(multisig_signer_arg())
                 .nonce_args(true)

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -53,6 +53,7 @@ use {
             metadata_pointer::MetadataPointer,
             mint_close_authority::MintCloseAuthority,
             permanent_delegate::PermanentDelegate,
+            scaled_ui_amount::ScaledUiAmountConfig,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
             transfer_hook::TransferHook,
             BaseStateWithExtensions, ExtensionType, StateWithExtensionsOwned,
@@ -258,6 +259,7 @@ async fn command_create_token(
     enable_metadata: bool,
     enable_group: bool,
     enable_member: bool,
+    ui_multiplier: Option<f64>,
     bulk_signers: Vec<Arc<dyn Signer>>,
 ) -> CommandResult {
     println_display(
@@ -341,6 +343,13 @@ async fn command_create_token(
         extensions.push(ExtensionInitializationParams::TransferHook {
             authority: Some(authority),
             program_id: Some(program_id),
+        });
+    }
+
+    if let Some(ui_multiplier) = ui_multiplier {
+        extensions.push(ExtensionInitializationParams::ScaledUiAmountConfig {
+            authority: Some(authority),
+            multiplier: ui_multiplier,
         });
     }
 
@@ -1083,6 +1092,13 @@ async fn command_authorize(
                         Err(format!("Mint `{}` does not support token groups", account))
                     }
                 }
+                CliAuthorityType::ScaledUiAmount => {
+                    if let Ok(extension) = mint.get_extension::<ScaledUiAmountConfig>() {
+                        Ok(Option::<Pubkey>::from(extension.authority))
+                    } else {
+                        Err(format!("Mint `{}` does not support UI multiplier", account))
+                    }
+                }
             }?;
 
             Ok((account, previous_authority))
@@ -1124,7 +1140,8 @@ async fn command_authorize(
                 | CliAuthorityType::Metadata
                 | CliAuthorityType::GroupPointer
                 | CliAuthorityType::Group
-                | CliAuthorityType::GroupMemberPointer => Err(format!(
+                | CliAuthorityType::GroupMemberPointer
+                | CliAuthorityType::ScaledUiAmount => Err(format!(
                     "Authority type `{auth_str}` not supported for SPL Token accounts",
                 )),
                 CliAuthorityType::Owner => {
@@ -3536,6 +3553,70 @@ async fn command_apply_pending_balance(
     })
 }
 
+async fn command_update_multiplier(
+    config: &Config<'_>,
+    token_pubkey: Pubkey,
+    multiplier_authority: Pubkey,
+    new_multiplier: f64,
+    new_multiplier_effective_timestamp: i64,
+    bulk_signers: Vec<Arc<dyn Signer>>,
+) -> CommandResult {
+    let token = token_client_from_config(config, &token_pubkey, None)?;
+
+    if !config.sign_only {
+        let mint_account = config.get_account_checked(&token_pubkey).await?;
+
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(mint_account.data)
+            .map_err(|_| format!("Could not deserialize token mint {}", token_pubkey))?;
+
+        if let Ok(scaled_ui_amount_config) = mint_state.get_extension::<ScaledUiAmountConfig>() {
+            let scaled_ui_amount_authority_pubkey =
+                Option::<Pubkey>::from(scaled_ui_amount_config.authority);
+
+            if scaled_ui_amount_authority_pubkey != Some(multiplier_authority) {
+                return Err(format!(
+                    "Mint {} has multiplier authority {}, but {} was provided",
+                    token_pubkey,
+                    scaled_ui_amount_authority_pubkey
+                        .map(|pubkey| pubkey.to_string())
+                        .unwrap_or_else(|| "disabled".to_string()),
+                    multiplier_authority
+                )
+                .into());
+            }
+        } else {
+            return Err(format!("Mint {} does not have a UI multiplier", token_pubkey).into());
+        }
+    }
+
+    println_display(
+        config,
+        format!(
+            "Setting UI Multiplier for {} to {} at UNIX timestamp {}",
+            token_pubkey, new_multiplier, new_multiplier_effective_timestamp
+        ),
+    );
+
+    let res = token
+        .update_multiplier(
+            &multiplier_authority,
+            new_multiplier,
+            new_multiplier_effective_timestamp,
+            &bulk_signers,
+        )
+        .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
+    Ok(match tx_return {
+        TransactionReturnData::CliSignature(signature) => {
+            config.output_format.formatted_string(&signature)
+        }
+        TransactionReturnData::CliSignOnlyData(sign_only_data) => {
+            config.output_format.formatted_string(&sign_only_data)
+        }
+    })
+}
+
 struct ConfidentialTransferArgs {
     sender_elgamal_keypair: ElGamalKeypair,
     sender_aes_key: AeKey,
@@ -3569,6 +3650,7 @@ pub async fn process_command<'a>(
             let metadata_address = value_t!(arg_matches, "metadata_address", Pubkey).ok();
             let group_address = value_t!(arg_matches, "group_address", Pubkey).ok();
             let member_address = value_t!(arg_matches, "member_address", Pubkey).ok();
+            let ui_multiplier = value_t!(arg_matches, "ui_multiplier", f64).ok();
 
             let transfer_fee = arg_matches.values_of("transfer_fee").map(|mut v| {
                 println_display(config,"transfer-fee has been deprecated and will be removed in a future release. Please specify --transfer-fee-basis-points and --transfer-fee-maximum-fee with a UI amount".to_string());
@@ -3632,6 +3714,7 @@ pub async fn process_command<'a>(
                 arg_matches.is_present("enable_metadata"),
                 arg_matches.is_present("enable_group"),
                 arg_matches.is_present("enable_member"),
+                ui_multiplier,
                 bulk_signers,
             )
             .await
@@ -4672,6 +4755,27 @@ pub async fn process_command<'a>(
                 bulk_signers,
                 &elgamal_keypair,
                 &aes_key,
+            )
+            .await
+        }
+        (CommandName::UpdateUiMultiplier, arg_matches) => {
+            let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let new_multiplier = value_t_or_exit!(arg_matches, "ui-multiplier", f64);
+            let new_multiplier_effective_timestamp =
+                value_t_or_exit!(arg_matches, "timestamp", i64);
+            let (multiplier_authority_signer, multiplier_authority_pubkey) =
+                config.signer_or_default(arg_matches, "multiplier_authority", &mut wallet_manager);
+            let bulk_signers = vec![multiplier_authority_signer];
+
+            command_update_multiplier(
+                config,
+                token_pubkey,
+                multiplier_authority_pubkey,
+                new_multiplier,
+                new_multiplier_effective_timestamp,
+                bulk_signers,
             )
             .await
         }

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -77,7 +77,15 @@ use {
     },
     spl_token_group_interface::state::TokenGroup,
     spl_token_metadata_interface::state::{Field, TokenMetadata},
-    std::{collections::HashMap, fmt::Display, process::exit, rc::Rc, str::FromStr, sync::Arc},
+    std::{
+        collections::HashMap,
+        fmt::Display,
+        process::exit,
+        rc::Rc,
+        str::FromStr,
+        sync::Arc,
+        time::{SystemTime, UNIX_EPOCH},
+    },
 };
 
 fn print_error_and_exit<T, E: Display>(e: E) -> T {
@@ -4764,7 +4772,14 @@ pub async fn process_command<'a>(
                 .unwrap();
             let new_multiplier = value_t_or_exit!(arg_matches, "multiplier", f64);
             let new_multiplier_effective_timestamp =
-                value_t_or_exit!(arg_matches, "timestamp", i64);
+                if let Some(timestamp) = arg_matches.value_of("timestamp") {
+                    timestamp.parse::<i64>().unwrap()
+                } else {
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs() as i64
+                };
             let (ui_multiplier_authority_signer, ui_multiplier_authority_pubkey) = config
                 .signer_or_default(arg_matches, "ui_multiplier_authority", &mut wallet_manager);
             let bulk_signers = vec![ui_multiplier_authority_signer];

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -3650,7 +3650,7 @@ pub async fn process_command<'a>(
             let metadata_address = value_t!(arg_matches, "metadata_address", Pubkey).ok();
             let group_address = value_t!(arg_matches, "group_address", Pubkey).ok();
             let member_address = value_t!(arg_matches, "member_address", Pubkey).ok();
-            let ui_multiplier = value_t!(arg_matches, "ui_multiplier", f64).ok();
+            let ui_multiplier = value_t!(arg_matches, "ui_amount_multiplier", f64).ok();
 
             let transfer_fee = arg_matches.values_of("transfer_fee").map(|mut v| {
                 println_display(config,"transfer-fee has been deprecated and will be removed in a future release. Please specify --transfer-fee-basis-points and --transfer-fee-maximum-fee with a UI amount".to_string());
@@ -4758,11 +4758,11 @@ pub async fn process_command<'a>(
             )
             .await
         }
-        (CommandName::UpdateUiMultiplier, arg_matches) => {
+        (CommandName::UpdateUiAmountMultiplier, arg_matches) => {
             let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
                 .unwrap()
                 .unwrap();
-            let new_multiplier = value_t_or_exit!(arg_matches, "ui-multiplier", f64);
+            let new_multiplier = value_t_or_exit!(arg_matches, "multiplier", f64);
             let new_multiplier_effective_timestamp =
                 value_t_or_exit!(arg_matches, "timestamp", i64);
             let (multiplier_authority_signer, multiplier_authority_pubkey) =

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -3556,7 +3556,7 @@ async fn command_apply_pending_balance(
 async fn command_update_multiplier(
     config: &Config<'_>,
     token_pubkey: Pubkey,
-    multiplier_authority: Pubkey,
+    ui_multiplier_authority: Pubkey,
     new_multiplier: f64,
     new_multiplier_effective_timestamp: i64,
     bulk_signers: Vec<Arc<dyn Signer>>,
@@ -3573,14 +3573,14 @@ async fn command_update_multiplier(
             let scaled_ui_amount_authority_pubkey =
                 Option::<Pubkey>::from(scaled_ui_amount_config.authority);
 
-            if scaled_ui_amount_authority_pubkey != Some(multiplier_authority) {
+            if scaled_ui_amount_authority_pubkey != Some(ui_multiplier_authority) {
                 return Err(format!(
                     "Mint {} has multiplier authority {}, but {} was provided",
                     token_pubkey,
                     scaled_ui_amount_authority_pubkey
                         .map(|pubkey| pubkey.to_string())
                         .unwrap_or_else(|| "disabled".to_string()),
-                    multiplier_authority
+                    ui_multiplier_authority
                 )
                 .into());
             }
@@ -3599,7 +3599,7 @@ async fn command_update_multiplier(
 
     let res = token
         .update_multiplier(
-            &multiplier_authority,
+            &ui_multiplier_authority,
             new_multiplier,
             new_multiplier_effective_timestamp,
             &bulk_signers,
@@ -4765,14 +4765,14 @@ pub async fn process_command<'a>(
             let new_multiplier = value_t_or_exit!(arg_matches, "multiplier", f64);
             let new_multiplier_effective_timestamp =
                 value_t_or_exit!(arg_matches, "timestamp", i64);
-            let (multiplier_authority_signer, multiplier_authority_pubkey) =
-                config.signer_or_default(arg_matches, "multiplier_authority", &mut wallet_manager);
-            let bulk_signers = vec![multiplier_authority_signer];
+            let (ui_multiplier_authority_signer, ui_multiplier_authority_pubkey) = config
+                .signer_or_default(arg_matches, "ui_multiplier_authority", &mut wallet_manager);
+            let bulk_signers = vec![ui_multiplier_authority_signer];
 
             command_update_multiplier(
                 config,
                 token_pubkey,
-                multiplier_authority_pubkey,
+                ui_multiplier_authority_pubkey,
                 new_multiplier,
                 new_multiplier_effective_timestamp,
                 bulk_signers,

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -2889,6 +2889,13 @@ async fn confidential_transfer(test_validator: &TestValidator, payer: &Keypair) 
     )
     .await
     .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint
+        .get_extension::<ConfidentialTransferMint>()
+        .unwrap();
+    assert_eq!(Option::<Pubkey>::from(extension.authority), None,);
 }
 
 async fn confidential_transfer_with_fee(test_validator: &TestValidator, payer: &Keypair) {
@@ -4388,4 +4395,9 @@ async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
     )
     .await
     .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(Option::<Pubkey>::from(extension.authority), None,);
 }

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -27,6 +27,7 @@ use {
             memo_transfer::MemoTransfer,
             metadata_pointer::MetadataPointer,
             non_transferable::NonTransferable,
+            scaled_ui_amount::ScaledUiAmountConfig,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
             transfer_hook::TransferHook,
             BaseStateWithExtensions, StateWithExtensionsOwned,
@@ -144,6 +145,7 @@ async fn main() {
         async_trial!(group, test_validator, payer),
         async_trial!(confidential_transfer_with_fee, test_validator, payer),
         async_trial!(compute_budget, test_validator, payer),
+        async_trial!(scaled_ui_amount, test_validator, payer),
         // GC messes with every other test, so have it on its own test validator
         async_trial!(gc, gc_test_validator, gc_payer),
     ];
@@ -4313,4 +4315,77 @@ async fn compute_budget(test_validator: &TestValidator, payer: &Keypair) {
         config.compute_unit_limit = ComputeUnitLimit::Static(40_000);
         run_transfer_test(&config, payer).await;
     }
+}
+
+async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
+    let config = test_config_with_default_signer(test_validator, payer, &spl_token_2022::id());
+
+    // create token with scaled ui amount extension
+    let token = Keypair::new();
+    let token_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&token, &token_keypair_file).unwrap();
+    let token_pubkey = token.pubkey();
+    let ui_multiplier = 1.0;
+
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::CreateToken.into(),
+            token_keypair_file.path().to_str().unwrap(),
+            "--ui-multiplier",
+            &ui_multiplier.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(f64::from(extension.multiplier), ui_multiplier);
+
+    // update multiplier
+    let new_ui_multiplier = 5.0;
+    let new_ui_multiplier_timestamp = 0;
+
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::UpdateUiMultiplier.into(),
+            &token_pubkey.to_string(),
+            &new_ui_multiplier.to_string(),
+            &new_ui_multiplier_timestamp.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
+    let extension = test_mint.get_extension::<ScaledUiAmountConfig>().unwrap();
+    assert_eq!(f64::from(extension.multiplier), new_ui_multiplier);
+    assert_eq!(f64::from(extension.new_multiplier), new_ui_multiplier);
+    assert_eq!(
+        i64::from(extension.new_multiplier_effective_timestamp),
+        new_ui_multiplier_timestamp
+    );
+
+    // disable authority
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Authorize.into(),
+            &token_pubkey.to_string(),
+            "scaled-ui-amount",
+            "--disable",
+        ],
+    )
+    .await
+    .unwrap();
 }

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -4334,7 +4334,7 @@ async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
             "spl-token",
             CommandName::CreateToken.into(),
             token_keypair_file.path().to_str().unwrap(),
-            "--ui-multiplier",
+            "--ui-amount-multiplier",
             &ui_multiplier.to_string(),
         ],
     )
@@ -4355,7 +4355,7 @@ async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
         payer,
         &[
             "spl-token",
-            CommandName::UpdateUiMultiplier.into(),
+            CommandName::UpdateUiAmountMultiplier.into(),
             &token_pubkey.to_string(),
             &new_ui_multiplier.to_string(),
             &new_ui_multiplier_timestamp.to_string(),


### PR DESCRIPTION
#### Problem
The rust legacy cli does not yet have support for the scaled ui amount extension.

#### Summary of Changes
Added support for the scaled ui amount extension. 
- I think everything should be straightforward. One exception is how the unix timestamp should be taken in as input and how it should be printed out. Currently, the unix timestamp is just taken in as `i64` and printed out as `i64`. If you have a different suggestion, please let me know.
- The solana account-decoder in the monorepo does not yet have support for the scaled ui amount extension, so I wasn't able to add changes to print out the extension. I can wait until the the extension is supported or I can create an issue for this and then follow-up on a subsequent PR.