### PR TITLE
[rust-legacy-client] Add confidential mint burn extension

### DIFF
--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -30,6 +30,11 @@ use {
     spl_record::state::RecordData,
     spl_token_2022::{
         extension::{
+            confidential_mint_burn::{
+                self,
+                account_info::{BurnAccountInfo, SupplyAccountInfo},
+                ConfidentialMintBurn,
+            },
             confidential_transfer::{
                 self,
                 account_info::{
@@ -52,7 +57,10 @@ use {
             encryption::{
                 auth_encryption::AeKey,
                 elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
-                pod::elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
+                pod::{
+                    auth_encryption::PodAeCiphertext,
+                    elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
+                },
             },
             zk_elgamal_proof_program::{
                 self,
@@ -67,8 +75,8 @@ use {
         zk_proof_type_to_instruction, ProofData, ProofLocation,
     },
     spl_token_confidential_transfer_proof_generation::{
-        transfer::TransferProofData, transfer_with_fee::TransferWithFeeProofData,
-        withdraw::WithdrawProofData,
+        burn::BurnProofData, mint::MintProofData, transfer::TransferProofData,
+        transfer_with_fee::TransferWithFeeProofData, withdraw::WithdrawProofData,
     },
     spl_token_group_interface::state::{TokenGroup, TokenGroupMember},
     spl_token_metadata_interface::state::{Field, TokenMetadata},
@@ -196,6 +204,10 @@ pub enum ExtensionInitializationParams {
     PausableConfig {
         authority: Pubkey,
     },
+    ConfidentialMintBurn {
+        supply_elgamal_pubkey: PodElGamalPubkey,
+        decryptable_supply: PodAeCiphertext,
+    },
 }
 impl ExtensionInitializationParams {
     /// Get the extension type associated with the init params
@@ -217,6 +229,7 @@ impl ExtensionInitializationParams {
             Self::GroupMemberPointer { .. } => ExtensionType::GroupMemberPointer,
             Self::ScaledUiAmountConfig { .. } => ExtensionType::ScaledUiAmount,
             Self::PausableConfig { .. } => ExtensionType::Pausable,
+            Self::ConfidentialMintBurn { .. } => ExtensionType::ConfidentialMintBurn,
         }
     }
     /// Generate an appropriate initialization instruction for the given mint
@@ -338,6 +351,15 @@ impl ExtensionInitializationParams {
             Self::PausableConfig { authority } => {
                 pausable::instruction::initialize(token_program_id, mint, &authority)
             }
+            Self::ConfidentialMintBurn {
+                supply_elgamal_pubkey,
+                decryptable_supply,
+            } => confidential_mint_burn::instruction::initialize_mint(
+                token_program_id,
+                mint,
+                &supply_elgamal_pubkey,
+                &decryptable_supply,
+            ),
         }
     }
 }
@@ -2687,7 +2709,7 @@ where
             && fee_ciphertext_validity_proof_account.is_some()
             && range_proof_account.is_some()
         {
-            // is all proofs come from accounts, then skip proof generation
+            // if all proofs come from accounts, then skip proof generation
             (None, None, None, None, None)
         } else {
             let TransferWithFeeProofData {
@@ -3175,6 +3197,367 @@ where
                     &multisig_signers,
                 )?,
             ],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Rotate supply ElGamal public key in a confidential mint
+    #[allow(clippy::too_many_arguments)]
+    pub async fn confidential_transfer_rotate_supply_elgamal_pubkey<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        current_supply_elgamal_keypair: &ElGamalKeypair,
+        new_supply_elgamal_pubkey: &ElGamalPubkey,
+        aes_key: &AeKey,
+        proof_account: Option<&ProofAccount>,
+        account_info: Option<SupplyAccountInfo>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        let account_info = if let Some(account_info) = account_info {
+            account_info
+        } else {
+            let account = self.get_mint_info().await?;
+            let confidential_supply_account = account.get_extension::<ConfidentialMintBurn>()?;
+            SupplyAccountInfo::new(confidential_supply_account)
+        };
+
+        let proof_data = if proof_account.is_some() {
+            None
+        } else {
+            Some(
+                account_info
+                    .generate_rotate_supply_elgamal_pubkey_proof(
+                        current_supply_elgamal_keypair,
+                        new_supply_elgamal_pubkey,
+                        aes_key,
+                    )
+                    .map_err(|_| TokenError::ProofGeneration)?,
+            )
+        };
+
+        // cannot panic as long as either `proof_data` or `proof_account` is `Some(..)`,
+        // which is guaranteed by the previous check
+        let proof_location = Self::confidential_transfer_create_proof_location(
+            proof_data.as_ref(),
+            proof_account,
+            1,
+        )
+        .unwrap();
+
+        let new_supply_elgamal_pubkey = (*new_supply_elgamal_pubkey).into();
+        self.process_ixs(
+            &confidential_mint_burn::instruction::rotate_supply_elgamal_pubkey(
+                &self.program_id,
+                &self.pubkey,
+                authority,
+                &multisig_signers,
+                &new_supply_elgamal_pubkey,
+                proof_location,
+            )?,
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Update decryptable supply in a confidential mint
+    pub async fn confidential_transfer_update_decrypt_supply<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        new_decryptable_supply: &DecryptableBalance,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        self.process_ixs(
+            &[
+                confidential_mint_burn::instruction::update_decryptable_supply(
+                    &self.program_id,
+                    &self.pubkey,
+                    authority,
+                    &multisig_signers,
+                    new_decryptable_supply,
+                )?,
+            ],
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Confidentially mint tokens
+    #[allow(clippy::too_many_arguments)]
+    pub async fn confidential_transfer_mint<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        destination_account: &Pubkey,
+        equality_proof_account: Option<&ProofAccount>,
+        ciphertext_validity_proof_account_with_ciphertext: Option<&ProofAccountWithCiphertext>,
+        range_proof_account: Option<&ProofAccount>,
+        mint_amount: u64,
+        supply_elgamal_keypair: &ElGamalKeypair,
+        destination_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
+        aes_key: &AeKey,
+        account_info: Option<SupplyAccountInfo>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        let account_info = if let Some(account_info) = account_info {
+            account_info
+        } else {
+            let account = self.get_mint_info().await?;
+            let confidential_supply_account = account.get_extension::<ConfidentialMintBurn>()?;
+            SupplyAccountInfo::new(confidential_supply_account)
+        };
+
+        let (equality_proof_data, ciphertext_validity_proof_data_with_ciphertext, range_proof_data) =
+            if equality_proof_account.is_some()
+                && ciphertext_validity_proof_account_with_ciphertext.is_some()
+                && range_proof_account.is_some()
+            {
+                // if all proofs come from accounts, then skip proof generation
+                (None, None, None)
+            } else {
+                let MintProofData {
+                    equality_proof_data,
+                    ciphertext_validity_proof_data_with_ciphertext,
+                    range_proof_data,
+                } = account_info
+                    .generate_split_mint_proof_data(
+                        mint_amount,
+                        supply_elgamal_keypair,
+                        aes_key,
+                        destination_elgamal_pubkey,
+                        auditor_elgamal_pubkey,
+                    )
+                    .map_err(|_| TokenError::ProofGeneration)?;
+
+                let equality_proof_data = equality_proof_account
+                    .is_none()
+                    .then_some(equality_proof_data);
+                let ciphertext_validity_proof_data_with_ciphertext =
+                    ciphertext_validity_proof_account_with_ciphertext
+                        .is_none()
+                        .then_some(ciphertext_validity_proof_data_with_ciphertext);
+                let range_proof_data = range_proof_account.is_none().then_some(range_proof_data);
+
+                (
+                    equality_proof_data,
+                    ciphertext_validity_proof_data_with_ciphertext,
+                    range_proof_data,
+                )
+            };
+
+        // cannot panic as long as either `proof_data` or `proof_account` is `Some(..)`,
+        // which is guaranteed by the previous check
+        let equality_proof_location = Self::confidential_transfer_create_proof_location(
+            equality_proof_data.as_ref(),
+            equality_proof_account,
+            1,
+        )
+        .unwrap();
+        let ciphertext_validity_proof_data =
+            ciphertext_validity_proof_data_with_ciphertext.map(|data| data.proof_data);
+        let ciphertext_validity_proof_location = Self::confidential_transfer_create_proof_location(
+            ciphertext_validity_proof_data.as_ref(),
+            ciphertext_validity_proof_account_with_ciphertext.map(|account| &account.proof_account),
+            2,
+        )
+        .unwrap();
+        let range_proof_location = Self::confidential_transfer_create_proof_location(
+            range_proof_data.as_ref(),
+            range_proof_account,
+            3,
+        )
+        .unwrap();
+
+        let (mint_amount_auditor_ciphertext_lo, mint_amount_auditor_ciphertext_hi) = if let Some(
+            proof_data_with_ciphertext,
+        ) =
+            ciphertext_validity_proof_data_with_ciphertext
+        {
+            (
+                proof_data_with_ciphertext.ciphertext_lo,
+                proof_data_with_ciphertext.ciphertext_hi,
+            )
+        } else {
+            // unwrap is safe as long as either `proof_data_with_ciphertext`,
+            // `proof_account_with_ciphertext` is `Some(..)`, which is guaranteed by the
+            // previous check
+            (
+                ciphertext_validity_proof_account_with_ciphertext
+                    .unwrap()
+                    .ciphertext_lo,
+                ciphertext_validity_proof_account_with_ciphertext
+                    .unwrap()
+                    .ciphertext_hi,
+            )
+        };
+
+        let new_decryptable_supply = account_info
+            .new_decryptable_supply(mint_amount, supply_elgamal_keypair, aes_key)
+            .map_err(|_| TokenError::AccountDecryption)?
+            .into();
+
+        self.process_ixs(
+            &confidential_mint_burn::instruction::confidential_mint_with_split_proofs(
+                &self.program_id,
+                destination_account,
+                &self.pubkey,
+                Some(*supply_elgamal_keypair.pubkey()),
+                &mint_amount_auditor_ciphertext_lo,
+                &mint_amount_auditor_ciphertext_hi,
+                authority,
+                &multisig_signers,
+                equality_proof_location,
+                ciphertext_validity_proof_location,
+                range_proof_location,
+                &new_decryptable_supply,
+            )?,
+            signing_keypairs,
+        )
+        .await
+    }
+
+    /// Confidentially burn tokens
+    #[allow(clippy::too_many_arguments)]
+    pub async fn confidential_transfer_burn<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        source_account: &Pubkey,
+        equality_proof_account: Option<&ProofAccount>,
+        ciphertext_validity_proof_account_with_ciphertext: Option<&ProofAccountWithCiphertext>,
+        range_proof_account: Option<&ProofAccount>,
+        burn_amount: u64,
+        source_elgamal_keypair: &ElGamalKeypair,
+        supply_elgamal_pubkey: &ElGamalPubkey,
+        auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
+        aes_key: &AeKey,
+        account_info: Option<BurnAccountInfo>,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        let account_info = if let Some(account_info) = account_info {
+            account_info
+        } else {
+            let account = self.get_account_info(source_account).await?;
+            let confidential_supply_account =
+                account.get_extension::<ConfidentialTransferAccount>()?;
+            BurnAccountInfo::new(confidential_supply_account)
+        };
+
+        let (equality_proof_data, ciphertext_validity_proof_data_with_ciphertext, range_proof_data) =
+            if equality_proof_account.is_some()
+                && ciphertext_validity_proof_account_with_ciphertext.is_some()
+                && range_proof_account.is_some()
+            {
+                // if all proofs come from accounts, then skip proof generation
+                (None, None, None)
+            } else {
+                let BurnProofData {
+                    equality_proof_data,
+                    ciphertext_validity_proof_data_with_ciphertext,
+                    range_proof_data,
+                } = account_info
+                    .generate_split_burn_proof_data(
+                        burn_amount,
+                        source_elgamal_keypair,
+                        aes_key,
+                        supply_elgamal_pubkey,
+                        auditor_elgamal_pubkey,
+                    )
+                    .map_err(|_| TokenError::ProofGeneration)?;
+
+                let equality_proof_data = equality_proof_account
+                    .is_none()
+                    .then_some(equality_proof_data);
+                let ciphertext_validity_proof_data_with_ciphertext =
+                    ciphertext_validity_proof_account_with_ciphertext
+                        .is_none()
+                        .then_some(ciphertext_validity_proof_data_with_ciphertext);
+                let range_proof_data = range_proof_account.is_none().then_some(range_proof_data);
+
+                (
+                    equality_proof_data,
+                    ciphertext_validity_proof_data_with_ciphertext,
+                    range_proof_data,
+                )
+            };
+
+        // cannot panic as long as either `proof_data` or `proof_account` is `Some(..)`,
+        // which is guaranteed by the previous check
+        let equality_proof_location = Self::confidential_transfer_create_proof_location(
+            equality_proof_data.as_ref(),
+            equality_proof_account,
+            1,
+        )
+        .unwrap();
+        let ciphertext_validity_proof_data =
+            ciphertext_validity_proof_data_with_ciphertext.map(|data| data.proof_data);
+        let ciphertext_validity_proof_location = Self::confidential_transfer_create_proof_location(
+            ciphertext_validity_proof_data.as_ref(),
+            ciphertext_validity_proof_account_with_ciphertext.map(|account| &account.proof_account),
+            2,
+        )
+        .unwrap();
+        let range_proof_location = Self::confidential_transfer_create_proof_location(
+            range_proof_data.as_ref(),
+            range_proof_account,
+            3,
+        )
+        .unwrap();
+
+        let (burn_amount_auditor_ciphertext_lo, burn_amount_auditor_ciphertext_hi) = if let Some(
+            proof_data_with_ciphertext,
+        ) =
+            ciphertext_validity_proof_data_with_ciphertext
+        {
+            (
+                proof_data_with_ciphertext.ciphertext_lo,
+                proof_data_with_ciphertext.ciphertext_hi,
+            )
+        } else {
+            // unwrap is safe as long as either `proof_data_with_ciphertext`,
+            // `proof_account_with_ciphertext` is `Some(..)`, which is guaranteed by the
+            // previous check
+            (
+                ciphertext_validity_proof_account_with_ciphertext
+                    .unwrap()
+                    .ciphertext_lo,
+                ciphertext_validity_proof_account_with_ciphertext
+                    .unwrap()
+                    .ciphertext_hi,
+            )
+        };
+
+        let new_decryptable_balance = account_info
+            .new_decryptable_balance(burn_amount, aes_key)
+            .map_err(|_| TokenError::AccountDecryption)?
+            .into();
+
+        self.process_ixs(
+            &confidential_mint_burn::instruction::confidential_burn_with_split_proofs(
+                &self.program_id,
+                source_account,
+                &self.pubkey,
+                Some(*supply_elgamal_pubkey),
+                &new_decryptable_balance,
+                &burn_amount_auditor_ciphertext_lo,
+                &burn_amount_auditor_ciphertext_hi,
+                authority,
+                &multisig_signers,
+                equality_proof_location,
+                ciphertext_validity_proof_location,
+                range_proof_location,
+            )?,
             signing_keypairs,
         )
         .await

--- a/clients/rust-legacy/tests/confidential_mint_burn.rs
+++ b/clients/rust-legacy/tests/confidential_mint_burn.rs
@@ -1,0 +1,1156 @@
+mod program_test;
+use {
+    program_test::{ConfidentialTransferOption, TestContext, TokenContext},
+    solana_program_test::tokio,
+    solana_sdk::{
+        instruction::InstructionError,
+        pubkey::Pubkey,
+        signature::Signer,
+        signer::{keypair::Keypair, signers::Signers},
+        transaction::TransactionError,
+        transport::TransportError,
+    },
+    spl_record::state::RecordData,
+    spl_token_2022::{
+        error::TokenError,
+        extension::{
+            confidential_mint_burn::{
+                account_info::{BurnAccountInfo, SupplyAccountInfo},
+                ConfidentialMintBurn,
+            },
+            confidential_transfer::ConfidentialTransferAccount,
+            BaseStateWithExtensions, ExtensionType,
+        },
+        solana_zk_sdk::encryption::{
+            auth_encryption::*, elgamal::*, pod::elgamal::PodElGamalCiphertext,
+        },
+    },
+    spl_token_client::{
+        client::{ProgramBanksClientProcessTransaction, SendTransaction, SimulateTransaction},
+        token::{
+            ExtensionInitializationParams, ProofAccount, ProofAccountWithCiphertext, Token,
+            TokenError as TokenClientError, TokenResult,
+        },
+    },
+    spl_token_confidential_transfer_proof_generation::{burn::BurnProofData, mint::MintProofData},
+    std::convert::TryInto,
+};
+
+struct ConfidentialTokenAccountMeta {
+    token_account: Pubkey,
+    elgamal_keypair: ElGamalKeypair,
+    aes_key: AeKey,
+}
+
+impl ConfidentialTokenAccountMeta {
+    async fn new<T>(token: &Token<T>, owner: &Keypair) -> Self
+    where
+        T: SendTransaction + SimulateTransaction,
+    {
+        let token_account_keypair = Keypair::new();
+        let extensions = vec![
+            ExtensionType::ConfidentialTransferAccount,
+            ExtensionType::ConfidentialMintBurn,
+        ];
+
+        token
+            .create_auxiliary_token_account_with_extension_space(
+                &token_account_keypair,
+                &owner.pubkey(),
+                extensions,
+            )
+            .await
+            .unwrap();
+
+        let token_account = token_account_keypair.pubkey();
+        let elgamal_keypair =
+            ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+        let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+
+        token
+            .confidential_transfer_configure_token_account(
+                &token_account,
+                &owner.pubkey(),
+                None,
+                None,
+                &elgamal_keypair,
+                &aes_key,
+                &[owner],
+            )
+            .await
+            .unwrap();
+
+        Self {
+            token_account,
+            elgamal_keypair,
+            aes_key,
+        }
+    }
+}
+
+#[tokio::test]
+async fn confidential_mint_burn_config() {
+    let confidential_transfer_authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let supply_elgamal_keypair = ElGamalKeypair::new_rand();
+    let supply_elgamal_pubkey = (*supply_elgamal_keypair.pubkey()).into();
+
+    let supply_aes_key = AeKey::new_rand();
+    let decryptable_supply = supply_aes_key.encrypt(0).into();
+
+    let mut context = TestContext::new().await;
+
+    // Try invalid combinations of extensions
+    let err = context
+        .init_token_with_mint(vec![ExtensionInitializationParams::ConfidentialMintBurn {
+            supply_elgamal_pubkey,
+            decryptable_supply,
+        }])
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(
+                2,
+                InstructionError::Custom(TokenError::InvalidExtensionCombination as u32),
+            )
+        )))
+    );
+
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(confidential_transfer_authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+            ExtensionInitializationParams::ConfidentialMintBurn {
+                supply_elgamal_pubkey,
+                decryptable_supply,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext { token, .. } = context.token_context.unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+
+    assert_eq!(extension.supply_elgamal_pubkey, supply_elgamal_pubkey);
+    assert_eq!(extension.decryptable_supply, decryptable_supply);
+    assert_eq!(
+        extension.confidential_supply,
+        PodElGamalCiphertext::default()
+    );
+}
+
+async fn rotate_supply_elgamal_pubkey<S: Signers>(
+    token: &Token<ProgramBanksClientProcessTransaction>,
+    authority: &Pubkey,
+    current_supply_elgamal_keypair: &ElGamalKeypair,
+    new_supply_elgamal_pubkey: &ElGamalPubkey,
+    aes_key: &AeKey,
+    signing_keypairs: &S,
+    option: ConfidentialTransferOption,
+) -> TokenResult<()> {
+    match option {
+        ConfidentialTransferOption::InstructionData => {
+            token
+                .confidential_transfer_rotate_supply_elgamal_pubkey(
+                    authority,
+                    current_supply_elgamal_keypair,
+                    new_supply_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    None,
+                    signing_keypairs,
+                )
+                .await
+        }
+        ConfidentialTransferOption::RecordAccount => {
+            let state = token.get_mint_info().await.unwrap();
+            let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+            let account_info = SupplyAccountInfo::new(extension);
+
+            let proof_data = account_info
+                .generate_rotate_supply_elgamal_pubkey_proof(
+                    current_supply_elgamal_keypair,
+                    new_supply_elgamal_pubkey,
+                    aes_key,
+                )
+                .unwrap();
+
+            let record_account = Keypair::new();
+            let record_account_authority = Keypair::new();
+
+            token
+                .confidential_transfer_create_record_account(
+                    &record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &proof_data,
+                    &record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let proof_account = ProofAccount::RecordAccount(
+                record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            let result = token
+                .confidential_transfer_rotate_supply_elgamal_pubkey(
+                    authority,
+                    current_supply_elgamal_keypair,
+                    new_supply_elgamal_pubkey,
+                    aes_key,
+                    Some(&proof_account),
+                    None,
+                    signing_keypairs,
+                )
+                .await;
+
+            let lamport_destination = Keypair::new().pubkey();
+            token
+                .confidential_transfer_close_record_account(
+                    &record_account.pubkey(),
+                    &lamport_destination,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            result
+        }
+        ConfidentialTransferOption::ContextStateAccount => {
+            let state = token.get_mint_info().await.unwrap();
+            let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+            let account_info = SupplyAccountInfo::new(extension);
+
+            let proof_data = account_info
+                .generate_rotate_supply_elgamal_pubkey_proof(
+                    current_supply_elgamal_keypair,
+                    new_supply_elgamal_pubkey,
+                    aes_key,
+                )
+                .unwrap();
+
+            let context_account = Keypair::new();
+            let context_account_authority = Keypair::new();
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &proof_data,
+                    false,
+                    &[&context_account],
+                )
+                .await
+                .unwrap();
+
+            let proof_account = ProofAccount::ContextAccount(context_account.pubkey());
+
+            let result = token
+                .confidential_transfer_rotate_supply_elgamal_pubkey(
+                    authority,
+                    current_supply_elgamal_keypair,
+                    new_supply_elgamal_pubkey,
+                    aes_key,
+                    Some(&proof_account),
+                    None,
+                    signing_keypairs,
+                )
+                .await;
+
+            let lamport_destination = Keypair::new().pubkey();
+            token
+                .confidential_transfer_close_context_state_account(
+                    &context_account.pubkey(),
+                    &lamport_destination,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            result
+        }
+    }
+}
+
+#[tokio::test]
+async fn confidential_mint_burn_rotate_supply_elgamal_pubkey() {
+    confidential_mint_burn_rotate_supply_elgamal_pubkey_with_option(
+        ConfidentialTransferOption::InstructionData,
+    )
+    .await;
+    confidential_mint_burn_rotate_supply_elgamal_pubkey_with_option(
+        ConfidentialTransferOption::RecordAccount,
+    )
+    .await;
+    confidential_mint_burn_rotate_supply_elgamal_pubkey_with_option(
+        ConfidentialTransferOption::ContextStateAccount,
+    )
+    .await;
+}
+
+async fn confidential_mint_burn_rotate_supply_elgamal_pubkey_with_option(
+    option: ConfidentialTransferOption,
+) {
+    let confidential_transfer_authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let supply_elgamal_keypair = ElGamalKeypair::new_rand();
+    let supply_elgamal_pubkey = (*supply_elgamal_keypair.pubkey()).into();
+    let supply_aes_key = AeKey::new_rand();
+    let decryptable_supply = supply_aes_key.encrypt(0).into();
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(confidential_transfer_authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+            ExtensionInitializationParams::ConfidentialMintBurn {
+                supply_elgamal_pubkey,
+                decryptable_supply,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token,
+        mint_authority,
+        ..
+    } = context.token_context.unwrap();
+
+    let new_supply_elgamal_keypair = ElGamalKeypair::new_rand();
+    let new_supply_elgamal_pubkey = new_supply_elgamal_keypair.pubkey();
+
+    rotate_supply_elgamal_pubkey(
+        &token,
+        &mint_authority.pubkey(),
+        &supply_elgamal_keypair,
+        new_supply_elgamal_pubkey,
+        &supply_aes_key,
+        &[&mint_authority],
+        option,
+    )
+    .await
+    .unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+
+    // check that the new supply ElGamal public key is updated
+    let expected_new_supply_elgamal_pubkey = (*new_supply_elgamal_pubkey).into();
+    assert_eq!(
+        extension.supply_elgamal_pubkey,
+        expected_new_supply_elgamal_pubkey
+    );
+
+    // check that the new supply ElGamal keypair can decrypt the supply
+    let confidential_supply: ElGamalCiphertext = extension.confidential_supply.try_into().unwrap();
+    assert_eq!(
+        confidential_supply
+            .decrypt_u32(new_supply_elgamal_keypair.secret())
+            .unwrap(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn confidential_mint_burn_update_decryptable_supply() {
+    let confidential_transfer_authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let supply_elgamal_keypair = ElGamalKeypair::new_rand();
+    let supply_elgamal_pubkey = (*supply_elgamal_keypair.pubkey()).into();
+    let supply_aes_key = AeKey::new_rand();
+    let decryptable_supply = supply_aes_key.encrypt(0).into();
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(confidential_transfer_authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+            ExtensionInitializationParams::ConfidentialMintBurn {
+                supply_elgamal_pubkey,
+                decryptable_supply,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token,
+        mint_authority,
+        ..
+    } = context.token_context.unwrap();
+
+    let new_decryptable_supply = supply_aes_key.encrypt(0).into();
+    token
+        .confidential_transfer_update_decrypt_supply(
+            &mint_authority.pubkey(),
+            &new_decryptable_supply,
+            &[&mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let state = token.get_mint_info().await.unwrap();
+    let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+
+    // check that the new decryptable supply is updated
+    assert_eq!(extension.decryptable_supply, new_decryptable_supply,);
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn mint_with_option<S: Signers>(
+    token: &Token<ProgramBanksClientProcessTransaction>,
+    authority: &Pubkey,
+    destination_account: &Pubkey,
+    mint_amount: u64,
+    supply_elgamal_keypair: &ElGamalKeypair,
+    destination_elgamal_pubkey: &ElGamalPubkey,
+    auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
+    aes_key: &AeKey,
+    signing_keypairs: &S,
+    option: ConfidentialTransferOption,
+) -> TokenResult<()> {
+    match option {
+        ConfidentialTransferOption::InstructionData => {
+            token
+                .confidential_transfer_mint(
+                    authority,
+                    destination_account,
+                    None,
+                    None,
+                    None,
+                    mint_amount,
+                    supply_elgamal_keypair,
+                    destination_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    signing_keypairs,
+                )
+                .await
+        }
+        ConfidentialTransferOption::RecordAccount => {
+            let state = token.get_mint_info().await.unwrap();
+            let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+            let account_info = SupplyAccountInfo::new(extension);
+
+            let MintProofData {
+                equality_proof_data,
+                ciphertext_validity_proof_data_with_ciphertext,
+                range_proof_data,
+            } = account_info
+                .generate_split_mint_proof_data(
+                    mint_amount,
+                    supply_elgamal_keypair,
+                    aes_key,
+                    destination_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                )
+                .unwrap();
+
+            let mint_amount_auditor_ciphertext_lo =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo;
+            let mint_amount_auditor_ciphertext_hi =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi;
+
+            let equality_proof_record_account = Keypair::new();
+            let ciphertext_validity_proof_record_account = Keypair::new();
+            let range_proof_record_account = Keypair::new();
+            let record_account_authority = Keypair::new();
+
+            token
+                .confidential_transfer_create_record_account(
+                    &equality_proof_record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &equality_proof_data,
+                    &equality_proof_record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let equality_proof_account = ProofAccount::RecordAccount(
+                equality_proof_record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            token
+                .confidential_transfer_create_record_account(
+                    &ciphertext_validity_proof_record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &ciphertext_validity_proof_data_with_ciphertext.proof_data,
+                    &ciphertext_validity_proof_record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let ciphertext_validity_proof_account = ProofAccount::RecordAccount(
+                ciphertext_validity_proof_record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            token
+                .confidential_transfer_create_record_account(
+                    &range_proof_record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &range_proof_data,
+                    &range_proof_record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let range_proof_account = ProofAccount::RecordAccount(
+                range_proof_record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
+                proof_account: ciphertext_validity_proof_account,
+                ciphertext_lo: mint_amount_auditor_ciphertext_lo,
+                ciphertext_hi: mint_amount_auditor_ciphertext_hi,
+            };
+
+            let result = token
+                .confidential_transfer_mint(
+                    authority,
+                    destination_account,
+                    Some(&equality_proof_account),
+                    Some(&ciphertext_validity_proof_account_with_ciphertext),
+                    Some(&range_proof_account),
+                    mint_amount,
+                    supply_elgamal_keypair,
+                    destination_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    signing_keypairs,
+                )
+                .await;
+
+            let lamport_destination_account = Keypair::new().pubkey();
+            token
+                .confidential_transfer_close_record_account(
+                    &equality_proof_record_account.pubkey(),
+                    &lamport_destination_account,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_record_account(
+                    &ciphertext_validity_proof_record_account.pubkey(),
+                    &lamport_destination_account,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_record_account(
+                    &range_proof_record_account.pubkey(),
+                    &lamport_destination_account,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            result
+        }
+        ConfidentialTransferOption::ContextStateAccount => {
+            let state = token.get_mint_info().await.unwrap();
+            let extension = state.get_extension::<ConfidentialMintBurn>().unwrap();
+            let account_info = SupplyAccountInfo::new(extension);
+
+            let MintProofData {
+                equality_proof_data,
+                ciphertext_validity_proof_data_with_ciphertext,
+                range_proof_data,
+            } = account_info
+                .generate_split_mint_proof_data(
+                    mint_amount,
+                    supply_elgamal_keypair,
+                    aes_key,
+                    destination_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                )
+                .unwrap();
+
+            let mint_amount_auditor_ciphertext_lo =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo;
+            let mint_amount_auditor_ciphertext_hi =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi;
+
+            let equality_proof_context_account = Keypair::new();
+            let ciphertext_validity_proof_context_account = Keypair::new();
+            let range_proof_context_account = Keypair::new();
+            let context_account_authority = Keypair::new();
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &equality_proof_context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &equality_proof_data,
+                    false,
+                    &[&equality_proof_context_account],
+                )
+                .await
+                .unwrap();
+
+            let equality_proof_context_proof_account =
+                ProofAccount::ContextAccount(equality_proof_context_account.pubkey());
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &ciphertext_validity_proof_context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &ciphertext_validity_proof_data_with_ciphertext.proof_data,
+                    false,
+                    &[&ciphertext_validity_proof_context_account],
+                )
+                .await
+                .unwrap();
+
+            let ciphertext_validity_proof_context_proof_account =
+                ProofAccount::ContextAccount(ciphertext_validity_proof_context_account.pubkey());
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &range_proof_context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &range_proof_data,
+                    false,
+                    &[&range_proof_context_account],
+                )
+                .await
+                .unwrap();
+
+            let range_proof_context_proof_account =
+                ProofAccount::ContextAccount(range_proof_context_account.pubkey());
+
+            let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
+                proof_account: ciphertext_validity_proof_context_proof_account,
+                ciphertext_lo: mint_amount_auditor_ciphertext_lo,
+                ciphertext_hi: mint_amount_auditor_ciphertext_hi,
+            };
+
+            let result = token
+                .confidential_transfer_mint(
+                    authority,
+                    destination_account,
+                    Some(&equality_proof_context_proof_account),
+                    Some(&ciphertext_validity_proof_account_with_ciphertext),
+                    Some(&range_proof_context_proof_account),
+                    mint_amount,
+                    supply_elgamal_keypair,
+                    destination_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    signing_keypairs,
+                )
+                .await;
+
+            let lamport_destination_account = Keypair::new().pubkey();
+            token
+                .confidential_transfer_close_context_state_account(
+                    &equality_proof_context_account.pubkey(),
+                    &lamport_destination_account,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_context_state_account(
+                    &ciphertext_validity_proof_context_account.pubkey(),
+                    &lamport_destination_account,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_context_state_account(
+                    &range_proof_context_account.pubkey(),
+                    &lamport_destination_account,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            result
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn burn_with_option<S: Signers>(
+    token: &Token<ProgramBanksClientProcessTransaction>,
+    authority: &Pubkey,
+    source_account: &Pubkey,
+    burn_amount: u64,
+    source_elgamal_keypair: &ElGamalKeypair,
+    supply_elgamal_pubkey: &ElGamalPubkey,
+    auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
+    aes_key: &AeKey,
+    signing_keypairs: &S,
+    option: ConfidentialTransferOption,
+) -> TokenResult<()> {
+    match option {
+        ConfidentialTransferOption::InstructionData => {
+            token
+                .confidential_transfer_burn(
+                    authority,
+                    source_account,
+                    None,
+                    None,
+                    None,
+                    burn_amount,
+                    source_elgamal_keypair,
+                    supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    signing_keypairs,
+                )
+                .await
+        }
+        ConfidentialTransferOption::RecordAccount => {
+            let state = token.get_account_info(source_account).await.unwrap();
+            let extension = state
+                .get_extension::<ConfidentialTransferAccount>()
+                .unwrap();
+            let account_info = BurnAccountInfo::new(extension);
+
+            let BurnProofData {
+                equality_proof_data,
+                ciphertext_validity_proof_data_with_ciphertext,
+                range_proof_data,
+            } = account_info
+                .generate_split_burn_proof_data(
+                    burn_amount,
+                    source_elgamal_keypair,
+                    aes_key,
+                    supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                )
+                .unwrap();
+
+            let burn_amount_auditor_ciphertext_lo =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo;
+            let burn_amount_auditor_ciphertext_hi =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi;
+
+            let equality_proof_record_account = Keypair::new();
+            let ciphertext_validity_proof_record_account = Keypair::new();
+            let range_proof_record_account = Keypair::new();
+            let record_account_authority = Keypair::new();
+
+            token
+                .confidential_transfer_create_record_account(
+                    &equality_proof_record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &equality_proof_data,
+                    &equality_proof_record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let equality_proof_account = ProofAccount::RecordAccount(
+                equality_proof_record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            token
+                .confidential_transfer_create_record_account(
+                    &ciphertext_validity_proof_record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &ciphertext_validity_proof_data_with_ciphertext.proof_data,
+                    &ciphertext_validity_proof_record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let ciphertext_validity_proof_account = ProofAccount::RecordAccount(
+                ciphertext_validity_proof_record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            token
+                .confidential_transfer_create_record_account(
+                    &range_proof_record_account.pubkey(),
+                    &record_account_authority.pubkey(),
+                    &range_proof_data,
+                    &range_proof_record_account,
+                    &record_account_authority,
+                )
+                .await
+                .unwrap();
+
+            let range_proof_account = ProofAccount::RecordAccount(
+                range_proof_record_account.pubkey(),
+                RecordData::WRITABLE_START_INDEX as u32,
+            );
+
+            let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
+                proof_account: ciphertext_validity_proof_account,
+                ciphertext_lo: burn_amount_auditor_ciphertext_lo,
+                ciphertext_hi: burn_amount_auditor_ciphertext_hi,
+            };
+
+            let result = token
+                .confidential_transfer_burn(
+                    authority,
+                    source_account,
+                    Some(&equality_proof_account),
+                    Some(&ciphertext_validity_proof_account_with_ciphertext),
+                    Some(&range_proof_account),
+                    burn_amount,
+                    source_elgamal_keypair,
+                    supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    signing_keypairs,
+                )
+                .await;
+
+            let lamport_destination_account = Keypair::new().pubkey();
+            token
+                .confidential_transfer_close_record_account(
+                    &equality_proof_record_account.pubkey(),
+                    &lamport_destination_account,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_record_account(
+                    &ciphertext_validity_proof_record_account.pubkey(),
+                    &lamport_destination_account,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_record_account(
+                    &range_proof_record_account.pubkey(),
+                    &lamport_destination_account,
+                    &record_account_authority.pubkey(),
+                    &[&record_account_authority],
+                )
+                .await
+                .unwrap();
+
+            result
+        }
+        ConfidentialTransferOption::ContextStateAccount => {
+            let state = token.get_account_info(source_account).await.unwrap();
+            let extension = state
+                .get_extension::<ConfidentialTransferAccount>()
+                .unwrap();
+            let account_info = BurnAccountInfo::new(extension);
+
+            let BurnProofData {
+                equality_proof_data,
+                ciphertext_validity_proof_data_with_ciphertext,
+                range_proof_data,
+            } = account_info
+                .generate_split_burn_proof_data(
+                    burn_amount,
+                    source_elgamal_keypair,
+                    aes_key,
+                    supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                )
+                .unwrap();
+
+            let burn_amount_auditor_ciphertext_lo =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo;
+            let burn_amount_auditor_ciphertext_hi =
+                ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi;
+
+            let equality_proof_context_account = Keypair::new();
+            let ciphertext_validity_proof_context_account = Keypair::new();
+            let range_proof_context_account = Keypair::new();
+            let context_account_authority = Keypair::new();
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &equality_proof_context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &equality_proof_data,
+                    false,
+                    &[&equality_proof_context_account],
+                )
+                .await
+                .unwrap();
+
+            let equality_proof_context_proof_account =
+                ProofAccount::ContextAccount(equality_proof_context_account.pubkey());
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &ciphertext_validity_proof_context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &ciphertext_validity_proof_data_with_ciphertext.proof_data,
+                    false,
+                    &[&ciphertext_validity_proof_context_account],
+                )
+                .await
+                .unwrap();
+
+            let ciphertext_validity_proof_context_proof_account =
+                ProofAccount::ContextAccount(ciphertext_validity_proof_context_account.pubkey());
+
+            token
+                .confidential_transfer_create_context_state_account(
+                    &range_proof_context_account.pubkey(),
+                    &context_account_authority.pubkey(),
+                    &range_proof_data,
+                    false,
+                    &[&range_proof_context_account],
+                )
+                .await
+                .unwrap();
+
+            let range_proof_context_proof_account =
+                ProofAccount::ContextAccount(range_proof_context_account.pubkey());
+
+            let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
+                proof_account: ciphertext_validity_proof_context_proof_account,
+                ciphertext_lo: burn_amount_auditor_ciphertext_lo,
+                ciphertext_hi: burn_amount_auditor_ciphertext_hi,
+            };
+
+            let result = token
+                .confidential_transfer_burn(
+                    authority,
+                    source_account,
+                    Some(&equality_proof_context_proof_account),
+                    Some(&ciphertext_validity_proof_account_with_ciphertext),
+                    Some(&range_proof_context_proof_account),
+                    burn_amount,
+                    source_elgamal_keypair,
+                    supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey,
+                    aes_key,
+                    None,
+                    signing_keypairs,
+                )
+                .await;
+
+            let lamport_destination_account = Keypair::new().pubkey();
+            token
+                .confidential_transfer_close_context_state_account(
+                    &equality_proof_context_account.pubkey(),
+                    &lamport_destination_account,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_context_state_account(
+                    &ciphertext_validity_proof_context_account.pubkey(),
+                    &lamport_destination_account,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            token
+                .confidential_transfer_close_context_state_account(
+                    &range_proof_context_account.pubkey(),
+                    &lamport_destination_account,
+                    &context_account_authority.pubkey(),
+                    &[&context_account_authority],
+                )
+                .await
+                .unwrap();
+
+            result
+        }
+    }
+}
+
+#[tokio::test]
+async fn confidential_mint_burn() {
+    confidential_mint_burn_with_option(ConfidentialTransferOption::InstructionData).await;
+    confidential_mint_burn_with_option(ConfidentialTransferOption::RecordAccount).await;
+    confidential_mint_burn_with_option(ConfidentialTransferOption::ContextStateAccount).await;
+}
+
+async fn confidential_mint_burn_with_option(option: ConfidentialTransferOption) {
+    let confidential_transfer_authority = Keypair::new();
+    let auto_approve_new_accounts = true;
+    let auditor_elgamal_keypair = ElGamalKeypair::new_rand();
+    let auditor_elgamal_pubkey = (*auditor_elgamal_keypair.pubkey()).into();
+
+    let supply_elgamal_keypair = ElGamalKeypair::new_rand();
+    let supply_elgamal_pubkey = (*supply_elgamal_keypair.pubkey()).into();
+    let supply_aes_key = AeKey::new_rand();
+    let decryptable_supply = supply_aes_key.encrypt(0).into();
+
+    let mut context = TestContext::new().await;
+    context
+        .init_token_with_mint(vec![
+            ExtensionInitializationParams::ConfidentialTransferMint {
+                authority: Some(confidential_transfer_authority.pubkey()),
+                auto_approve_new_accounts,
+                auditor_elgamal_pubkey: Some(auditor_elgamal_pubkey),
+            },
+            ExtensionInitializationParams::ConfidentialMintBurn {
+                supply_elgamal_pubkey,
+                decryptable_supply,
+            },
+        ])
+        .await
+        .unwrap();
+
+    let TokenContext {
+        token,
+        mint_authority,
+        alice,
+        ..
+    } = context.token_context.unwrap();
+
+    let alice_meta = ConfidentialTokenAccountMeta::new(&token, &alice).await;
+    let mint_amount = 120;
+
+    mint_with_option(
+        &token,
+        &mint_authority.pubkey(),
+        &alice_meta.token_account,
+        mint_amount,
+        &supply_elgamal_keypair,
+        alice_meta.elgamal_keypair.pubkey(),
+        Some(auditor_elgamal_keypair.pubkey()),
+        &supply_aes_key,
+        &[&mint_authority],
+        option,
+    )
+    .await
+    .unwrap();
+
+    let state = token
+        .get_account_info(&alice_meta.token_account)
+        .await
+        .unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
+
+    assert_eq!(
+        alice_meta
+            .elgamal_keypair
+            .secret()
+            .decrypt_u32(&extension.pending_balance_lo.try_into().unwrap())
+            .unwrap(),
+        mint_amount
+    );
+    assert_eq!(
+        alice_meta
+            .elgamal_keypair
+            .secret()
+            .decrypt_u32(&extension.pending_balance_hi.try_into().unwrap())
+            .unwrap(),
+        0
+    );
+
+    token
+        .confidential_transfer_apply_pending_balance(
+            &alice_meta.token_account,
+            &alice.pubkey(),
+            None,
+            alice_meta.elgamal_keypair.secret(),
+            &alice_meta.aes_key,
+            &[&alice],
+        )
+        .await
+        .unwrap();
+
+    burn_with_option(
+        &token,
+        &alice.pubkey(),
+        &alice_meta.token_account,
+        mint_amount,
+        &alice_meta.elgamal_keypair,
+        supply_elgamal_keypair.pubkey(),
+        Some(auditor_elgamal_keypair.pubkey()),
+        &alice_meta.aes_key,
+        &[&alice],
+        option,
+    )
+    .await
+    .unwrap();
+
+    let state = token
+        .get_account_info(&alice_meta.token_account)
+        .await
+        .unwrap();
+    let extension = state
+        .get_extension::<ConfidentialTransferAccount>()
+        .unwrap();
+
+    assert_eq!(
+        alice_meta
+            .elgamal_keypair
+            .secret()
+            .decrypt_u32(&extension.pending_balance_lo.try_into().unwrap())
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        alice_meta
+            .elgamal_keypair
+            .secret()
+            .decrypt_u32(&extension.pending_balance_hi.try_into().unwrap())
+            .unwrap(),
+        0
+    );
+}

--- a/program/src/extension/confidential_mint_burn/account_info.rs
+++ b/program/src/extension/confidential_mint_burn/account_info.rs
@@ -87,20 +87,19 @@ impl SupplyAccountInfo {
     pub fn generate_rotate_supply_elgamal_pubkey_proof(
         &self,
         current_supply_elgamal_keypair: &ElGamalKeypair,
-        new_supply_elgamal_keypair: &ElGamalKeypair,
+        new_supply_elgamal_pubkey: &ElGamalPubkey,
         aes_key: &AeKey,
     ) -> Result<CiphertextCiphertextEqualityProofData, TokenError> {
         let current_supply =
             self.decrypted_current_supply(aes_key, current_supply_elgamal_keypair)?;
 
         let new_supply_opening = PedersenOpening::new_rand();
-        let new_supply_ciphertext = new_supply_elgamal_keypair
-            .pubkey()
-            .encrypt_with(current_supply, &new_supply_opening);
+        let new_supply_ciphertext =
+            new_supply_elgamal_pubkey.encrypt_with(current_supply, &new_supply_opening);
 
         CiphertextCiphertextEqualityProofData::new(
             current_supply_elgamal_keypair,
-            new_supply_elgamal_keypair.pubkey(),
+            new_supply_elgamal_pubkey,
             &self
                 .current_supply
                 .try_into()
@@ -117,8 +116,8 @@ impl SupplyAccountInfo {
     pub fn generate_split_mint_proof_data(
         &self,
         mint_amount: u64,
-        current_supply: u64,
         supply_elgamal_keypair: &ElGamalKeypair,
+        aes_key: &AeKey,
         destination_elgamal_pubkey: &ElGamalPubkey,
         auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
     ) -> Result<MintProofData, TokenError> {
@@ -126,6 +125,8 @@ impl SupplyAccountInfo {
             .current_supply
             .try_into()
             .map_err(|_| TokenError::MalformedCiphertext)?;
+
+        let current_supply = self.decrypted_current_supply(aes_key, supply_elgamal_keypair)?;
 
         mint_split_proof_data(
             &current_supply_ciphertext,
@@ -204,5 +205,22 @@ impl BurnAccountInfo {
             supply_elgamal_pubkey,
         )
         .map_err(|e| -> TokenError { e.into() })
+    }
+
+    /// Compute the new decryptable supply.
+    pub fn new_decryptable_balance(
+        &self,
+        burn_amount: u64,
+        aes_key: &AeKey,
+    ) -> Result<AeCiphertext, TokenError> {
+        let current_available_balance = AeCiphertext::try_from(self.decryptable_available_balance)
+            .map_err(|_| TokenError::MalformedCiphertext)?
+            .decrypt(aes_key)
+            .ok_or(TokenError::MalformedCiphertext)?;
+        let new_decryptable_balance = current_available_balance
+            .checked_sub(burn_amount)
+            .ok_or(TokenError::Overflow)?;
+
+        Ok(aes_key.encrypt(new_decryptable_balance))
     }
 }


### PR DESCRIPTION
#### Problem
There is no support for the confidential mint burn extension in the rust-legacy client.

#### Summary of Changes
Added support for the confidential mint burn in the rust-legacy client:
[329676c](https://github.com/solana-program/token-2022/pull/168/commits/329676cfe125b70bae4015f4236a465ec842e8c2): Made a couple of relatively small changes in the account info interface:
- When generating the proof needed to rotate ElGamal public key, the new ElGamal keypair is not actually needed for the proof generation. So I fixed this.
- When generating the proof needed for confidential mint, the proof constructor takes in the current supply amount. I updated this so that it takes in a aes key instead, which can be used to decrypt the current supply. This interface seemed more natural and simpler by the consumers of this function.
- I added the `new_decryptable_balance` to simplify the rust client a bit.

[d5a9575](https://github.com/solana-program/token-2022/pull/168/commits/d5a95753034ac7f7930dd183be301775625da403): Added support for the confidential mint and burn in the rust client. I don't think there is anything specifically notable here other than the fact that it is verbose as always to account for all the different variations of how proofs can be provided.

[3c9a62b](https://github.com/solana-program/token-2022/pull/168/commits/3c9a62b30aa061c73ec43209938ac07fc74a8dbf): Added tests rust-client. Nothing notable here either. The logic is in-line with the tests for the confidential transfer and confidential fee extensions.

There is an interface change, so the semver check does seem to complain. Other than that, the rest of the CI checks seem to pass.