### PR TITLE
[program] Add pending burn field to `ConfidentialMintBurn`

### DIFF
--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -3563,6 +3563,27 @@ where
         .await
     }
 
+    /// Apply pending burn amount to the confidential supply amount
+    pub async fn confidential_transfer_apply_pending_burn<S: Signers>(
+        &self,
+        authority: &Pubkey,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        self.process_ixs(
+            &[confidential_mint_burn::instruction::apply_pending_burn(
+                &self.program_id,
+                &self.pubkey,
+                authority,
+                &multisig_signers,
+            )?],
+            signing_keypairs,
+        )
+        .await
+    }
+
     // Creates `ProofLocation` from proof data and `ProofAccount`. If both
     // `proof_data` and `proof_account` are `None`, then the result is `None`.
     fn confidential_transfer_create_proof_location<'a, ZK: ZkProofData<U>, U: Pod>(

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -269,6 +269,9 @@ pub enum TokenError {
     /// Transferring, minting, and burning is paused on this mint
     #[error("Transferring, minting, and burning is paused on this mint")]
     MintPaused,
+    /// Pending supply is not zero
+    #[error("Key rotation attempted while pending balance is not zero")]
+    PendingBalanceNonZero,
 }
 impl From<TokenError> for ProgramError {
     fn from(e: TokenError) -> Self {
@@ -464,6 +467,9 @@ impl PrintProgramError for TokenError {
             }
             TokenError::MintPaused => {
                 msg!("Transferring, minting, and burning is paused on this mint")
+            }
+            TokenError::PendingBalanceNonZero => {
+                msg!("Key rotation attempted while pending balance is not zero")
             }
         }
     }

