### PR TITLE
deps: Bump everything else to v2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ check-cfg = [
 ]
 
 [workspace.metadata.cli]
-solana = "2.1.0"
+solana = "2.2.0"
 
 # Specify Rust toolchains for rustfmt, clippy, and build.
 # Any unprovided toolchains default to stable.

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -28,7 +28,7 @@ solana-cli-output = "2.2.0"
 solana-client = "2.2.0"
 solana-logger = "2.2.0"
 solana-remote-wallet = "2.2.0"
-solana-sdk = "2.2.0"
+solana-sdk = "2.2.1"
 solana-transaction-status = "2.2.0"
 spl-associated-token-account-client = { version = "2.0.0" }
 spl-token = { version = "7.0", features = ["no-entrypoint"] }

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -20,12 +20,12 @@ bincode = "1.3.2"
 bytemuck = "1.21.0"
 futures = "0.3.31"
 futures-util = "0.3"
-solana-banks-interface = "2.1.0"
-solana-cli-output = { version = "2.1.0", optional = true }
-solana-program-test = "2.1.0"
-solana-rpc-client = "2.1.0"
-solana-rpc-client-api = "2.1.0"
-solana-sdk = "2.2.0"
+solana-banks-interface = "2.2.0"
+solana-cli-output = { version = "2.2.0", optional = true }
+solana-program-test = "2.2.0"
+solana-rpc-client = "2.2.0"
+solana-rpc-client-api = "2.2.0"
+solana-sdk = "2.2.1"
 spl-associated-token-account-client = { version = "2.0.0" }
 spl-elgamal-registry = { version = "0.1.1", path = "../../confidential-transfer/elgamal-registry"}
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
@@ -44,7 +44,7 @@ async-trait = "0.1"
 borsh = "1.5.5"
 bytemuck = "1.21.0"
 futures-util = "0.3"
-solana-program = "2.2.0"
+solana-program = "2.2.1"
 spl-associated-token-account = { version = "6.0.0" }
 spl-pod = { version = "0.5.0" }
 spl-instruction-padding = { version = "0.3.0", features = ["no-entrypoint"] }

--- a/clients/rust-legacy/transfer-hook-test-programs/downgrade/Cargo.toml
+++ b/clients/rust-legacy/transfer-hook-test-programs/downgrade/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-account-info = "2.1.0"
-solana-program-entrypoint = "2.1.0"
-solana-program-error = "2.1.0"
-solana-pubkey = "2.2.0"
+solana-account-info = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
+solana-pubkey = "2.2.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/clients/rust-legacy/transfer-hook-test-programs/fail/Cargo.toml
+++ b/clients/rust-legacy/transfer-hook-test-programs/fail/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-account-info = "2.1.0"
-solana-program-entrypoint = "2.1.0"
-solana-program-error = "2.1.0"
-solana-pubkey = "2.2.0"
+solana-account-info = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
+solana-pubkey = "2.2.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/clients/rust-legacy/transfer-hook-test-programs/success/Cargo.toml
+++ b/clients/rust-legacy/transfer-hook-test-programs/success/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-account-info = "2.1.0"
-solana-program-entrypoint = "2.1.0"
-solana-program-error = "2.1.0"
-solana-pubkey = "2.2.0"
+solana-account-info = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
+solana-pubkey = "2.2.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/clients/rust-legacy/transfer-hook-test-programs/swap-with-fee/Cargo.toml
+++ b/clients/rust-legacy/transfer-hook-test-programs/swap-with-fee/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-account-info = "2.1.0"
-solana-program-entrypoint = "2.1.0"
-solana-program-error = "2.1.0"
-solana-pubkey = "2.2.0"
+solana-account-info = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
+solana-pubkey = "2.2.1"
 spl-token-2022 = { path = "../../../program-2022", features = ["no-entrypoint"] }
 
 [lib]

--- a/clients/rust-legacy/transfer-hook-test-programs/swap/Cargo.toml
+++ b/clients/rust-legacy/transfer-hook-test-programs/swap/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-account-info = "2.1.0"
-solana-program-entrypoint = "2.1.0"
-solana-program-error = "2.1.0"
-solana-pubkey = "2.2.0"
+solana-account-info = "2.2.1"
+solana-program-entrypoint = "2.2.1"
+solana-program-error = "2.2.1"
+solana-pubkey = "2.2.1"
 spl-token-2022 = { path = "../../../program-2022", features = ["no-entrypoint"] }
 
 [lib]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -17,5 +17,5 @@ num-derive = "^0.3"
 num-traits = "^0.2"
 serde = { version = "^1.0", features = ["derive"], optional = true }
 serde_with = { version = "^3.0", optional = true }
