### PR TITLE
[program] Remove unnecessary constants in the confidential mint burn extension

### DIFF
--- a/program/src/extension/confidential_mint_burn/mod.rs
+++ b/program/src/extension/confidential_mint_burn/mod.rs
@@ -7,14 +7,6 @@ use {
     },
 };
 
-/// Maximum bit length of any mint or burn amount
-///
-/// Any mint or burn amount must be less than `2^48`
-pub const MAXIMUM_DEPOSIT_TRANSFER_AMOUNT: u64 = (u16::MAX as u64) + (1 << 16) * (u32::MAX as u64);
-
-/// Bit length of the low bits of pending balance plaintext
-pub const PENDING_BALANCE_LO_BIT_LENGTH: u32 = 16;
-
 /// Confidential Mint-Burn Extension instructions
 pub mod instruction;
 


### PR DESCRIPTION
#### Problem
Currently, constants `MAXIMUM_DEPOSIT_TRANSFER_AMOUNT` and `PENDING_BALANCE_LO_BIT_LENGTH` exists in the confidential mint burn extension, but these constants are not used. They are also duplicates of the constants that exist for the confidential transfer extension. 

They are relic from a sequence of initial attempts at creating the confidential mint burn. 

#### Summary of Changes
Remove the constants.

Fixes https://github.com/solana-program/token-2022/issues/131.