### PR TITLE
Multisig support on invoke helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules
 test-ledger
 dist
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9165,6 +9165,7 @@ dependencies = [
  "spl-token-metadata-interface",
  "spl-transfer-hook-interface",
  "spl-type-length-value",
+ "test-case",
  "thiserror 2.0.11",
 ]
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -43,7 +43,7 @@ serde_with = { version = "3.12.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "../confidential-transfer/proof-generation"}
+spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "../confidential-transfer/proof-generation" }
 
 [dev-dependencies]
 lazy_static = "1.5.0"
@@ -53,6 +53,7 @@ solana-program-test = "2.2.0"
 solana-sdk = "2.2.1"
 spl-tlv-account-resolution = { version = "0.9.0" }
 serde_json = "1.0.139"
+test-case = "3.3.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/src/onchain.rs
+++ b/program/src/onchain.rs
@@ -2,21 +2,19 @@
 //! correct accounts
 
 use {
-    crate::state::Mint,
+    crate::{
+        extension::{transfer_fee, transfer_hook, StateWithExtensions},
+        instruction,
+        state::Mint,
+    },
     solana_program::{
         account_info::AccountInfo, entrypoint::ProgramResult, program::invoke_signed,
         pubkey::Pubkey,
     },
-};
-use {
-    crate::{
-        extension::{transfer_fee, transfer_hook, StateWithExtensions},
-        instruction,
-    },
     spl_transfer_hook_interface::onchain::add_extra_accounts_for_execute_cpi,
 };
 
-/// Internal function that uses dependency injection for testing
+/// Internal function to reduce redundancy between the callers
 #[allow(clippy::too_many_arguments)]
 fn _invoke_transfer_internal<'a>(
     token_program_id: &Pubkey,
@@ -151,11 +149,15 @@ pub fn invoke_transfer_checked_with_fee<'a>(
 
 #[cfg(test)]
 mod tests {
-    use solana_program::instruction::AccountMeta;
-    use solana_program::program_option::COption;
-    use solana_program::program_pack::Pack;
-    use std::cell::RefCell;
-    use {super::*, solana_program::instruction::Instruction};
+    use {
+        super::*,
+        solana_program::{
+            instruction::{AccountMeta, Instruction},
+            program_option::COption,
+            program_pack::Pack,
+        },
+        std::cell::RefCell,
+    };
 
     thread_local! {
         static CAPTURED_INSTRUCTION: RefCell<Option<Instruction>> = const { RefCell::new(None) };

--- a/program/src/onchain.rs
+++ b/program/src/onchain.rs
@@ -8,16 +8,16 @@ use {
         state::Mint,
     },
     solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, instruction::AccountMeta,
+        account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
         program::invoke_signed, pubkey::Pubkey,
     },
     spl_transfer_hook_interface::onchain::add_extra_accounts_for_execute_cpi,
 };
 
-/// Helper to CPI into token-2022 on-chain, looking through the additional
-/// account infos to create the proper instruction with the proper account infos
+/// Internal function that uses dependency injection for testing
 #[allow(clippy::too_many_arguments)]
-pub fn invoke_transfer_checked<'a>(
+fn _invoke_transfer_internal<'a, F>(
+    invoker: F,
     token_program_id: &Pubkey,
     source_info: AccountInfo<'a>,
     mint_info: AccountInfo<'a>,
