### PR TITLE
ui-amount: Add a warning for floating-point math

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -519,6 +519,14 @@ pub enum TokenInstruction<'a> {
     /// Return data can be fetched using `sol_get_return_data` and deserialized
     /// with `String::from_utf8`.
     ///
+    /// WARNING: For mints using the interest-bearing or scaled-ui-amount
+    /// extensions, this instruction uses standard floating-point arithmetic to
+    /// convert values, which is not guaranteed to give consistent behavior.
+    ///
+    /// In particular, conversions will not always work in reverse. For example,
+    /// if you pass amount `A` to `AmountToUiAmount` and receive `B`, and pass
+    /// the result `B` to `UiAmountToAmount`, you will not always get back `A`.
+    ///
     /// Accounts expected by this instruction:
     ///
     ///   0. `[]` The mint to calculate for
@@ -531,6 +539,14 @@ pub enum TokenInstruction<'a> {
     ///
     /// Return data can be fetched using `sol_get_return_data` and deserializing
     /// the return data as a little-endian `u64`.
+    ///
+    /// WARNING: For mints using the interest-bearing or scaled-ui-amount
+    /// extensions, this instruction uses standard floating-point arithmetic to
+    /// convert values, which is not guaranteed to give consistent behavior.
+    ///
+    /// In particular, conversions will not always work in reverse. For example,
+    /// if you pass amount `A` to `UiAmountToAmount` and receive `B`, and pass
+    /// the result `B` to `AmountToUiAmount`, you will not always get back `A`.
     ///
     /// Accounts expected by this instruction:
     ///


### PR DESCRIPTION
#### Problem

Although the UI amount <-> amount conversions are clear because they use strings, the underlying math uses floats, which has all of the problems normally associated with floats.

#### Summary of changes

Add warnings about the inner workings of `AmountToUiAmount` and `UiAmountToAmount`.

Fixes #130