### PR TITLE
fix: support builds targeting `wasm32`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,6 +286,9 @@ jobs:
       - name: Build Token-2022
         run: pnpm programs:build
 
+      - name: Build Token-2022 Wasm
+        run: pnpm wasm:build
+
       - name: Build ElGamal Registry
         run: pnpm confidential-transfer:elgamal-registry:build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -287,7 +287,7 @@ jobs:
         run: pnpm programs:build
 
       - name: Build Token-2022 Wasm
-        run: pnpm wasm:build
+        run: pnpm programs:build-wasm
 
       - name: Build ElGamal Registry
         run: pnpm confidential-transfer:elgamal-registry:build

--- a/confidential-transfer/proof-generation/src/mint.rs
+++ b/confidential-transfer/proof-generation/src/mint.rs
@@ -1,3 +1,5 @@
+#[cfg(target_arch = "wasm32")]
+use solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamalCiphertext3Handles;
 use {
     crate::{
         encryption::MintAmountCiphertext, errors::TokenProofGenerationError,
@@ -52,12 +54,32 @@ pub fn mint_split_proof_data(
         supply_elgamal_keypair.pubkey(),
         auditor_elgamal_pubkey,
     );
+    #[cfg(not(target_arch = "wasm32"))]
+    let grouped_ciphertext_lo = mint_amount_grouped_ciphertext_lo.0;
+    #[cfg(target_arch = "wasm32")]
+    let grouped_ciphertext_lo = GroupedElGamalCiphertext3Handles::encryption_with_u64(
+        destination_elgamal_pubkey,
+        supply_elgamal_keypair.pubkey(),
+        auditor_elgamal_pubkey,
+        mint_amount_lo,
+        &mint_amount_opening_lo,
+    );
 
     let (mint_amount_grouped_ciphertext_hi, mint_amount_opening_hi) = MintAmountCiphertext::new(
         mint_amount_hi,
         destination_elgamal_pubkey,
         supply_elgamal_keypair.pubkey(),
         auditor_elgamal_pubkey,
+    );
+    #[cfg(not(target_arch = "wasm32"))]
+    let grouped_ciphertext_hi = mint_amount_grouped_ciphertext_hi.0;
+    #[cfg(target_arch = "wasm32")]
+    let grouped_ciphertext_hi = GroupedElGamalCiphertext3Handles::encryption_with_u64(
+        destination_elgamal_pubkey,
+        supply_elgamal_keypair.pubkey(),
+        auditor_elgamal_pubkey,
+        mint_amount_hi,
+        &mint_amount_opening_hi,
     );
 
     // compute the new supply ciphertext
@@ -101,8 +123,8 @@ pub fn mint_split_proof_data(
         destination_elgamal_pubkey,
         supply_elgamal_keypair.pubkey(),
         auditor_elgamal_pubkey,
-        &mint_amount_grouped_ciphertext_lo.0,
-        &mint_amount_grouped_ciphertext_hi.0,
+        &grouped_ciphertext_lo,
+        &grouped_ciphertext_hi,
         mint_amount_lo,
         mint_amount_hi,
         &mint_amount_opening_lo,

--- a/confidential-transfer/proof-generation/src/transfer.rs
+++ b/confidential-transfer/proof-generation/src/transfer.rs
@@ -1,3 +1,5 @@
+#[cfg(target_arch = "wasm32")]
+use solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamalCiphertext3Handles;
 use {
     crate::{
         encryption::TransferAmountCiphertext, errors::TokenProofGenerationError,
@@ -55,6 +57,16 @@ pub fn transfer_split_proof_data(
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
         );
+    #[cfg(not(target_arch = "wasm32"))]
+    let grouped_ciphertext_lo = transfer_amount_grouped_ciphertext_lo.0;
+    #[cfg(target_arch = "wasm32")]
+    let grouped_ciphertext_lo = GroupedElGamalCiphertext3Handles::encryption_with_u64(
+        source_elgamal_keypair.pubkey(),
+        destination_elgamal_pubkey,
+        auditor_elgamal_pubkey,
+        transfer_amount_lo,
+        &transfer_amount_opening_lo,
+    );
 
     let (transfer_amount_grouped_ciphertext_hi, transfer_amount_opening_hi) =
         TransferAmountCiphertext::new(
@@ -63,6 +75,16 @@ pub fn transfer_split_proof_data(
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
         );
+    #[cfg(not(target_arch = "wasm32"))]
+    let grouped_ciphertext_hi = transfer_amount_grouped_ciphertext_hi.0;
+    #[cfg(target_arch = "wasm32")]
+    let grouped_ciphertext_hi = GroupedElGamalCiphertext3Handles::encryption_with_u64(
+        source_elgamal_keypair.pubkey(),
+        destination_elgamal_pubkey,
+        auditor_elgamal_pubkey,
+        transfer_amount_hi,
+        &transfer_amount_opening_hi,
+    );
 
     // Decrypt the current available balance at the source
     let current_decrypted_available_balance = current_decryptable_available_balance
@@ -112,8 +134,8 @@ pub fn transfer_split_proof_data(
         source_elgamal_keypair.pubkey(),
         destination_elgamal_pubkey,
         auditor_elgamal_pubkey,
-        &transfer_amount_grouped_ciphertext_lo.0,
-        &transfer_amount_grouped_ciphertext_hi.0,
+        &grouped_ciphertext_lo,
+        &grouped_ciphertext_hi,
         transfer_amount_lo,
         transfer_amount_hi,
         &transfer_amount_opening_lo,

--- a/confidential-transfer/proof-generation/src/transfer_with_fee.rs
+++ b/confidential-transfer/proof-generation/src/transfer_with_fee.rs
@@ -1,3 +1,7 @@
+#[cfg(target_arch = "wasm32")]
+use solana_zk_sdk::encryption::grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles};
+#[cfg(not(target_arch = "wasm32"))]
+use solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal;
 use {
     crate::{
         encryption::{FeeCiphertext, TransferAmountCiphertext},
@@ -9,10 +13,7 @@ use {
     curve25519_dalek::scalar::Scalar,
     solana_zk_sdk::{
         encryption::{
-            auth_encryption::{AeCiphertext, AeKey},
-            elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
-            grouped_elgamal::GroupedElGamal,
-            pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
+            auth_encryption::{AeCiphertext, AeKey}, elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey}, pedersen::{Pedersen, PedersenCommitment, PedersenOpening}
         },
         zk_elgamal_proof_program::proof_data::{
             BatchedGroupedCiphertext2HandlesValidityProofData,
@@ -71,6 +72,16 @@ pub fn transfer_with_fee_split_proof_data(
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
         );
+    #[cfg(not(target_arch = "wasm32"))]
+    let grouped_ciphertext_lo = transfer_amount_grouped_ciphertext_lo.0;
+    #[cfg(target_arch = "wasm32")]
+    let grouped_ciphertext_lo = GroupedElGamalCiphertext3Handles::encryption_with_u64(
+        source_elgamal_keypair.pubkey(),
+        destination_elgamal_pubkey,
+        auditor_elgamal_pubkey,
+        transfer_amount_lo,
+        &transfer_amount_opening_lo,
+    );
 
     let (transfer_amount_grouped_ciphertext_hi, transfer_amount_opening_hi) =
         TransferAmountCiphertext::new(
@@ -79,6 +90,16 @@ pub fn transfer_with_fee_split_proof_data(
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
         );
+    #[cfg(not(target_arch = "wasm32"))]
+    let grouped_ciphertext_hi = transfer_amount_grouped_ciphertext_hi.0;
+    #[cfg(target_arch = "wasm32")]
+    let grouped_ciphertext_hi = GroupedElGamalCiphertext3Handles::encryption_with_u64(
+        source_elgamal_keypair.pubkey(),
+        destination_elgamal_pubkey,
+        auditor_elgamal_pubkey,
+        transfer_amount_hi,
+        &transfer_amount_opening_hi,
+    );
 
     // Decrypt the current available balance at the source
     let current_decrypted_available_balance = current_decryptable_available_balance
@@ -130,8 +151,8 @@ pub fn transfer_with_fee_split_proof_data(
             source_elgamal_keypair.pubkey(),
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
-            &transfer_amount_grouped_ciphertext_lo.0,
-            &transfer_amount_grouped_ciphertext_hi.0,
+            &grouped_ciphertext_lo,
+            &grouped_ciphertext_hi,
             transfer_amount_lo,
             transfer_amount_hi,
             &transfer_amount_opening_lo,
@@ -233,6 +254,7 @@ pub fn transfer_with_fee_split_proof_data(
 
     // encrypt the fee amount under the destination and withdraw withheld authority
     // ElGamal public key
+    #[cfg(not(target_arch = "wasm32"))]
     let fee_destination_withdraw_withheld_authority_ciphertext_lo = GroupedElGamal::encrypt_with(
         [
             destination_elgamal_pubkey,
@@ -241,11 +263,26 @@ pub fn transfer_with_fee_split_proof_data(
         fee_amount_lo,
         &fee_opening_lo,
     );
-    let fee_destination_withdraw_withheld_authority_ciphertext_hi = GroupedElGamal::encrypt_with(
-        [
+    #[cfg(target_arch = "wasm32")]
+    let fee_destination_withdraw_withheld_authority_ciphertext_lo = GroupedElGamalCiphertext2Handles::encryption_with_u64(
+        destination_elgamal_pubkey,
+        withdraw_withheld_authority_elgamal_pubkey,
+        fee_amount_lo,
+        &fee_opening_lo
+    );
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let fee_destination_withdraw_withheld_authority_ciphertext_hi = GroupedElGamal::encrypt_with([
             destination_elgamal_pubkey,
             withdraw_withheld_authority_elgamal_pubkey,
         ],
+        fee_amount_hi,
+        &fee_opening_hi,
+    );
+    #[cfg(target_arch = "wasm32")]
+    let fee_destination_withdraw_withheld_authority_ciphertext_hi = GroupedElGamalCiphertext2Handles::encryption_with_u64(
+        destination_elgamal_pubkey,
+        withdraw_withheld_authority_elgamal_pubkey,
         fee_amount_hi,
         &fee_opening_hi,
     );

--- a/confidential-transfer/proof-generation/src/transfer_with_fee.rs
+++ b/confidential-transfer/proof-generation/src/transfer_with_fee.rs
@@ -1,7 +1,9 @@
-#[cfg(target_arch = "wasm32")]
-use solana_zk_sdk::encryption::grouped_elgamal::{GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles};
 #[cfg(not(target_arch = "wasm32"))]
 use solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal;
+#[cfg(target_arch = "wasm32")]
+use solana_zk_sdk::encryption::grouped_elgamal::{
+    GroupedElGamalCiphertext2Handles, GroupedElGamalCiphertext3Handles,
+};
 use {
     crate::{
         encryption::{FeeCiphertext, TransferAmountCiphertext},
@@ -13,7 +15,9 @@ use {
     curve25519_dalek::scalar::Scalar,
     solana_zk_sdk::{
         encryption::{
-            auth_encryption::{AeCiphertext, AeKey}, elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey}, pedersen::{Pedersen, PedersenCommitment, PedersenOpening}
+            auth_encryption::{AeCiphertext, AeKey},
+            elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+            pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
         },
         zk_elgamal_proof_program::proof_data::{
             BatchedGroupedCiphertext2HandlesValidityProofData,
@@ -264,15 +268,17 @@ pub fn transfer_with_fee_split_proof_data(
         &fee_opening_lo,
     );
     #[cfg(target_arch = "wasm32")]
-    let fee_destination_withdraw_withheld_authority_ciphertext_lo = GroupedElGamalCiphertext2Handles::encryption_with_u64(
-        destination_elgamal_pubkey,
-        withdraw_withheld_authority_elgamal_pubkey,
-        fee_amount_lo,
-        &fee_opening_lo
-    );
+    let fee_destination_withdraw_withheld_authority_ciphertext_lo =
+        GroupedElGamalCiphertext2Handles::encryption_with_u64(
+            destination_elgamal_pubkey,
+            withdraw_withheld_authority_elgamal_pubkey,
+            fee_amount_lo,
+            &fee_opening_lo,
+        );
 
     #[cfg(not(target_arch = "wasm32"))]
-    let fee_destination_withdraw_withheld_authority_ciphertext_hi = GroupedElGamal::encrypt_with([
+    let fee_destination_withdraw_withheld_authority_ciphertext_hi = GroupedElGamal::encrypt_with(
+        [
             destination_elgamal_pubkey,
             withdraw_withheld_authority_elgamal_pubkey,
         ],
@@ -280,12 +286,13 @@ pub fn transfer_with_fee_split_proof_data(
         &fee_opening_hi,
     );
     #[cfg(target_arch = "wasm32")]
-    let fee_destination_withdraw_withheld_authority_ciphertext_hi = GroupedElGamalCiphertext2Handles::encryption_with_u64(
-        destination_elgamal_pubkey,
-        withdraw_withheld_authority_elgamal_pubkey,
-        fee_amount_hi,
-        &fee_opening_hi,
-    );
+    let fee_destination_withdraw_withheld_authority_ciphertext_hi =
+        GroupedElGamalCiphertext2Handles::encryption_with_u64(
+            destination_elgamal_pubkey,
+            withdraw_withheld_authority_elgamal_pubkey,
+            fee_amount_hi,
+            &fee_opening_hi,
+        );
 
     // generate fee ciphertext validity data
     let fee_ciphertext_validity_proof_data =

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "wasm:build": "cargo build -p spl-token-2022 --target=\"wasm32-unknown-unknown\"",
     "programs:build": "zx ./scripts/rust/build-sbf.mjs program",
+    "programs:build-wasm": "zx ./scripts/rust/build-wasm.mjs program",
     "programs:test": "zx ./scripts/rust/test-sbf.mjs program",
     "programs:format": "zx ./scripts/rust/format.mjs program",
     "programs:lint": "zx ./scripts/rust/lint.mjs program",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "wasm:build": "cargo build -p spl-token-2022 --target=\"wasm32-unknown-unknown\"",
     "programs:build": "zx ./scripts/rust/build-sbf.mjs program",
     "programs:test": "zx ./scripts/rust/test-sbf.mjs program",
     "programs:format": "zx ./scripts/rust/format.mjs program",

--- a/program/src/extension/confidential_transfer_fee/processor.rs
+++ b/program/src/extension/confidential_transfer_fee/processor.rs
@@ -29,7 +29,6 @@ use {
         processor::Processor,
         solana_zk_sdk::encryption::pod::elgamal::PodElGamalPubkey,
     },
-    bytemuck::Zeroable,
     solana_account_info::{next_account_info, AccountInfo},
     solana_msg::msg,
     solana_program_error::{ProgramError, ProgramResult},
@@ -37,6 +36,9 @@ use {
     spl_pod::optional_keys::OptionalNonZeroPubkey,
     spl_token_confidential_transfer_proof_extraction::instruction::verify_and_extract_context,
 };
+
+#[cfg(not(target_arch = "wasm32"))]
+use bytemuck::Zeroable;
 
 /// Processes an [`InitializeConfidentialTransferFeeConfig`] instruction.
 fn process_initialize_confidential_transfer_fee_config(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.84.1"
+targets = ["wasm32-unknown-unknown"]

--- a/scripts/rust/build-wasm.mjs
+++ b/scripts/rust/build-wasm.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import {
+  cliArguments,
+  workingDirectory,
+} from '../utils.mjs';
+
+const [folder, ...args] = cliArguments();
+const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+await $`cargo build --target wasm32-unknown-unknown --manifest-path ${manifestPath} ${args}`;


### PR DESCRIPTION
### Description

- Introduced conditional compilation for WASM target architecture in burn.rs, mint.rs, transfer.rs, and transfer_with_fee.rs.
   
- Add a new job in the GitHub Actions workflow to build the `spl-token-2022` codebase for the WASM target architecture.

This should ensure no future regressions.

Fixes #293