### PR TITLE
[confidential-transfer] Remove unnecessary range proof check and add clarifying comments

### DIFF
--- a/confidential-transfer/proof-extraction/src/burn.rs
+++ b/confidential-transfer/proof-extraction/src/burn.rs
@@ -85,6 +85,9 @@ impl BurnProofContext {
             burn_amount_commitment_hi,
         ];
 
+        // range proof context always contains 8 commitments and therefore,
+        // this check will verify equality of all expected commitments
+        // (`zip` will not be short-circuited)
         if !range_proof_commitments
             .iter()
             .zip(expected_commitments.iter())
@@ -106,6 +109,9 @@ impl BurnProofContext {
         ]
         .iter();
 
+        // range proof context always contains 8 bit lengths and therefore,
+        // this check will verify equality of all expected bit lengths
+        // (`zip` will not be short-circuited)
         if !range_proof_bit_lengths
             .iter()
             .zip(expected_bit_lengths)

--- a/confidential-transfer/proof-extraction/src/mint.rs
+++ b/confidential-transfer/proof-extraction/src/mint.rs
@@ -85,6 +85,9 @@ impl MintProofContext {
             mint_amount_commitment_hi,
         ];
 
+        // range proof context always contains 8 commitments and therefore,
+        // this check will verify equality of all expected commitments
+        // (`zip` will not be short-circuited)
         if !range_proof_commitments
             .iter()
             .zip(expected_commitments.iter())
@@ -106,6 +109,9 @@ impl MintProofContext {
         ]
         .iter();
 
+        // range proof context always contains 8 bit lengths and therefore,
+        // this check will verify equality of all expected bit lengths
+        // (`zip` will not be short-circuited)
         if !range_proof_bit_lengths
             .iter()
             .zip(expected_bit_lengths)

--- a/confidential-transfer/proof-extraction/src/transfer.rs
+++ b/confidential-transfer/proof-extraction/src/transfer.rs
@@ -90,6 +90,9 @@ impl TransferProofContext {
             transfer_amount_commitment_hi,
         ];
 
+        // range proof context always contains 8 commitments and therefore,
+        // this check will verify equality of all expected commitments
+        // (`zip` will not be short-circuited)
         if !range_proof_commitments
             .iter()
             .zip(expected_commitments.iter())
@@ -111,6 +114,9 @@ impl TransferProofContext {
         ]
         .iter();
 
+        // range proof context always contains 8 bit lengths and therefore,
+        // this check will verify equality of all expected bit lengths
+        // (`zip` will not be short-circuited)
         if !range_proof_bit_lengths
             .iter()
             .zip(expected_bit_lengths)

--- a/confidential-transfer/proof-extraction/src/transfer_with_fee.rs
+++ b/confidential-transfer/proof-extraction/src/transfer_with_fee.rs
@@ -176,6 +176,9 @@ impl TransferWithFeeProofContext {
             bytes_of(&fee_commitment_hi),
         ];
 
+        // range proof context always contains 8 commitments and therefore,
+        // this check will verify equality of all expected commitments
+        // (`zip` will not be short-circuited)
         if !range_proof_commitments
             .iter()
             .zip(expected_commitments.into_iter())
@@ -198,6 +201,9 @@ impl TransferWithFeeProofContext {
         ]
         .iter();
 
+        // range proof context always contains 8 bit lengths and therefore,
+        // this check will verify equality of all expected bit lengths
+        // (`zip` will not be short-circuited)
         if !range_proof_bit_lengths
             .iter()
             .zip(expected_bit_lengths)

--- a/confidential-transfer/proof-extraction/src/withdraw.rs
+++ b/confidential-transfer/proof-extraction/src/withdraw.rs
@@ -31,15 +31,15 @@ impl WithdrawProofContext {
             bit_lengths: range_proof_bit_lengths,
         } = range_proof_context;
 
-        if range_proof_commitments.is_empty()
-            || range_proof_commitments[0] != *remaining_balance_commitment
-        {
+        // range proof context always contains 8 commitments and therefore,
+        // we can assume that `range_proof_commitments` is not empty
+        if range_proof_commitments[0] != *remaining_balance_commitment {
             return Err(TokenProofExtractionError::PedersenCommitmentMismatch);
         }
 
-        if range_proof_bit_lengths.is_empty()
-            || range_proof_bit_lengths[0] != REMAINING_BALANCE_BIT_LENGTH
-        {
+        // range proof context always contains 8 bit lengths and therefore,
+        // we can assume that `range_proof_bit_lengths` is not empty
+        if range_proof_bit_lengths[0] != REMAINING_BALANCE_BIT_LENGTH {
             return Err(TokenProofExtractionError::RangeProofLengthMismatch);
         }
 


### PR DESCRIPTION
#### Problem
In the proof extraction logic, `.zip` is used to pair the expected commitments and bit lengths with what were provided in the `BatchedRangeProofContext`. This could be confusing to follow without the background knowledge on `BatchedRangeProofContext`, which always holds exactly 8 Pedersen commitments and 8 bit lengths for which the proof is generated for. (https://github.com/solana-program/token-2022/issues/133)

#### Summary of Changes
Remove redundant checks and add clarifying comments about `.zip`.

Fixes https://github.com/solana-program/token-2022/issues/133.