@@ -26,19 +26,12 @@ pub fn invoke_transfer_checked<'a>(
     additional_accounts: &[AccountInfo<'a>],
     amount: u64,
     decimals: u8,
+    fee: Option<u64>,
     seeds: &[&[&[u8]]],
-) -> ProgramResult {
-    let mut cpi_instruction = instruction::transfer_checked(
-        token_program_id,
-        source_info.key,
-        mint_info.key,
-        destination_info.key,
-        authority_info.key,
-        &[], // add them later, to avoid unnecessary clones
-        amount,
-        decimals,
-    )?;
-
+) -> ProgramResult
+where
+    F: Fn(&Instruction, &[AccountInfo<'a>], &[&[&[u8]]]) -> ProgramResult,
+{
     let mut cpi_account_infos = vec![
         source_info.clone(),
         mint_info.clone(),
@@ -46,16 +39,37 @@ pub fn invoke_transfer_checked<'a>(
         authority_info.clone(),
     ];
 
-    // if it's a signer, it might be a multisig signer, throw it in!
-    additional_accounts
-        .iter()
-        .filter(|ai| ai.is_signer)
-        .for_each(|ai| {
-            cpi_account_infos.push(ai.clone());
-            cpi_instruction
-                .accounts
-                .push(AccountMeta::new_readonly(*ai.key, ai.is_signer));
-        });
+    let mut multisig_signer_pubkeys = Vec::new();
+    for info in additional_accounts.iter() {
+        if info.is_signer {
+            multisig_signer_pubkeys.push(info.key);
+            cpi_account_infos.push(info.clone());
+        }
+    }
+
+    let mut cpi_instruction = match fee {
+        None => instruction::transfer_checked(
+            token_program_id,
+            source_info.key,
+            mint_info.key,
+            destination_info.key,
+            authority_info.key,
+            &multisig_signer_pubkeys,
+            amount,
+            decimals,
+        )?,
+        Some(fee) => transfer_fee::instruction::transfer_checked_with_fee(
+            token_program_id,
+            source_info.key,
+            mint_info.key,
+            destination_info.key,
+            authority_info.key,
+            &multisig_signer_pubkeys,
+            amount,
+            decimals,
+            fee,
+        )?,
+    };
 
     // scope the borrowing to avoid a double-borrow during CPI
     {
@@ -76,7 +90,36 @@ pub fn invoke_transfer_checked<'a>(
         }
     }
 
-    invoke_signed(&cpi_instruction, &cpi_account_infos, seeds)
+    invoker(&cpi_instruction, &cpi_account_infos, seeds)
+}
+
+/// Helper to CPI into token-2022 on-chain, looking through the additional
+/// account infos to create the proper instruction with the proper account infos
+#[allow(clippy::too_many_arguments)]
+pub fn invoke_transfer_checked<'a>(
+    token_program_id: &Pubkey,
+    source_info: AccountInfo<'a>,
+    mint_info: AccountInfo<'a>,
+    destination_info: AccountInfo<'a>,
+    authority_info: AccountInfo<'a>,
+    additional_accounts: &[AccountInfo<'a>],
+    amount: u64,
+    decimals: u8,
+    seeds: &[&[&[u8]]],
+) -> ProgramResult {
+    _invoke_transfer_internal(
+        invoke_signed,
+        token_program_id,
+        source_info,
+        mint_info,
+        destination_info,
+        authority_info,
+        additional_accounts,
+        amount,
+        decimals,
+        None,
+        seeds,
+    )
 }
 
 /// Helper to CPI into token-2022 on-chain, looking through the additional
@@ -95,54 +138,281 @@ pub fn invoke_transfer_checked_with_fee<'a>(
     fee: u64,
     seeds: &[&[&[u8]]],
 ) -> ProgramResult {
-    let mut cpi_instruction = transfer_fee::instruction::transfer_checked_with_fee(
+    _invoke_transfer_internal(
+        invoke_signed,
         token_program_id,
-        source_info.key,
-        mint_info.key,
-        destination_info.key,
-        authority_info.key,
-        &[], // add them later, to avoid unnecessary clones
+        source_info,
+        mint_info,
+        destination_info,
+        authority_info,
+        additional_accounts,
         amount,
         decimals,
-        fee,
-    )?;
+        Some(fee),
+        seeds,
+    )
+}
 
-    let mut cpi_account_infos = vec![
-        source_info.clone(),
-        mint_info.clone(),
-        destination_info.clone(),
-        authority_info.clone(),
-    ];
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_program::{
+            account_info::AccountInfo,
+            entrypoint::ProgramResult,
+            instruction::{AccountMeta, Instruction},
+            program_option::COption,
+            program_pack::Pack,
+            pubkey::Pubkey,
+        },
+        std::cell::RefCell,
+    };
 
