### PR TITLE
CI: Enable semver check job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,9 +258,10 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
+          cli: true
           cargo-cache-key: cargo-semver
 
-      - name: Install cargo-audit
+      - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-semver-checks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,6 @@ jobs:
         run: pnpm rust:audit
 
   semver_rust:
-    if: false # enable after token-2022 bumps to a new major version
     name: Check semver Rust
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#### Problem

The Rust crates in this repo adhere to semver, but we don't check that new PRs maintain that in CI.

#### Summary of changes

Enable the disabled semver job in CI.