### PR TITLE
CI: Blast a bit more when running purge job

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -61,8 +61,19 @@ runs:
         sudo rm -rf /imagegeneration
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo docker image prune --all --force
-        sudo swapoff -a
-        sudo rm -f /mnt/swapfile
+        sudo apt-get remove -y '^aspnetcore-.*'
+        sudo apt-get remove -y '^dotnet-.*' --fix-missing
+        sudo apt-get remove -y '^llvm-.*' --fix-missing
+        sudo apt-get remove -y 'php.*' --fix-missing
+        sudo apt-get remove -y '^mongodb-.*' --fix-missing
+        sudo apt-get remove -y '^mysql-.*' --fix-missing
+        sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing
+        sudo apt-get remove -y google-cloud-sdk --fix-missing
+        sudo apt-get remove -y google-cloud-cli --fix-missing
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        #sudo swapoff -a
+        #sudo rm -f /mnt/swapfile
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -50,6 +50,7 @@ runs:
         sudo rm -rf /usr/share/az_*
         sudo rm -rf /usr/share/postgresql-common
         sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/.ghcup
         sudo rm -rf /opt/az
         sudo rm -rf /opt/pipx
         sudo rm -rf /opt/microsoft
@@ -60,6 +61,8 @@ runs:
         sudo rm -rf /imagegeneration
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo docker image prune --all --force
+        sudo swapoff -a
+        sudo rm -f /mnt/swapfile
 
     - name: Install Dependencies
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
#### Problem

The Rust legacy job is failing due to running out of disk space.

#### Summary of changes

Remove large packages too before the run