-    // if it's a signer, it might be a multisig signer, throw it in!
-    additional_accounts
-        .iter()
-        .filter(|ai| ai.is_signer)
-        .for_each(|ai| {
-            cpi_account_infos.push(ai.clone());
-            cpi_instruction
-                .accounts
-                .push(AccountMeta::new_readonly(*ai.key, ai.is_signer));
-        });
+    struct MockInvoker {
+        captured_instruction: Option<Instruction>,
+        captured_account_keys: Option<Vec<Pubkey>>,
+        return_result: ProgramResult,
+    }
 
-    // scope the borrowing to avoid a double-borrow during CPI
-    {
-        let mint_data = mint_info.try_borrow_data()?;
-        let mint = StateWithExtensions::<Mint>::unpack(&mint_data)?;
-        if let Some(program_id) = transfer_hook::get_program_id(&mint) {
-            add_extra_accounts_for_execute_cpi(
-                &mut cpi_instruction,
-                &mut cpi_account_infos,
-                &program_id,
-                source_info,
-                mint_info.clone(),
-                destination_info,
-                authority_info,
-                amount,
-                additional_accounts,
-            )?;
+    impl MockInvoker {
+        fn new(return_result: ProgramResult) -> Self {
+            MockInvoker {
+                captured_instruction: None,
+                captured_account_keys: None,
+                return_result,
+            }
+        }
+
+        fn invoke(
+            &mut self,
+            instruction: &Instruction,
+            account_infos: &[AccountInfo],
+        ) -> ProgramResult {
+            self.captured_instruction = Some(instruction.clone());
+            self.captured_account_keys = Some(account_infos.iter().map(|ai| *ai.key).collect());
+            self.return_result.clone()
         }
     }
 
-    invoke_signed(&cpi_instruction, &cpi_account_infos, seeds)
+    // Setup mint data
+    fn setup_mint() -> Vec<u8> {
+        let state = Mint {
+            decimals: 10,
+            is_initialized: true,
+            supply: 100_000,
+            mint_authority: COption::Some(Pubkey::new_unique()),
+            freeze_authority: COption::None,
+        };
+        let mut data = vec![0u8; Mint::LEN];
+        state.pack_into_slice(&mut data);
+        data
+    }
+
+    // Parameterized test function
+    fn test_invoke_fns_with_params(is_multisig: bool, with_fee: bool) {
+        let token_program_id = crate::id();
+        let source_key = Pubkey::new_unique();
+        let mint_key = Pubkey::new_unique();
+        let destination_key = Pubkey::new_unique();
+        let authority_key = Pubkey::new_unique();
+
+        // Setup base accounts
+        let mut source_lamports = 0;
+        let source_owner = Pubkey::new_unique();
+        let source_info = AccountInfo::new(
+            &source_key,
+            false,
+            false,
+            &mut source_lamports,
+            &mut [],
+            &source_owner,
+            false,
+            0,
+        );
+
+        let mut mint_lamports = 100;
+        let mut mint_data = setup_mint();
+        let mint_owner = Pubkey::new_unique();
+        let mint_info = AccountInfo::new(
+            &mint_key,
+            false,
+            false,
+            &mut mint_lamports,
+            &mut mint_data,
+            &mint_owner,
+            false,
+            0,
+        );
+
+        let mut destination_lamports = 100;
+        let destination_owner = Pubkey::new_unique();
+        let destination_info = AccountInfo::new(
+            &destination_key,
+            false,
+            false,
+            &mut destination_lamports,
+            &mut [],
+            &destination_owner,
+            false,
+            0,
+        );
+
+        let authority_is_signer = !is_multisig; // Authority signs only if not multisig
+        let mut authority_lamports = 100;
+        let authority_owner = Pubkey::new_unique();
+        let authority_info = AccountInfo::new(
+            &authority_key,
+            authority_is_signer,
+            false,
+            &mut authority_lamports,
+            &mut [],
+            &authority_owner,
+            false,
+            0,
+        );
+
+        let signer1_key = Pubkey::new_unique();
+        let signer1_owner = Pubkey::new_unique();
+        let mut signer1_lamports = 100;
+
+        let signer2_key = Pubkey::new_unique();
+        let signer2_owner = Pubkey::new_unique();
+        let mut signer2_lamports = 100;
+
+        let signer3_key = Pubkey::new_unique();
+        let signer3_owner = Pubkey::new_unique();
+        let mut signer3_lamports = 100;
+
+        let signer_keys = [signer1_key, signer2_key, signer3_key];
+
+        let additional_accounts = if !is_multisig {
+            vec![]
+        } else {
+            let signer1_info = AccountInfo::new(
+                &signer1_key,
+                true,
+                false,
+                &mut signer1_lamports,
+                &mut [],
+                &signer1_owner,
+                false,
+                0,
+            );
+
+            let signer2_info = AccountInfo::new(
+                &signer2_key,
+                true,
+                false,
+                &mut signer2_lamports,
+                &mut [],
+                &signer2_owner,
+                false,
+                0,
+            );
+
+            let signer3_info = AccountInfo::new(
+                &signer3_key,
+                true,
+                false,
+                &mut signer3_lamports,
+                &mut [],
+                &signer3_owner,
+                false,
+                0,
+            );
+
+            vec![signer1_info, signer2_info, signer3_info]
+        };
+
+        let mock_invoker = RefCell::new(MockInvoker::new(Ok(())));
+        let invoker_fn =
+            |instruction: &Instruction, account_infos: &[AccountInfo], _seeds: &[&[&[u8]]]| {
+                mock_invoker.borrow_mut().invoke(instruction, account_infos)
+            };
+
+        let fee = if with_fee { Some(120) } else { None };
+
+        let result = _invoke_transfer_internal(
+            invoker_fn,
+            &token_program_id,
+            source_info.clone(),
+            mint_info.clone(),
+            destination_info.clone(),
+            authority_info.clone(),
+            &additional_accounts,
+            200,
+            6,
+            fee,
+            &[],
+        );
+        assert!(result.is_ok());
+
+        let expected_account_count = if is_multisig { 7 } else { 4 };
+
+        let mock_invoker = mock_invoker.borrow();
+        let instruction = mock_invoker.captured_instruction.as_ref().unwrap();
+        let account_keys = mock_invoker.captured_account_keys.as_ref().unwrap();
+
+        // Check instruction
+        assert_eq!(instruction.program_id, token_program_id,);
+        assert_eq!(instruction.accounts.len(), expected_account_count,);
+
+        // Verify base account metas
+        assert_eq!(instruction.accounts[0], AccountMeta::new(source_key, false),);
+        assert_eq!(
+            instruction.accounts[1],
+            AccountMeta::new_readonly(mint_key, false),
+        );
+        assert_eq!(
+            instruction.accounts[2],
+            AccountMeta::new(destination_key, false),
+        );
+        assert_eq!(
+            instruction.accounts[3],
+            AccountMeta::new_readonly(authority_key, authority_is_signer),
+        );
+
+        // Verify additional signer metas if multisig
+        if is_multisig {
+            for (i, signer_key) in signer_keys.iter().enumerate() {
+                assert_eq!(
+                    instruction.accounts[4 + i],
+                    AccountMeta::new_readonly(*signer_key, true),
+                );
+            }
+        }
+
+        // Verify account keys
+        assert_eq!(account_keys.len(), expected_account_count);
+        assert_eq!(account_keys[0], source_key);
+        assert_eq!(account_keys[1], mint_key);
+        assert_eq!(account_keys[2], destination_key);
+        assert_eq!(account_keys[3], authority_key);
+
+        if is_multisig {
+            for (i, signer_key) in signer_keys.iter().enumerate() {
+                assert_eq!(account_keys[4 + i], *signer_key);
+            }
+        }
+    }
+
+    #[test]
+    fn test_invoke_transfer_checked_single_signer_authority() {
+        test_invoke_fns_with_params(false, false);
+    }
+
+    #[test]
+    fn test_invoke_transfer_checked_multisig() {
+        test_invoke_fns_with_params(true, false);
+    }
+
+    #[test]
+    fn test_transfer_checked_with_fee_single_signer_authority() {
+        test_invoke_fns_with_params(false, true);
+    }
+
+    #[test]
+    fn test_transfer_checked_with_fee_multisig() {
+        test_invoke_fns_with_params(true, true);
+    }
 }

--- a/program/src/onchain.rs
+++ b/program/src/onchain.rs
@@ -2,22 +2,23 @@
 //! correct accounts
 
 use {
+    crate::state::Mint,
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, program::invoke_signed,
+        pubkey::Pubkey,
+    },
+};
+use {
     crate::{
         extension::{transfer_fee, transfer_hook, StateWithExtensions},
         instruction,
-        state::Mint,
-    },
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
-        program::invoke_signed, pubkey::Pubkey,
     },
     spl_transfer_hook_interface::onchain::add_extra_accounts_for_execute_cpi,
 };
 
 /// Internal function that uses dependency injection for testing
 #[allow(clippy::too_many_arguments)]
