### PR TITLE
[js-legacy] add helpers for scaled ui amount

### DIFF
--- a/clients/js-legacy/src/actions/amountToUiAmount.ts
+++ b/clients/js-legacy/src/actions/amountToUiAmount.ts
@@ -31,7 +31,7 @@ export async function amountToUiAmount(
 ): Promise<string | TransactionError | null> {
     const transaction = new Transaction().add(createAmountToUiAmountInstruction(mint, amount, programId));
     const { returnData, err } = (await connection.simulateTransaction(transaction, [payer], false)).value;
-    
+
     if (returnData?.data) {
         return Buffer.from(returnData.data[0], returnData.data[1]).toString('utf-8');
     }
@@ -60,15 +60,15 @@ function calculateExponentForTimesAndRate(t1: number, t2: number, r: number): nu
  */
 async function getSysvarClockTimestamp(connection: Connection): Promise<number> {
     const info = await connection.getParsedAccountInfo(SYSVAR_CLOCK_PUBKEY);
-    
+
     if (!info?.value) {
         throw new Error('Failed to fetch sysvar clock');
     }
-    
+
     if (typeof info.value === 'object' && 'data' in info.value && 'parsed' in info.value.data) {
         return info.value.data.parsed.info.unixTimestamp;
     }
-    
+
     throw new Error('Failed to parse sysvar clock');
 }
 
@@ -99,7 +99,7 @@ function uiAmountToAtomicUiAmount(uiAmount: string, decimals: number): number {
 /**
  * Convert amount to UiAmount for a mint with interest bearing extension without simulating a transaction
  * This implements the same logic as the CPI instruction available in /token/program-2022/src/extension/interest_bearing_mint/mod.rs
- * 
+ *
  * Formula: A = P * e^(r * t) where
  * A = final amount after interest
  * P = principal amount (initial investment)
@@ -139,15 +139,11 @@ export function amountToUiAmountForInterestBearingMintWithoutSimulation(
     );
 
     // Calculate post-update exponent (interest accrued from last update to current time)
-    const postUpdateExp = calculateExponentForTimesAndRate(
-        lastUpdateTimestamp, 
-        currentTimestamp, 
-        currentRate,
-    );
+    const postUpdateExp = calculateExponentForTimesAndRate(lastUpdateTimestamp, currentTimestamp, currentRate);
 
     // Calculate total scale factor
     const totalScale = preUpdateExp * postUpdateExp;
-    
+
     // Scale the amount by the total interest factor
     const scaledAmount = Number(amount) * totalScale;
 
@@ -193,7 +189,7 @@ export async function amountToUiAmountForMintWithoutSimulation(
 ): Promise<string> {
     const accountInfo = await connection.getAccountInfo(mint);
     const programId = accountInfo?.owner;
-    
+
     if (programId !== TOKEN_PROGRAM_ID && programId !== TOKEN_2022_PROGRAM_ID) {
         throw new Error('Invalid program ID');
     }
@@ -269,11 +265,7 @@ export function uiAmountToAmountForInterestBearingMintWithoutSimulation(
     );
 
     // Calculate post-update exponent
-    const postUpdateExp = calculateExponentForTimesAndRate(
-        lastUpdateTimestamp, 
-        currentTimestamp, 
-        currentRate,
-    );
+    const postUpdateExp = calculateExponentForTimesAndRate(lastUpdateTimestamp, currentTimestamp, currentRate);
 
     // Calculate total scale
     const totalScale = preUpdateExp * postUpdateExp;
@@ -319,7 +311,7 @@ export async function uiAmountToAmountForMintWithoutSimulation(
 ): Promise<bigint> {
     const accountInfo = await connection.getAccountInfo(mint);
     const programId = accountInfo?.owner;
-    
+
     if (programId !== TOKEN_PROGRAM_ID && programId !== TOKEN_2022_PROGRAM_ID) {
         throw new Error('Invalid program ID');
     }

--- a/clients/js-legacy/test/unit/scaledAmount.test.ts
+++ b/clients/js-legacy/test/unit/scaledAmount.test.ts
@@ -1,0 +1,282 @@
+import { expect } from 'chai';
+import type { Connection } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
+import {
+    amountToUiAmountForMintWithoutSimulation,
+    amountToUiAmountForScaledUiAmountMintWithoutSimulation,
+    uiAmountToAmountForMintWithoutSimulation,
+    uiAmountToAmountForScaledUiAmountMintWithoutSimulation,
+} from '../../src/actions/amountToUiAmount';
+import { AccountLayout, AccountType, ScaledUiAmountConfigLayout, TOKEN_2022_PROGRAM_ID } from '../../src';
+import { MintLayout } from '../../src/state/mint';
+import { ExtensionType } from '../../src/extensions/extensionType';
+
+const ONE_YEAR_IN_SECONDS = 31556736;
+const TEST_DECIMALS = 2;
+
+// Mock connection class
+class MockConnection {
+    private mockAccountInfo: any;
+    private mockClock: {
+        epoch: number;
+        epochStartTimestamp: number;
+        leaderScheduleEpoch: number;
+        slot: number;
+        unixTimestamp: number;
+    };
+
+    constructor() {
+        this.mockAccountInfo = null;
+        this.mockClock = {
+            epoch: 0,
+            epochStartTimestamp: 0,
+            leaderScheduleEpoch: 0,
+            slot: 0,
+            unixTimestamp: ONE_YEAR_IN_SECONDS,
+        };
+    }
+
+    getAccountInfo = async (address: PublicKey) => {
+        return this.getParsedAccountInfo(address);
+    };
+
+    // used to get the clock timestamp
+    getParsedAccountInfo = async (address: PublicKey) => {
+        if (address.toString() === 'SysvarC1ock11111111111111111111111111111111') {
+            return {
+                value: {
+                    data: {
+                        parsed: {
+                            info: this.mockClock,
+                        },
+                    },
+                },
+            };
+        }
+        return this.mockAccountInfo;
+    };
+
+    setClockTimestamp(timestamp: number) {
+        this.mockClock = {
+            ...this.mockClock,
+            unixTimestamp: timestamp,
+        };
+    }
+
+    setAccountInfo(info: any) {
+        this.mockAccountInfo = info;
+    }
+}
+
+function createMockMintData(
+    decimals = 2,
+    hasScaledUiAmountConfig = false,
+    config: { multiplier?: number; newMultiplier?: number; newMultiplierEffectiveTimestamp?: number } = {},
+) {
+    const mintData = Buffer.alloc(MintLayout.span);
+    MintLayout.encode(
+        {
+            mintAuthorityOption: 1,
+            mintAuthority: new PublicKey(new Uint8Array(32).fill(1)),
+            supply: BigInt(1000000),
+            decimals: decimals,
+            isInitialized: true,
+            freezeAuthorityOption: 1,
+            freezeAuthority: new PublicKey(new Uint8Array(32).fill(1)),
+        },
+        mintData,
+    );
+
+    const baseData = Buffer.alloc(AccountLayout.span + 1);
+    mintData.copy(baseData, 0);
+    baseData[AccountLayout.span] = AccountType.Mint;
+
+    if (!hasScaledUiAmountConfig) {
+        return baseData;
+    }
+
+    // write extension data using the ScaledUiAmountConfigLayout
+    const extensionData = Buffer.alloc(ScaledUiAmountConfigLayout.span);
+    const rateAuthority = new Uint8Array(32).fill(1); // rate authority
+    Buffer.from(rateAuthority).copy(extensionData, 0);
+    extensionData.writeDoubleLE(config.multiplier || 0, 32); // multiplier (f64)
+    extensionData.writeBigUInt64LE(BigInt(config.newMultiplierEffectiveTimestamp || ONE_YEAR_IN_SECONDS), 40); // new multiplier effective timestamp (u64)
+    extensionData.writeDoubleLE(config.newMultiplier || 0, 48); // new multiplier (f64)
+
+    const TYPE_SIZE = 2;
+    const LENGTH_SIZE = 2;
+    const tlvBuffer = Buffer.alloc(TYPE_SIZE + LENGTH_SIZE + extensionData.length);
+    tlvBuffer.writeUInt16LE(ExtensionType.ScaledUiAmountConfig, 0);
+    tlvBuffer.writeUInt16LE(extensionData.length, TYPE_SIZE);
+    extensionData.copy(tlvBuffer, TYPE_SIZE + LENGTH_SIZE);
+
+    const fullData = Buffer.alloc(baseData.length + tlvBuffer.length);
+    baseData.copy(fullData, 0);
+    tlvBuffer.copy(fullData, baseData.length);
+
+    return fullData;
+}
+
+describe('Scaled UI Amount Extension', () => {
+    let connection: MockConnection;
+    const mint = new PublicKey('So11111111111111111111111111111111111111112');
+
+    beforeEach(() => {
+        connection = new MockConnection() as unknown as MockConnection;
+    });
+
+    describe('amountToUiAmountForScaledUiAmountMintWithoutSimulation', () => {
+        it('should correctly scale amounts with different multipliers', () => {
+            const testCases = [
+                { amount: 100n, multiplier: 1, decimals: 2, expected: '1' },
+                { amount: 100n, multiplier: 2, decimals: 2, expected: '2' },
+                { amount: 100n, multiplier: 0.5, decimals: 2, expected: '0.5' },
+                { amount: 1000000n, multiplier: 1.5, decimals: 6, expected: '1.5' },
+            ];
+
+            for (const { amount, multiplier, decimals, expected } of testCases) {
+                const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(
+                    amount,
+                    decimals,
+                    multiplier
+                );
+                expect(result).to.equal(expected);
+            }
+        });
+
+        it('should handle zero multiplier', () => {
+            const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(
+                100n,
+                2,
+                0
+            );
+            expect(result).to.equal('0');
+        });
+
+        it('should handle large numbers correctly', () => {
+            const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(
+                BigInt(10_000_000_000),
+                10,
+                5
+            );
+            expect(result).to.equal('5')
+        });
+    });
+
+    describe('uiAmountToAmountForScaledUiAmountMintWithoutSimulation', () => {
+        it('should correctly unscale amounts with different multipliers', () => {
+            const testCases = [
+                { uiAmount: '1', multiplier: 1, decimals: 2, expected: 100n },
+                { uiAmount: '2', multiplier: 2, decimals: 2, expected: 100n },
+                { uiAmount: '0.5', multiplier: 0.5, decimals: 2, expected: 100n },
+                { uiAmount: '1.5', multiplier: 1.5, decimals: 6, expected: 1000000n },
+            ];
+
+            for (const { uiAmount, multiplier, decimals, expected } of testCases) {
+                const result = uiAmountToAmountForScaledUiAmountMintWithoutSimulation(
+                    uiAmount,
+                    decimals,
+                    multiplier
+                );
+                expect(result).to.equal(expected);
+            }
+        });
+
+        it('should handle zero multiplier', () => {
+            expect(() => 
+                uiAmountToAmountForScaledUiAmountMintWithoutSimulation('1', 2, 0)
+            ).to.throw();
+        });
+
+        it('should handle large numbers correctly', () => {
+            const result = uiAmountToAmountForScaledUiAmountMintWithoutSimulation(
+                '5.0000000000000000',
+                10,
+                5
+            );
+            expect(result).to.equal(10000000000n);
+        });
+    });
+
+    describe('Integration with mint account', () => {
+        it('should handle multiplier transition correctly', async () => {
+            const currentTime = ONE_YEAR_IN_SECONDS;
+            const futureTime = ONE_YEAR_IN_SECONDS * 2;
+            
+            connection.setAccountInfo({
+                owner: TOKEN_2022_PROGRAM_ID,
+                lamports: 1000000,
+                data: createMockMintData(2, true, {
+                    multiplier: 1,
+                    newMultiplier: 2,
+                    newMultiplierEffectiveTimestamp: futureTime,
+                }),
+            });
+
+            // Test with current multiplier
+            connection.setClockTimestamp(currentTime);
+            let result = await amountToUiAmountForMintWithoutSimulation(
+                connection as unknown as Connection,
+                mint,
+                100n
+            );
+            expect(result).to.equal('1');
+
+            // Test with new multiplier after effective timestamp
+            connection.setClockTimestamp(futureTime);
+            result = await amountToUiAmountForMintWithoutSimulation(
+                connection as unknown as Connection,
+                mint,
+                100n
+            );
+            expect(result).to.equal('2');
+        });
+
+        it('should correctly convert back and forth', async () => {
+            connection.setAccountInfo({
+                owner: TOKEN_2022_PROGRAM_ID,
+                lamports: 1000000,
+                data: createMockMintData(2, true, {
+                    multiplier: 5,
+                    newMultiplierEffectiveTimestamp: 0,
+                    newMultiplier: 5,
+                }),
+            });
+
+            const originalAmount = BigInt(100);
+            const uiAmount = await amountToUiAmountForMintWithoutSimulation(
+                connection as unknown as Connection,
+                mint,
+                originalAmount
+            );
+            expect(uiAmount).to.equal('5');
+
+            const convertedBack = await uiAmountToAmountForMintWithoutSimulation(
+                connection as unknown as Connection,
+                mint,
+                uiAmount
+            );
+
+            expect(convertedBack).to.equal(originalAmount);
+        });
+
+        it('should handle max values correctly', async () => {
+            connection.setAccountInfo({
+                owner: TOKEN_2022_PROGRAM_ID,
+                lamports: 1000000,
+                data: createMockMintData(0, true, {
+                    multiplier: Number.MAX_VALUE,
+                    newMultiplierEffectiveTimestamp: 0,
+                    newMultiplier: Number.MAX_VALUE,
+                }),
+            });
+
+            const result = await amountToUiAmountForMintWithoutSimulation(
+                connection as unknown as Connection,
+                mint,
+                BigInt(Number.MAX_SAFE_INTEGER)
+            );
+            expect(result).to.equal('Infinity');
+        });
+    });
+});

--- a/clients/js-legacy/test/unit/scaledAmount.test.ts
+++ b/clients/js-legacy/test/unit/scaledAmount.test.ts
@@ -135,31 +135,19 @@ describe('Scaled UI Amount Extension', () => {
             ];
 
             for (const { amount, multiplier, decimals, expected } of testCases) {
-                const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(
-                    amount,
-                    decimals,
-                    multiplier
-                );
+                const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(amount, decimals, multiplier);
                 expect(result).to.equal(expected);
             }
         });
 
         it('should handle zero multiplier', () => {
-            const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(
-                100n,
-                2,
-                0
-            );
+            const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(100n, 2, 0);
             expect(result).to.equal('0');
         });
 
         it('should handle large numbers correctly', () => {
-            const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(
-                BigInt(10_000_000_000),
-                10,
-                5
-            );
-            expect(result).to.equal('5')
+            const result = amountToUiAmountForScaledUiAmountMintWithoutSimulation(BigInt(10_000_000_000), 10, 5);
+            expect(result).to.equal('5');
         });
     });
 
@@ -173,27 +161,17 @@ describe('Scaled UI Amount Extension', () => {
             ];
 
             for (const { uiAmount, multiplier, decimals, expected } of testCases) {
-                const result = uiAmountToAmountForScaledUiAmountMintWithoutSimulation(
-                    uiAmount,
-                    decimals,
-                    multiplier
-                );
+                const result = uiAmountToAmountForScaledUiAmountMintWithoutSimulation(uiAmount, decimals, multiplier);
                 expect(result).to.equal(expected);
             }
         });
 
         it('should handle zero multiplier', () => {
-            expect(() => 
-                uiAmountToAmountForScaledUiAmountMintWithoutSimulation('1', 2, 0)
-            ).to.throw();
+            expect(() => uiAmountToAmountForScaledUiAmountMintWithoutSimulation('1', 2, 0)).to.throw();
         });
 
         it('should handle large numbers correctly', () => {
-            const result = uiAmountToAmountForScaledUiAmountMintWithoutSimulation(
-                '5.0000000000000000',
-                10,
-                5
-            );
+            const result = uiAmountToAmountForScaledUiAmountMintWithoutSimulation('5.0000000000000000', 10, 5);
             expect(result).to.equal(10000000000n);
         });
     });
@@ -202,7 +180,7 @@ describe('Scaled UI Amount Extension', () => {
         it('should handle multiplier transition correctly', async () => {
             const currentTime = ONE_YEAR_IN_SECONDS;
             const futureTime = ONE_YEAR_IN_SECONDS * 2;
-            
+
             connection.setAccountInfo({
                 owner: TOKEN_2022_PROGRAM_ID,
                 lamports: 1000000,
@@ -218,17 +196,13 @@ describe('Scaled UI Amount Extension', () => {
             let result = await amountToUiAmountForMintWithoutSimulation(
                 connection as unknown as Connection,
                 mint,
-                100n
+                100n,
             );
             expect(result).to.equal('1');
 
             // Test with new multiplier after effective timestamp
             connection.setClockTimestamp(futureTime);
-            result = await amountToUiAmountForMintWithoutSimulation(
-                connection as unknown as Connection,
-                mint,
-                100n
-            );
+            result = await amountToUiAmountForMintWithoutSimulation(connection as unknown as Connection, mint, 100n);
             expect(result).to.equal('2');
         });
 
@@ -247,14 +221,14 @@ describe('Scaled UI Amount Extension', () => {
             const uiAmount = await amountToUiAmountForMintWithoutSimulation(
                 connection as unknown as Connection,
                 mint,
-                originalAmount
+                originalAmount,
             );
             expect(uiAmount).to.equal('5');
 
             const convertedBack = await uiAmountToAmountForMintWithoutSimulation(
                 connection as unknown as Connection,
                 mint,
-                uiAmount
+                uiAmount,
             );
 
             expect(convertedBack).to.equal(originalAmount);
@@ -274,7 +248,7 @@ describe('Scaled UI Amount Extension', () => {
             const result = await amountToUiAmountForMintWithoutSimulation(
                 connection as unknown as Connection,
                 mint,
-                BigInt(Number.MAX_SAFE_INTEGER)
+                BigInt(Number.MAX_SAFE_INTEGER),
             );
             expect(result).to.equal('Infinity');
         });


### PR DESCRIPTION
# Add Scaled UI Amount Extension Utilities

This PR adds better support for the Scaled UI Amount extension in the legacy SPL Token SDK, along with code quality improvements for better readability and maintainability.

## Changes

### New Functionality
- Added utility functions for the Scaled UI Amount extension:
  - `amountToUiAmountForScaledUiAmountMintWithoutSimulation` - Converts raw token amounts to UI amounts using the scaling multiplier
  - `uiAmountToAmountForScaledUiAmountMintWithoutSimulation` - Converts UI amounts back to raw token amounts
- Enhanced `amountToUiAmountForMintWithoutSimulation` to detect and handle Scaled UI Amount extensions
- Enhanced `uiAmountToAmountForMintWithoutSimulation` to support Scaled UI Amount extensions

### Code Quality Improvements
- Extracted common constants to improve maintainability
- Added helper functions to reduce code duplication
- Improved variable naming for better readability
- Added better comment documentation

### Testing
- Added a dedicated test file for Scaled UI Amount extension
- Implemented unit tests for all new utility functions that also mimic the existing tests for the rust crate

## Implementation Details

The Scaled UI Amount extension allows token creators to apply a scaling factor to token amounts when displaying them to users. This is useful for various applications:

1. Redenomination of tokens (e.g., displaying 1 token as 1000 tokens to users)
2. Supporting tokens with changing valuations (IBT)

The implementation follows the same pattern as the Interest Bearing Mint extension, providing both simulation-based and direct calculation methods for converting between raw and UI amounts.
