### PR TITLE
dependabot: Add JS client directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,10 @@ updates:
     timezone: UTC
   open-pull-requests-limit: 6
 - package-ecosystem: npm
-  directory: "/"
+  directories:
+    - "/"
+    - "/clients/js"
+    - "/clients/js-legacy"
   schedule:
     interval: daily
     time: "09:00"


### PR DESCRIPTION
#### Problem

Dependabot is only configured for the top-level JS lockfile, but we have two other JS client libraries.

#### Summary of changes

Add their directories to the dependabot configuration.