### PR TITLE
Added support to PubkeyData ExtraAccountMeta in the JS client

### DIFF
--- a/clients/js-legacy/src/errors.ts
+++ b/clients/js-legacy/src/errors.ts
@@ -84,3 +84,13 @@ export class TokenTransferHookInvalidSeed extends TokenError {
 export class TokenTransferHookAccountDataNotFound extends TokenError {
     name = 'TokenTransferHookAccountDataNotFound';
 }
+
+/** Thrown if pubkey data extra accounts config is invalid */
+export class TokenTransferHookInvalidPubkeyData extends TokenError {
+    name = 'TokenTransferHookInvalidPubkeyData';
+}
+
+/** Thrown if pubkey data source is too small for a pubkey */
+export class TokenTransferHookPubkeyDataTooSmall extends TokenError {
+    name = 'TokenTransferHookPubkeyDataTooSmall';
+}

--- a/clients/js-legacy/src/extensions/transferHook/index.ts
+++ b/clients/js-legacy/src/extensions/transferHook/index.ts
@@ -2,3 +2,4 @@ export * from './actions.js';
 export * from './instructions.js';
 export * from './seeds.js';
 export * from './state.js';
+export * from './pubkeyData.js';

--- a/clients/js-legacy/src/extensions/transferHook/pubkeyData.ts
+++ b/clients/js-legacy/src/extensions/transferHook/pubkeyData.ts
@@ -1,0 +1,49 @@
+import { PublicKey } from '@solana/web3.js';
+import type { AccountMeta, Connection } from '@solana/web3.js';
+import { TokenTransferHookAccountDataNotFound, TokenTransferHookInvalidPubkeyData, TokenTransferHookPubkeyDataTooSmall, TokenTransferHookAccountNotFound} from '../../errors.js';
+
+export async function unpackPubkeyData(
+    keyDataConfig: Uint8Array,
+    previousMetas: AccountMeta[],
+    instructionData: Buffer,
+    connection: Connection,
+): Promise<PublicKey> {
+    const [discriminator, ...rest] = keyDataConfig;
+    const remaining = new Uint8Array(rest);
+    switch (discriminator) {
+        case 1:
+            return unpackPubkeyDataFromInstructionData(remaining, instructionData);
+        case 2:
+            return await unpackPubkeyDataFromAccountData(remaining, previousMetas, connection);
+        default:
+            throw new TokenTransferHookInvalidPubkeyData();
+    }
+}
+
+function unpackPubkeyDataFromInstructionData(remaining: Uint8Array, instructionData: Buffer): PublicKey {
+    if (remaining.length < 1) {
+        throw new TokenTransferHookInvalidPubkeyData();
+    }
+    if (instructionData.length < 32) {
+        throw new TokenTransferHookPubkeyDataTooSmall();
+    }
+    return new PublicKey(instructionData.slice(remaining[0], remaining[0] + 32));
+}
+
+async function unpackPubkeyDataFromAccountData(remaining: Uint8Array, previousMetas: AccountMeta[], connection: Connection): Promise<PublicKey> {
+    if (remaining.length < 2) {
+        throw new TokenTransferHookInvalidPubkeyData();
+    }
+    const [accountIndex, dataIndex] = remaining;
+    if (previousMetas.length <= accountIndex) {
+        throw new TokenTransferHookAccountDataNotFound();
+    }
+    const accountInfo = await connection.getAccountInfo(previousMetas[accountIndex].pubkey);
+    if (accountInfo == null) {
+        throw new TokenTransferHookAccountNotFound();
+    }
+    if (accountInfo.data.length < dataIndex + 32) {
+        throw new TokenTransferHookPubkeyDataTooSmall();
+    }
+    return new PublicKey(accountInfo.data.slice(dataIndex, dataIndex + 32));
+}

--- a/clients/js-legacy/src/extensions/transferHook/state.ts
+++ b/clients/js-legacy/src/extensions/transferHook/state.ts
@@ -7,6 +7,7 @@ import { bool, publicKey, u64 } from '@solana/buffer-layout-utils';
 import type { Account } from '../../state/account.js';
 import { TokenTransferHookAccountNotFound } from '../../errors.js';
 import { unpackSeeds } from './seeds.js';
+import { unpackPubkeyData } from './pubkeyData.js';
 
 /** TransferHook as stored by the program */
 export interface TransferHook {
@@ -116,6 +117,13 @@ export async function resolveExtraAccountMeta(
     if (extraMeta.discriminator === 0) {
         return {
             pubkey: new PublicKey(extraMeta.addressConfig),
+            isSigner: extraMeta.isSigner,
+            isWritable: extraMeta.isWritable,
+        };
+    } else if (extraMeta.discriminator === 2) {
+        const pubkey = await unpackPubkeyData(extraMeta.addressConfig, previousMetas, instructionData, connection);
+        return {
+            pubkey,
             isSigner: extraMeta.isSigner,
             isWritable: extraMeta.isWritable,
         };


### PR DESCRIPTION
# Problem

Transfer-hook js client lacks support to PubkeyData [ExtraAccountMeta discriminator](https://github.com/solana-program/libraries/blob/main/tlv-account-resolution/src/account.rs#L177) and respective data.

# Summary of changes

Added parsing of PubkeyData structure with both variants: data sourced from instruction data and from account data.
Updated tests with the two scenarios.