-solana-program = "2.2.0"
+solana-program = "2.2.1"
 thiserror = "^1.0"

--- a/confidential-transfer/ciphertext-arithmetic/Cargo.toml
+++ b/confidential-transfer/ciphertext-arithmetic/Cargo.toml
@@ -12,7 +12,7 @@ edition = { workspace = true }
 base64 = "0.22.1"
 bytemuck = "1.21.0"
 solana-curve25519 = "2.2.0"
-solana-zk-sdk = "2.1.0"
+solana-zk-sdk = "2.2.0"
 
 [dev-dependencies]
 spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "../proof-generation" }

--- a/confidential-transfer/elgamal-registry/Cargo.toml
+++ b/confidential-transfer/elgamal-registry/Cargo.toml
@@ -14,8 +14,8 @@ test-sbf = []
 
 [dependencies]
 bytemuck = { version = "1.21.0", features = ["derive"] }
-solana-program = "2.2.0"
-solana-zk-sdk = "2.1.0"
+solana-program = "2.2.1"
+solana-zk-sdk = "2.2.0"
 spl-pod = "0.5.0"
 spl-token-confidential-transfer-proof-extraction = { version = "0.2.1", path = "../proof-extraction" }
 

--- a/confidential-transfer/proof-extraction/Cargo.toml
+++ b/confidential-transfer/proof-extraction/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 [dependencies]
 bytemuck = "1.21.0"
 solana-curve25519 = "2.2.0"
-solana-program = "2.2.0"
-solana-zk-sdk = "2.1.0"
+solana-program = "2.2.1"
+solana-zk-sdk = "2.2.0"
 spl-pod = "0.5.0"
 thiserror = "2.0.11"

--- a/confidential-transfer/proof-generation/Cargo.toml
+++ b/confidential-transfer/proof-generation/Cargo.toml
@@ -10,7 +10,7 @@ edition = { workspace = true }
 
 [dependencies]
 curve25519-dalek = "4.1.3"
-solana-zk-sdk = "2.1.0"
+solana-zk-sdk = "2.2.0"
 thiserror = "2.0.11"
 
 [lints]

--- a/confidential-transfer/proof-tests/Cargo.toml
+++ b/confidential-transfer/proof-tests/Cargo.toml
@@ -10,7 +10,7 @@ edition = { workspace = true }
 
 [dev-dependencies]
 curve25519-dalek = "4.1.3"
-solana-zk-sdk = "2.1.0"
+solana-zk-sdk = "2.2.0"
 thiserror = "2.0.11"
 spl-token-confidential-transfer-proof-extraction = { version = "0.2.1", path = "../proof-extraction" }
 spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "../proof-generation" }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,9 +24,9 @@ bytemuck = { version = "1.21.0", features = ["derive"] }
 num-derive = "0.4"
 num-traits = "0.2"
 num_enum = "0.7.3"
-solana-program = "2.2.0"
+solana-program = "2.2.1"
 solana-security-txt = "1.1.1"
-solana-zk-sdk = "2.1.0"
+solana-zk-sdk = "2.2.0"
 spl-elgamal-registry = { version = "0.1.1", path = "../confidential-transfer/elgamal-registry", features = ["no-entrypoint"] }
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
 spl-token = { version = "7.0", features = ["no-entrypoint"] }
@@ -49,8 +49,8 @@ spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "
 lazy_static = "1.5.0"
 proptest = "1.6"
 serial_test = "3.2.0"
-solana-program-test = "2.1.0"
-solana-sdk = "2.2.0"
+solana-program-test = "2.2.0"
+solana-sdk = "2.2.1"
 spl-tlv-account-resolution = { version = "0.9.0" }
 serde_json = "1.0.138"
 


### PR DESCRIPTION
#### Problem

#204 did the hard work of upgrading crates to v2.2 as needed, but some of the dependencies were missed. Also, the tool suite is still on v2.1.

#### Summary of changes

Bump the sdk crates to v2.2.1 and the non-sdk crates to v2.2.0