--- a/program/src/extension/confidential_mint_burn/mod.rs
+++ b/program/src/extension/confidential_mint_burn/mod.rs
@@ -30,6 +30,8 @@ pub struct ConfidentialMintBurn {
     pub decryptable_supply: PodAeCiphertext,
     /// The ElGamal pubkey used to encrypt the confidential supply
     pub supply_elgamal_pubkey: PodElGamalPubkey,
+    /// The amount of burn amounts not yet aggregated into the confidential supply
+    pub pending_burn: PodElGamalCiphertext,
 }
 
 impl Extension for ConfidentialMintBurn {

--- a/program/src/extension/confidential_mint_burn/processor.rs
+++ b/program/src/extension/confidential_mint_burn/processor.rs
@@ -30,7 +30,10 @@ use {
         pubkey::Pubkey,
     },
     solana_zk_sdk::{
-        encryption::pod::{auth_encryption::PodAeCiphertext, elgamal::PodElGamalPubkey},
+        encryption::pod::{
+            auth_encryption::PodAeCiphertext,
+            elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
+        },
         zk_elgamal_proof_program::proof_data::{
             CiphertextCiphertextEqualityProofContext, CiphertextCiphertextEqualityProofData,
         },
@@ -91,6 +94,9 @@ fn process_rotate_supply_elgamal_pubkey(
     }
     if mint_burn_extension.confidential_supply != proof_context.first_ciphertext {
         return Err(ProgramError::InvalidInstructionData);
+    }
+    if mint_burn_extension.pending_burn != PodElGamalCiphertext::default() {
+        return Err(TokenError::PendingBalanceNonZero.into());
     }
 
     let authority_info = next_account_info(account_info_iter)?;
@@ -397,9 +403,9 @@ fn process_confidential_burn(
     if mint_burn_extension.supply_elgamal_pubkey != proof_context.burn_pubkeys.supply {
         return Err(ProgramError::InvalidInstructionData);
     }
-    let current_supply = mint_burn_extension.confidential_supply;
-    mint_burn_extension.confidential_supply = ciphertext_arithmetic::subtract_with_lo_hi(
-        &current_supply,
+    let pending_burn = mint_burn_extension.pending_burn;
+    mint_burn_extension.pending_burn = ciphertext_arithmetic::add_with_lo_hi(
+        &pending_burn,
         &proof_context
             .burn_amount_ciphertext_lo
             .try_extract_ciphertext(1)
@@ -410,6 +416,40 @@ fn process_confidential_burn(
             .map_err(|_| ProgramError::InvalidAccountData)?,
     )
     .ok_or(TokenError::CiphertextArithmeticFailed)?;
+
+    Ok(())
+}
+
+/// Processes a [`ApplyPendingBurn`] instruction.
+fn process_apply_pending_burn(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let mint_info = next_account_info(account_info_iter)?;
+
+    check_program_account(mint_info.owner)?;
+    let mint_data = &mut mint_info.data.borrow_mut();
+    let mut mint = PodStateWithExtensionsMut::<PodMint>::unpack(mint_data)?;
+    let mint_authority = mint.base.mint_authority;
+    let mint_burn_extension = mint.get_extension_mut::<ConfidentialMintBurn>()?;
+
+    let authority_info = next_account_info(account_info_iter)?;
+    let authority_info_data_len = authority_info.data_len();
+    let authority = mint_authority.ok_or(TokenError::NoAuthorityExists)?;
+
+    Processor::validate_owner(
+        program_id,
+        &authority,
+        authority_info,
+        authority_info_data_len,
+        account_info_iter.as_slice(),
+    )?;
+
+    let current_supply = mint_burn_extension.confidential_supply;
+    let pending_burn = mint_burn_extension.pending_burn;
+    mint_burn_extension.confidential_supply =
+        ciphertext_arithmetic::subtract(&current_supply, &pending_burn)
+            .ok_or(TokenError::CiphertextArithmeticFailed)?;
+
+    mint_burn_extension.pending_burn = PodElGamalCiphertext::default();
 
     Ok(())
 }
@@ -447,6 +487,10 @@ pub(crate) fn process_instruction(
             msg!("ConfidentialMintBurnInstruction::ConfidentialBurn");
             let data = decode_instruction_data::<BurnInstructionData>(input)?;
             process_confidential_burn(program_id, accounts, data)
+        }
+        ConfidentialMintBurnInstruction::ApplyPendingBurn => {
+            msg!("ConfidentialMintBurnInstruction::ApplyPendingBurn");
+            process_apply_pending_burn(program_id, accounts)
         }
     }
 }


### PR DESCRIPTION
#### Problem
The confidential mint instruction requires zkp that is generated with respect to the current confidential supply in the mint. However, since a confidential mint instruction, which is instigated by individual account owners, updates the confidential supply, this could lead to a DoS attack where a malicious actor constantly burns small amounts tokens to prevent mint.

More information can be found in https://github.com/solana-program/token-2022/issues/126.

#### Summary of Changes
I added a `pending_burn` field to `ConfidentialMintBurn` extension. Whenever a confidential burn instruction is processed, the burn amount is added to the `pending_burn` field in the mint. Then on an instruction `ApplyPendingBurn`, this field is subtracted from the confidential supply.

We have the following changes to the program.

State:
- `pending_burn` field is added to `ConfidentialMintBurn`

Instruction:
- A new `ApplyPendingBurn` instruction is added, which acts pretty much like `ApplyPendingBalance` of the confidential transfer extension. When applied, the `pending_supply` is subtracted out from the `confidential_supply`.

Processor:
- When rotating the keys, we enforce that the `pending_burn` field is always zero. The `ApplyPendingBurn` can be applied to flush out the `pending_burn` field. We do note that key rotation is still susceptible to DoS, but this is inherent and I think this is less of an issue given that key rotation happens less frequently than mints.
- Updated the burn logic so that the burn amount is accumulated into the pending burn instead of subtracted into the confidential supply.

The client side update is very simple. I updated the tests to check that (1) the key rotation fails when `pending_burn` is not zero and (2) the pending burn and confidential supply is updated correctly on confidential mints.

Fixes https://github.com/solana-program/token-2022/issues/126.