-fn _invoke_transfer_internal<'a, F>(
-    invoker: F,
+fn _invoke_transfer_internal<'a>(
     token_program_id: &Pubkey,
     source_info: AccountInfo<'a>,
     mint_info: AccountInfo<'a>,
@@ -28,10 +29,7 @@ fn _invoke_transfer_internal<'a, F>(
     decimals: u8,
     fee: Option<u64>,
     seeds: &[&[&[u8]]],
-) -> ProgramResult
-where
-    F: Fn(&Instruction, &[AccountInfo<'a>], &[&[&[u8]]]) -> ProgramResult,
-{
+) -> ProgramResult {
     let mut cpi_account_infos = vec![
         source_info.clone(),
         mint_info.clone(),
@@ -90,7 +88,7 @@ where
         }
     }
 
-    invoker(&cpi_instruction, &cpi_account_infos, seeds)
+    invoke_signed(&cpi_instruction, &cpi_account_infos, seeds)
 }
 
 /// Helper to CPI into token-2022 on-chain, looking through the additional
@@ -108,7 +106,6 @@ pub fn invoke_transfer_checked<'a>(
     seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     _invoke_transfer_internal(
-        invoke_signed,
         token_program_id,
         source_info,
         mint_info,
@@ -139,7 +136,6 @@ pub fn invoke_transfer_checked_with_fee<'a>(
     seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     _invoke_transfer_internal(
-        invoke_signed,
         token_program_id,
         source_info,
         mint_info,
@@ -155,46 +151,59 @@ pub fn invoke_transfer_checked_with_fee<'a>(
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        solana_program::{
-            account_info::AccountInfo,
-            entrypoint::ProgramResult,
-            instruction::{AccountMeta, Instruction},
-            program_option::COption,
-            program_pack::Pack,
-            pubkey::Pubkey,
-        },
-        std::cell::RefCell,
-    };
+    use solana_program::instruction::AccountMeta;
+    use solana_program::program_option::COption;
+    use solana_program::program_pack::Pack;
+    use std::cell::RefCell;
+    use {super::*, solana_program::instruction::Instruction};
 
-    struct MockInvoker {
-        captured_instruction: Option<Instruction>,
-        captured_account_keys: Option<Vec<Pubkey>>,
-        return_result: ProgramResult,
+    thread_local! {
+        static CAPTURED_INSTRUCTION: RefCell<Option<Instruction>> = RefCell::new(None);
+        static CAPTURED_ACCOUNT_KEYS: RefCell<Option<Vec<Pubkey>>> = RefCell::new(None);
     }
 
-    impl MockInvoker {
-        fn new(return_result: ProgramResult) -> Self {
-            MockInvoker {
-                captured_instruction: None,
-                captured_account_keys: None,
-                return_result,
-            }
-        }
+    fn get_captured_params() -> (Instruction, Vec<Pubkey>) {
+        let instr = CAPTURED_INSTRUCTION.with(|ci| ci.borrow().clone().unwrap());
+        let keys = CAPTURED_ACCOUNT_KEYS.with(|ck| ck.borrow().clone().unwrap());
+        (instr, keys)
+    }
 
-        fn invoke(
-            &mut self,
+    struct SyscallStubs {}
+    impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
+        fn sol_invoke_signed(
+            &self,
             instruction: &Instruction,
             account_infos: &[AccountInfo],
+            _signers_seeds: &[&[&[u8]]],
         ) -> ProgramResult {
-            self.captured_instruction = Some(instruction.clone());
-            self.captured_account_keys = Some(account_infos.iter().map(|ai| *ai.key).collect());
-            self.return_result.clone()
+            CAPTURED_INSTRUCTION.with(|ci| {
+                *ci.borrow_mut() = Some(instruction.clone());
+            });
+            let account_keys: Vec<Pubkey> = account_infos.iter().map(|info| *info.key).collect();
+            CAPTURED_ACCOUNT_KEYS.with(|ck| {
+                *ck.borrow_mut() = Some(account_keys);
+            });
+            Ok(())
         }
     }
 
-    // Setup mint data
+    fn reset_globals() {
+        CAPTURED_INSTRUCTION.with(|ci| *ci.borrow_mut() = None);
+        CAPTURED_ACCOUNT_KEYS.with(|ck| *ck.borrow_mut() = None);
+    }
+
+    fn set_stubs() -> ProgramResult {
+        {
+            use std::sync::Once;
+            static ONCE: Once = Once::new();
+
+            ONCE.call_once(|| {
+                solana_sdk::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
+            });
+        }
+        Ok(())
+    }
+
     fn setup_mint() -> Vec<u8> {
         let state = Mint {
             decimals: 10,
@@ -210,6 +219,9 @@ mod tests {
 
     // Parameterized test function
     fn test_invoke_fns_with_params(is_multisig: bool, with_fee: bool) {
+        reset_globals();
+        set_stubs().unwrap();
+
         let token_program_id = crate::id();
         let source_key = Pubkey::new_unique();
         let mint_key = Pubkey::new_unique();
@@ -324,52 +336,56 @@ mod tests {
             vec![signer1_info, signer2_info, signer3_info]
         };
 
-        let mock_invoker = RefCell::new(MockInvoker::new(Ok(())));
-        let invoker_fn =
-            |instruction: &Instruction, account_infos: &[AccountInfo], _seeds: &[&[&[u8]]]| {
-                mock_invoker.borrow_mut().invoke(instruction, account_infos)
-            };
-
-        let fee = if with_fee { Some(120) } else { None };
-
-        let result = _invoke_transfer_internal(
-            invoker_fn,
-            &token_program_id,
-            source_info.clone(),
-            mint_info.clone(),
-            destination_info.clone(),
-            authority_info.clone(),
-            &additional_accounts,
-            200,
-            6,
-            fee,
-            &[],
-        );
-        assert!(result.is_ok());
+        if with_fee {
+            invoke_transfer_checked_with_fee(
+                &token_program_id,
+                source_info.clone(),
+                mint_info.clone(),
+                destination_info.clone(),
+                authority_info.clone(),
+                &additional_accounts,
+                200,
+                6,
+                120,
+                &[],
+            )
+            .unwrap();
+        } else {
+            invoke_transfer_checked(
+                &token_program_id,
+                source_info.clone(),
+                mint_info.clone(),
+                destination_info.clone(),
+                authority_info.clone(),
+                &additional_accounts,
+                200,
+                6,
+                &[],
+            )
+            .unwrap();
+        }
 
         let expected_account_count = if is_multisig { 7 } else { 4 };
 
-        let mock_invoker = mock_invoker.borrow();
-        let instruction = mock_invoker.captured_instruction.as_ref().unwrap();
-        let account_keys = mock_invoker.captured_account_keys.as_ref().unwrap();
+        let (instruction, account_keys) = get_captured_params();
 
         // Check instruction
-        assert_eq!(instruction.program_id, token_program_id,);
-        assert_eq!(instruction.accounts.len(), expected_account_count,);
+        assert_eq!(instruction.program_id, token_program_id);
+        assert_eq!(instruction.accounts.len(), expected_account_count);
 
         // Verify base account metas
-        assert_eq!(instruction.accounts[0], AccountMeta::new(source_key, false),);
+        assert_eq!(instruction.accounts[0], AccountMeta::new(source_key, false));
         assert_eq!(
             instruction.accounts[1],
-            AccountMeta::new_readonly(mint_key, false),
+            AccountMeta::new_readonly(mint_key, false)
         );
         assert_eq!(
             instruction.accounts[2],
-            AccountMeta::new(destination_key, false),
+            AccountMeta::new(destination_key, false)
         );
         assert_eq!(
             instruction.accounts[3],
-            AccountMeta::new_readonly(authority_key, authority_is_signer),
+            AccountMeta::new_readonly(authority_key, authority_is_signer)
         );
 
         // Verify additional signer metas if multisig

--- a/program/src/onchain.rs
+++ b/program/src/onchain.rs
@@ -158,8 +158,8 @@ mod tests {
     use {super::*, solana_program::instruction::Instruction};
 
     thread_local! {
-        static CAPTURED_INSTRUCTION: RefCell<Option<Instruction>> = RefCell::new(None);
-        static CAPTURED_ACCOUNT_KEYS: RefCell<Option<Vec<Pubkey>>> = RefCell::new(None);
+        static CAPTURED_INSTRUCTION: RefCell<Option<Instruction>> = const { RefCell::new(None) };
+        static CAPTURED_ACCOUNT_KEYS: RefCell<Option<Vec<Pubkey>>> = const { RefCell::new(None) };
     }
 
     fn get_captured_params() -> (Instruction, Vec<Pubkey>) {

--- a/program/src/onchain.rs
+++ b/program/src/onchain.rs
@@ -169,6 +169,7 @@ mod tests {
             get_extra_account_metas_address, instruction::ExecuteInstruction,
         },
         std::cell::RefCell,
+        test_case::test_case,
     };
 
     thread_local! {
@@ -272,6 +273,14 @@ mod tests {
     }
 
     // Parameterized test function
+    #[test_case(false, false, false; "single signer")]
+    #[test_case(false, true, false; "single signer with fee")]
+    #[test_case(false, false, true; "single signer with transfer hook")]
+    #[test_case(false, true, true; "single signer with fee and transfer hook")]
+    #[test_case(true, false, false; "multisig")]
+    #[test_case(true, true, false; "multisig with fee")]
+    #[test_case(true, false, true; "multisig with transfer hook")]
+    #[test_case(true, true, true; "multisig with fee and transfer_hook")]
     fn test_parameterized_invoke_fns(
         with_multisig: bool,
         with_fee: bool,
@@ -625,45 +634,5 @@ mod tests {
                 transfer_hook_program_id
             );
         }
-    }
-
-    #[test]
-    fn test_single_signer() {
-        test_parameterized_invoke_fns(false, false, false);
-    }
-
-    #[test]
-    fn test_single_signer_with_fee() {
-        test_parameterized_invoke_fns(false, true, false);
-    }
-
-    #[test]
-    fn test_single_signer_with_transfer_hook() {
-        test_parameterized_invoke_fns(false, false, true);
-    }
-
-    #[test]
-    fn test_single_signer_with_fee_and_transfer_hook() {
-        test_parameterized_invoke_fns(false, true, true);
-    }
-
-    #[test]
-    fn test_multisig() {
-        test_parameterized_invoke_fns(true, false, false);
-    }
-
-    #[test]
-    fn test_multisig_with_fee() {
-        test_parameterized_invoke_fns(true, true, false);
-    }
-
-    #[test]
-    fn test_multisig_with_transfer_hook() {
-        test_parameterized_invoke_fns(true, false, true);
-    }
-
-    #[test]
-    fn test_multisig_with_fee_and_transfer_hook() {
-        test_parameterized_invoke_fns(true, true, true);
     }
 }


### PR DESCRIPTION
== Bug fix ==

At the moment, these helpers are passing in an empty signers slice to `transfer_checked()` and `transfer_checked_with_fee()` to avoid clones. Unfortunately, for multisigs, this improperly adds signer status to the `authority_info` which causes an permissions escalation error for consumers.

This PR does:
- Fixes bug where it passes signers to helpers
- Creates a single internal `_invoke_transfer_internal()` to reduce redundancy between functions & allow dependency injection
- Adds unit tests
