### PR TITLE
Allow Fallback for TokenTransferHookAccountDataNotFound in SPL Token JS

### DIFF
--- a/clients/js-legacy/src/extensions/transferHook/actions.ts
+++ b/clients/js-legacy/src/extensions/transferHook/actions.ts
@@ -75,17 +75,18 @@ export async function updateTransferHook(
 /**
  * Transfer tokens from one account to another, asserting the token mint, and decimals
  *
- * @param connection     Connection to use
- * @param payer          Payer of the transaction fees
- * @param source         Source account
- * @param mint           Mint for the account
- * @param destination    Destination account
- * @param authority      Authority of the source account
- * @param amount         Number of tokens to transfer
- * @param decimals       Number of decimals in transfer amount
- * @param multiSigners   Signing accounts if `owner` is a multisig
- * @param confirmOptions Options for confirming the transaction
- * @param programId      SPL Token program account
+ * @param connection                    Connection to use
+ * @param payer                         Payer of the transaction fees
+ * @param source                        Source account
+ * @param mint                          Mint for the account
+ * @param destination                   Destination account
+ * @param authority                     Authority of the source account
+ * @param amount                        Number of tokens to transfer
+ * @param decimals                      Number of decimals in transfer amount
+ * @param multiSigners                  Signing accounts if `owner` is a multisig
+ * @param confirmOptions                Options for confirming the transaction
+ * @param programId                     SPL Token program account
+ * @param allowAccountDataFallback      Fallback to zeroed pubkey when resolveExtraAccountMeta fails with TokenTransferHookAccountDataNotFound
  *
  * @return Signature of the confirmed transaction
  */
@@ -101,6 +102,7 @@ export async function transferCheckedWithTransferHook(
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
+    allowAccountDataFallback = false,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
@@ -116,6 +118,7 @@ export async function transferCheckedWithTransferHook(
             signers,
             confirmOptions?.commitment,
             programId,
+            allowAccountDataFallback,
         ),
     );
 
@@ -125,18 +128,19 @@ export async function transferCheckedWithTransferHook(
 /**
  * Transfer tokens from one account to another, asserting the transfer fee, token mint, and decimals
  *
- * @param connection     Connection to use
- * @param payer          Payer of the transaction fees
- * @param source         Source account
- * @param mint           Mint for the account
- * @param destination    Destination account
- * @param authority      Authority of the source account
- * @param amount         Number of tokens to transfer
- * @param decimals       Number of decimals in transfer amount
- * @param fee            The calculated fee for the transfer fee extension
- * @param multiSigners   Signing accounts if `owner` is a multisig
- * @param confirmOptions Options for confirming the transaction
- * @param programId      SPL Token program account
+ * @param connection                    Connection to use
+ * @param payer                         Payer of the transaction fees
+ * @param source                        Source account
+ * @param mint                          Mint for the account
+ * @param destination                   Destination account
+ * @param authority                     Authority of the source account
+ * @param amount                        Number of tokens to transfer
+ * @param decimals                      Number of decimals in transfer amount
+ * @param fee                           The calculated fee for the transfer fee extension
+ * @param multiSigners                  Signing accounts if `owner` is a multisig
+ * @param confirmOptions                Options for confirming the transaction
+ * @param programId                     SPL Token program account
+ * @param allowAccountDataFallback      Fallback to zeroed pubkey when resolveExtraAccountMeta fails with TokenTransferHookAccountDataNotFound
  *
  * @return Signature of the confirmed transaction
  */
@@ -153,6 +157,7 @@ export async function transferCheckedWithFeeAndTransferHook(
     multiSigners: Signer[] = [],
     confirmOptions?: ConfirmOptions,
     programId = TOKEN_PROGRAM_ID,
+    allowAccountDataFallback = false,
 ): Promise<TransactionSignature> {
     const [authorityPublicKey, signers] = getSigners(authority, multiSigners);
 
@@ -169,6 +174,7 @@ export async function transferCheckedWithFeeAndTransferHook(
             signers,
             confirmOptions?.commitment,
             programId,
+            allowAccountDataFallback,
         ),
     );
 

--- a/clients/js-legacy/src/extensions/transferHook/instructions.ts
+++ b/clients/js-legacy/src/extensions/transferHook/instructions.ts
@@ -176,15 +176,16 @@ export function createExecuteInstruction(
  *
  * Note this will modify the instruction passed in.
  *
- * @param connection            Connection to use
- * @param instruction           The instruction to add accounts to
- * @param programId             Transfer hook program ID
- * @param source                The source account
- * @param mint                  The mint account
- * @param destination           The destination account
- * @param owner                 Owner of the source account
- * @param amount                The amount of tokens to transfer
- * @param commitment            Commitment to use
+ * @param connection                    Connection to use
+ * @param instruction                   The instruction to add accounts to
+ * @param programId                     Transfer hook program ID
+ * @param source                        The source account
+ * @param mint                          The mint account
+ * @param destination                   The destination account
+ * @param owner                         Owner of the source account
+ * @param amount                        The amount of tokens to transfer
+ * @param commitment                    Commitment to use
+ * @param allowAccountDataFallback      Fallback to zeroed pubkey when resolveExtraAccountMeta fails with TokenTransferHookAccountDataNotFound
  */
 export async function addExtraAccountMetasForExecute(
     connection: Connection,
@@ -196,6 +197,7 @@ export async function addExtraAccountMetasForExecute(
     owner: PublicKey,
     amount: number | bigint,
     commitment?: Commitment,
+    allowAccountDataFallback = false,
 ) {
     const validateStatePubkey = getExtraAccountMetaAddress(mint, programId);
     const validateStateAccount = await connection.getAccountInfo(validateStatePubkey, commitment);
@@ -228,6 +230,7 @@ export async function addExtraAccountMetasForExecute(
                     executeInstruction.keys,
                     executeInstruction.data,
                     executeInstruction.programId,
+                    allowAccountDataFallback,
                 ),
                 executeInstruction.keys,
             ),
@@ -245,16 +248,17 @@ export async function addExtraAccountMetasForExecute(
 /**
  * Construct an transferChecked instruction with extra accounts for transfer hook
  *
- * @param connection            Connection to use
- * @param source                Source account
- * @param mint                  Mint to update
- * @param destination           Destination account
- * @param owner                 Owner of the source account
- * @param amount                The amount of tokens to transfer
- * @param decimals              Number of decimals in transfer amount
- * @param multiSigners          The signer account(s) for a multisig
- * @param commitment            Commitment to use
- * @param programId             SPL Token program account
+ * @param connection                    Connection to use
+ * @param source                        Source account
+ * @param mint                          Mint to update
+ * @param destination                   Destination account
+ * @param owner                         Owner of the source account
+ * @param amount                        The amount of tokens to transfer
+ * @param decimals                      Number of decimals in transfer amount
+ * @param multiSigners                  The signer account(s) for a multisig
+ * @param commitment                    Commitment to use
+ * @param programId                     SPL Token program account
+ * @param allowAccountDataFallback      Fallback to zeroed pubkey when resolveExtraAccountMeta fails with TokenTransferHookAccountDataNotFound
  *
  * @return Instruction to add to a transaction
  */
@@ -269,6 +273,7 @@ export async function createTransferCheckedWithTransferHookInstruction(
     multiSigners: (Signer | PublicKey)[] = [],
     commitment?: Commitment,
     programId = TOKEN_PROGRAM_ID,
+    allowAccountDataFallback = false,
 ) {
     const instruction = createTransferCheckedInstruction(
         source,
@@ -295,6 +300,7 @@ export async function createTransferCheckedWithTransferHookInstruction(
             owner,
             amount,
             commitment,
+            allowAccountDataFallback,
         );
     }
 
@@ -304,17 +310,18 @@ export async function createTransferCheckedWithTransferHookInstruction(
 /**
  * Construct an transferChecked instruction with extra accounts for transfer hook
  *
- * @param connection            Connection to use
- * @param source                Source account
- * @param mint                  Mint to update
- * @param destination           Destination account
- * @param owner                 Owner of the source account
- * @param amount                The amount of tokens to transfer
- * @param decimals              Number of decimals in transfer amount
- * @param fee                   The calculated fee for the transfer fee extension
- * @param multiSigners          The signer account(s) for a multisig
- * @param commitment            Commitment to use
- * @param programId             SPL Token program account
+ * @param connection                    Connection to use
+ * @param source                        Source account
+ * @param mint                          Mint to update
+ * @param destination                   Destination account
+ * @param owner                         Owner of the source account
+ * @param amount                        The amount of tokens to transfer
+ * @param decimals                      Number of decimals in transfer amount
+ * @param fee                           The calculated fee for the transfer fee extension
+ * @param multiSigners                  The signer account(s) for a multisig
+ * @param commitment                    Commitment to use
+ * @param programId                     SPL Token program account
+ * @param allowAccountDataFallback      Fallback to zeroed pubkey when resolveExtraAccountMeta fails with TokenTransferHookAccountDataNotFound
  *
  * @return Instruction to add to a transaction
  */
@@ -330,6 +337,7 @@ export async function createTransferCheckedWithFeeAndTransferHookInstruction(
     multiSigners: (Signer | PublicKey)[] = [],
     commitment?: Commitment,
     programId = TOKEN_PROGRAM_ID,
+    allowAccountDataFallback = false,
 ) {
     const instruction = createTransferCheckedWithFeeInstruction(
         source,
@@ -357,6 +365,7 @@ export async function createTransferCheckedWithFeeAndTransferHookInstruction(
             owner,
             amount,
             commitment,
+            allowAccountDataFallback,
         );
     }
 


### PR DESCRIPTION
**To the Solana SDK Team**,

We are the Fragmetric team, leveraging **Token 2022 Transfer Hooks** to improve transparency in yield distribution on De-Fi protocol. Our system tracks all transfer transactions using the transfer hook mechanism to adjust reward accrual efficiently.


## 1. Issue Overview
While integrating transfer hooks, we encountered a limitation in metadata resolution within SPL Token JS that prevents seamless transfers when the destination token account is missing.

#### How This Issue Arises
Our extra account meta references `destination_token_account.owner` to handle recipient-related updates.
If the destination token account does not exist, SPL Token JS throws a `TokenTransferHookAccountDataNotFound` error (reference: https://github.com/solana-program/token-2022/blob/main/clients/js-legacy/src/extensions/transferHook/seeds.ts#L74).

This means that while we can transfer to an already created ATA, if the ATA does not exist, we are forced to send two separate transactions:
- First transaction: Create the ATA.
- Second transaction: Perform transfer_checked.
While this is manageable operationally, it disrupts wallet integrations and end-user experience, making it impossible to handle transfers seamlessly in one atomic transaction.

#### A Possible Solution
We propose introducing a fallback mechanism in SPL Token JS to allow unresolved accounts to be replaced by a placeholder (such as PublicKey.default). This enables **on-chain programs to handle missing accounts gracefully** instead of outright failing.


## 2. Implementation Detail
To address this, we have implemented an optional flag:

```ts
allowAccountDataFallback = false;
```
When set to true, this allows unresolved extra accounts to fall back to `PublicKey.default` instead of failing with `TokenTransferHookAccountDataNotFound`.

Our implementation modifies `resolveExtraAccountMeta()` in SPL Token JS as follows:

```ts
export async function resolveExtraAccountMeta(
    connection: Connection,
    extraMeta: ExtraAccountMeta,
    previousMetas: AccountMeta[],
    instructionData: Buffer,
    transferHookProgramId: PublicKey,
    allowAccountDataFallback = false, // New flag
): Promise<AccountMeta> {
    try {
        const seeds = await unpackSeeds(extraMeta.addressConfig, previousMetas, instructionData, connection);
        const pubkey = PublicKey.findProgramAddressSync(seeds, programId)[0];

        return { pubkey, isSigner: extraMeta.isSigner, isWritable: extraMeta.isWritable };
    } catch (error) {
        if (allowAccountDataFallback && error instanceof TokenTransferHookAccountDataNotFound) {
            return { pubkey: PublicKey.default, isSigner: false, isWritable: false };
        }
        throw error;
    }
}
````

## 3. Why This Change Matters
This simple fallback mechanism does not break any existing on-chain use cases and does not affect transaction simulation results, but it expands the utility of transfer hooks in the following ways:

- Makes transfer hooks more resilient and applicable to more various use cases. **Delegating how to handle these edge cases to the program, not the client would expand use cases of the transfer hook extension.**
- This approach can resolve similar old issues like discussed on Stack Exchange before:
https://solana.stackexchange.com/questions/12797/transfer-hook-how-to-get-destination-ata-owner-public-key

## 4. Request
Would it be possible to merge this change into SPL Token JS or consider a similar fallback mechanism for **handling missing accounts in transfer hooks**? We believe this enhancement will greatly improve the flexibility of Token 2022 adoption, particularly in DeFi applications like us trying to resolve challenging problem utilizing token extensions.

Looking forward to your feedback!

Best,
Fragmetric Team
