### PR TITLE
[program] Check that new supply in the mint and proof data are consistent

### DIFF
--- a/program/src/extension/confidential_mint_burn/processor.rs
+++ b/program/src/extension/confidential_mint_burn/processor.rs
@@ -268,6 +268,13 @@ fn process_confidential_mint(
             .map_err(|_| ProgramError::InvalidAccountData)?,
     )
     .ok_or(TokenError::CiphertextArithmeticFailed)?;
+
+    // Check that the computed supply ciphertext is consistent with what was
+    // actually used to generate the zkp on the client side.
+    if mint_burn_extension.confidential_supply != proof_context.new_supply_ciphertext {
+        return Err(TokenError::ConfidentialTransferBalanceMismatch.into());
+    }
+
     mint_burn_extension.decryptable_supply = data.new_decryptable_supply;
 
     Ok(())


### PR DESCRIPTION
#### Problem
Currently there is a check missing in the confidential mint processor logic (https://github.com/solana-program/token-2022/issues/127).

A confidential mint proof is generated as follows:
1. The client fetches the current supply and computes the updated supply if a mint were to be processed successfully
2. A zkp is generated with respect to the updated supply
3. Finally, on the program side, the processor computes the updated supply and should check that this updated supply that it computed is actually consistent with what was included in the zkp.

The check in step 3 is currently absent in the confidential mint processor logic.

#### Summary of Changes
I added the check.

Fixes https://github.com/solana-program/token-2022/issues/127.