### PR TITLE
js-legacy: Add prepublish step

### DIFF
--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -28,6 +28,7 @@
         "import": "./lib/esm/index.js"
     },
     "scripts": {
+        "prepublishOnly": "pnpm build",
         "nuke": "shx rm -rf node_modules package-lock.json || true",
         "reinstall": "npm run nuke && npm install",
         "clean": "shx rm -rf lib **/*.tsbuildinfo || true",


### PR DESCRIPTION
#### Problem

The newest spl-token JS library wasn't actually built before publishing.

#### Summary of changes

Add a `prepublishOnly` step, similar to the other js client.

Fixes https://github.com/solana-program/token/issues/20