### PR TITLE
[program] Re-order confidential mint burn ciphertexts to dest/src, supply, then auditor

### DIFF
--- a/clients/rust-legacy/tests/confidential_mint_burn.rs
+++ b/clients/rust-legacy/tests/confidential_mint_burn.rs
@@ -1112,7 +1112,7 @@ async fn confidential_mint_burn_with_option(option: ConfidentialTransferOption) 
             .decrypt_u32(&extension.confidential_supply.try_into().unwrap())
             .unwrap(),
         mint_amount
-    ); // this test fails due to wrong supply ciphertexts being added
+    );
     assert_eq!(
         supply_aes_key
             .decrypt(&extension.decryptable_supply.try_into().unwrap())
@@ -1182,7 +1182,7 @@ async fn confidential_mint_burn_with_option(option: ConfidentialTransferOption) 
             .decrypt_u32(&extension.confidential_supply.try_into().unwrap())
             .unwrap(),
         0
-    ); // this test fails due to wrong supply ciphertexts being subtracted
+    );
     assert_eq!(
         supply_aes_key
             .decrypt(&extension.decryptable_supply.try_into().unwrap())

--- a/confidential-transfer/proof-extraction/src/burn.rs
+++ b/confidential-transfer/proof-extraction/src/burn.rs
@@ -12,8 +12,8 @@ use {
 /// The public keys associated with a confidential burn
 pub struct BurnPubkeys {
     pub source: PodElGamalPubkey,
-    pub auditor: PodElGamalPubkey,
     pub supply: PodElGamalPubkey,
+    pub auditor: PodElGamalPubkey,
 }
 
 /// The proof context information needed to process a confidential burn
@@ -51,8 +51,8 @@ impl BurnProofContext {
         // `BurnProofContext`.
         let BatchedGroupedCiphertext3HandlesValidityProofContext {
             first_pubkey: source_elgamal_pubkey_from_validity_proof,
-            second_pubkey: auditor_elgamal_pubkey,
-            third_pubkey: supply_elgamal_pubkey,
+            second_pubkey: supply_elgamal_pubkey,
+            third_pubkey: auditor_elgamal_pubkey,
             grouped_ciphertext_lo: burn_amount_ciphertext_lo,
             grouped_ciphertext_hi: burn_amount_ciphertext_hi,
         } = ciphertext_validity_proof_context;
@@ -116,8 +116,8 @@ impl BurnProofContext {
 
         let burn_pubkeys = BurnPubkeys {
             source: *source_elgamal_pubkey_from_equality_proof,
-            auditor: *auditor_elgamal_pubkey,
             supply: *supply_elgamal_pubkey,
+            auditor: *auditor_elgamal_pubkey,
         };
 
         Ok(BurnProofContext {

--- a/confidential-transfer/proof-extraction/src/mint.rs
+++ b/confidential-transfer/proof-extraction/src/mint.rs
@@ -12,8 +12,8 @@ use {
 /// The public keys associated with a confidential mint
 pub struct MintPubkeys {
     pub destination: PodElGamalPubkey,
-    pub auditor: PodElGamalPubkey,
     pub supply: PodElGamalPubkey,
+    pub auditor: PodElGamalPubkey,
 }
 
 /// The proof context information needed to process a confidential mint
@@ -49,8 +49,8 @@ impl MintProofContext {
         // fields should be returned as part of `MintProofContext`.
         let BatchedGroupedCiphertext3HandlesValidityProofContext {
             first_pubkey: destination_elgamal_pubkey,
-            second_pubkey: auditor_elgamal_pubkey,
-            third_pubkey: supply_elgamal_pubkey_from_ciphertext_validity_proof,
+            second_pubkey: supply_elgamal_pubkey_from_ciphertext_validity_proof,
+            third_pubkey: auditor_elgamal_pubkey,
             grouped_ciphertext_lo: mint_amount_ciphertext_lo,
             grouped_ciphertext_hi: mint_amount_ciphertext_hi,
         } = ciphertext_validity_proof_context;
@@ -116,8 +116,8 @@ impl MintProofContext {
 
         let mint_pubkeys = MintPubkeys {
             destination: *destination_elgamal_pubkey,
-            auditor: *auditor_elgamal_pubkey,
             supply: *supply_elgamal_pubkey_from_equality_proof,
+            auditor: *auditor_elgamal_pubkey,
         };
 
         Ok(MintProofContext {

--- a/confidential-transfer/proof-generation/src/burn.rs
+++ b/confidential-transfer/proof-generation/src/burn.rs
@@ -36,8 +36,8 @@ pub fn burn_split_proof_data(
     burn_amount: u64,
     source_elgamal_keypair: &ElGamalKeypair,
     source_aes_key: &AeKey,
-    auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
     supply_elgamal_pubkey: &ElGamalPubkey,
+    auditor_elgamal_pubkey: Option<&ElGamalPubkey>,
 ) -> Result<BurnProofData, TokenProofGenerationError> {
     let default_auditor_pubkey = ElGamalPubkey::default();
     let auditor_elgamal_pubkey = auditor_elgamal_pubkey.unwrap_or(&default_auditor_pubkey);
@@ -50,15 +50,15 @@ pub fn burn_split_proof_data(
     let (burn_amount_ciphertext_lo, burn_amount_opening_lo) = BurnAmountCiphertext::new(
         burn_amount_lo,
         source_elgamal_keypair.pubkey(),
-        auditor_elgamal_pubkey,
         supply_elgamal_pubkey,
+        auditor_elgamal_pubkey,
     );
 
     let (burn_amount_ciphertext_hi, burn_amount_opening_hi) = BurnAmountCiphertext::new(
         burn_amount_hi,
         source_elgamal_keypair.pubkey(),
-        auditor_elgamal_pubkey,
         supply_elgamal_pubkey,
+        auditor_elgamal_pubkey,
     );
 
     // decrypt the current available balance at the source
@@ -106,8 +106,8 @@ pub fn burn_split_proof_data(
     // generate ciphertext validity data
     let ciphertext_validity_proof_data = BatchedGroupedCiphertext3HandlesValidityProofData::new(
         source_elgamal_keypair.pubkey(),
-        auditor_elgamal_pubkey,
         supply_elgamal_pubkey,
+        auditor_elgamal_pubkey,
         &burn_amount_ciphertext_lo.0,
         &burn_amount_ciphertext_hi.0,
         burn_amount_lo,

--- a/confidential-transfer/proof-generation/src/encryption.rs
+++ b/confidential-transfer/proof-generation/src/encryption.rs
@@ -95,12 +95,12 @@ impl BurnAmountCiphertext {
     pub fn new(
         amount: u64,
         source_pubkey: &ElGamalPubkey,
-        auditor_pubkey: &ElGamalPubkey,
         supply_pubkey: &ElGamalPubkey,
+        auditor_pubkey: &ElGamalPubkey,
     ) -> (Self, PedersenOpening) {
         let opening = PedersenOpening::new_rand();
         let grouped_ciphertext = GroupedElGamal::<3>::encrypt_with(
-            [source_pubkey, auditor_pubkey, supply_pubkey],
+            [source_pubkey, supply_pubkey, auditor_pubkey],
             amount,
             &opening,
         );
@@ -121,12 +121,12 @@ impl MintAmountCiphertext {
     pub fn new(
         amount: u64,
         source_pubkey: &ElGamalPubkey,
-        auditor_pubkey: &ElGamalPubkey,
         supply_pubkey: &ElGamalPubkey,
+        auditor_pubkey: &ElGamalPubkey,
     ) -> (Self, PedersenOpening) {
         let opening = PedersenOpening::new_rand();
         let grouped_ciphertext = GroupedElGamal::<3>::encrypt_with(
-            [source_pubkey, auditor_pubkey, supply_pubkey],
+            [source_pubkey, supply_pubkey, auditor_pubkey],
             amount,
             &opening,
         );

--- a/confidential-transfer/proof-generation/src/mint.rs
+++ b/confidential-transfer/proof-generation/src/mint.rs
@@ -49,25 +49,25 @@ pub fn mint_split_proof_data(
     let (mint_amount_grouped_ciphertext_lo, mint_amount_opening_lo) = MintAmountCiphertext::new(
         mint_amount_lo,
         destination_elgamal_pubkey,
-        auditor_elgamal_pubkey,
         supply_elgamal_keypair.pubkey(),
+        auditor_elgamal_pubkey,
     );
 
     let (mint_amount_grouped_ciphertext_hi, mint_amount_opening_hi) = MintAmountCiphertext::new(
         mint_amount_hi,
         destination_elgamal_pubkey,
-        auditor_elgamal_pubkey,
         supply_elgamal_keypair.pubkey(),
+        auditor_elgamal_pubkey,
     );
 
     // compute the new supply ciphertext
     let mint_amount_ciphertext_supply_lo = mint_amount_grouped_ciphertext_lo
         .0
-        .to_elgamal_ciphertext(2)
+        .to_elgamal_ciphertext(1)
         .unwrap();
     let mint_amount_ciphertext_supply_hi = mint_amount_grouped_ciphertext_hi
         .0
-        .to_elgamal_ciphertext(2)
+        .to_elgamal_ciphertext(1)
         .unwrap();
 
     #[allow(clippy::arithmetic_side_effects)]
@@ -99,8 +99,8 @@ pub fn mint_split_proof_data(
     // generate ciphertext validity proof data
     let ciphertext_validity_proof_data = BatchedGroupedCiphertext3HandlesValidityProofData::new(
         destination_elgamal_pubkey,
-        auditor_elgamal_pubkey,
         supply_elgamal_keypair.pubkey(),
+        auditor_elgamal_pubkey,
         &mint_amount_grouped_ciphertext_lo.0,
         &mint_amount_grouped_ciphertext_hi.0,
         mint_amount_lo,

--- a/confidential-transfer/proof-tests/tests/proof_test.rs
+++ b/confidential-transfer/proof-tests/tests/proof_test.rs
@@ -288,8 +288,8 @@ fn test_burn_validity(spendable_balance: u64, burn_amount: u64) {
         burn_amount,
         &source_keypair,
         &aes_key,
-        Some(auditor_pubkey),
         supply_pubkey,
+        Some(auditor_pubkey),
     )
     .unwrap();
 

--- a/program/src/extension/confidential_mint_burn/account_info.rs
+++ b/program/src/extension/confidential_mint_burn/account_info.rs
@@ -201,8 +201,8 @@ impl BurnAccountInfo {
             burn_amount,
             source_elgamal_keypair,
             aes_key,
-            auditor_elgamal_pubkey,
             supply_elgamal_pubkey,
+            auditor_elgamal_pubkey,
         )
         .map_err(|e| -> TokenError { e.into() })
     }

--- a/program/src/extension/confidential_mint_burn/processor.rs
+++ b/program/src/extension/confidential_mint_burn/processor.rs
@@ -260,11 +260,11 @@ fn process_confidential_mint(
         &current_supply,
         &proof_context
             .mint_amount_ciphertext_lo
-            .try_extract_ciphertext(2)
+            .try_extract_ciphertext(1)
             .map_err(|_| ProgramError::InvalidAccountData)?,
         &proof_context
             .mint_amount_ciphertext_hi
-            .try_extract_ciphertext(2)
+            .try_extract_ciphertext(1)
             .map_err(|_| ProgramError::InvalidAccountData)?,
     )
     .ok_or(TokenError::CiphertextArithmeticFailed)?;
@@ -395,11 +395,11 @@ fn process_confidential_burn(
         &current_supply,
         &proof_context
             .burn_amount_ciphertext_lo
-            .try_extract_ciphertext(2)
+            .try_extract_ciphertext(1)
             .map_err(|_| ProgramError::InvalidAccountData)?,
         &proof_context
             .burn_amount_ciphertext_hi
-            .try_extract_ciphertext(2)
+            .try_extract_ciphertext(1)
             .map_err(|_| ProgramError::InvalidAccountData)?,
     )
     .ok_or(TokenError::CiphertextArithmeticFailed)?;


### PR DESCRIPTION
#### Problem
Auditor ciphertexts for the confidential mint and burn amounts were added to instruction data in https://github.com/solana-labs/solana-program-library/pull/7480. In the processor logic for confidential mint and burn, the auditor ciphertext that is included in the instruction data should be checked whether it corresponds to the auditor ciphertext in the proof data.

Currently, the wrong component of the grouped ciphertext is checked. A grouped ElGamal ciphertext for the confidential mint and confidential burn amounts have the second component correspond to the "auditor" component. However, the third component that corresponds to the confidential "supply" is checked for consistency instead.

#### Summary of Changes
A simple fix is to just update the processor logic to check the consistency of the second component of the ciphertexts. However, as suggested in https://github.com/solana-program/token-2022/issues/128, I swapped the order of the auditor and supply ciphertext components in the proof data as suggested in https://github.com/solana-program/token-2022/issues/128. This way, the auditor ciphertext component is always third in grouped ciphertexts in confidential transfer, confidential transfer with fee, and confidential mint burn extensions, which could prevent confusion.

Fixes https://github.com/solana-program/token-2022/issues/128.