### PR TITLE
js-legacy: Add more examples

### DIFF
--- a/clients/js-legacy/examples/group.ts
+++ b/clients/js-legacy/examples/group.ts
@@ -1,0 +1,53 @@
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    LAMPORTS_PER_SOL,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+} from '@solana/web3.js';
+import {
+    createInitializeGroupPointerInstruction,
+    createInitializeGroupMemberPointerInstruction,
+    createInitializeMintInstruction,
+    ExtensionType,
+    getMintLen,
+    TOKEN_2022_PROGRAM_ID,
+} from '@solana/spl-token';
+
+(async () => {
+    const payer = Keypair.generate();
+    const mint = Keypair.generate();
+    const decimals = 9;
+    const mintLen = getMintLen([ExtensionType.GroupPointer, ExtensionType.GroupMemberPointer]);
+
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({
+        signature: airdropSignature,
+        ...(await connection.getLatestBlockhash()),
+    });
+
+    const mintLamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const mintTransaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mint.publicKey,
+            space: mintLen,
+            lamports: mintLamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializeGroupPointerInstruction(mint.publicKey, payer.publicKey, mint.publicKey, TOKEN_2022_PROGRAM_ID),
+        createInitializeGroupMemberPointerInstruction(
+            mint.publicKey,
+            payer.publicKey,
+            mint.publicKey,
+            TOKEN_2022_PROGRAM_ID,
+        ),
+        createInitializeMintInstruction(mint.publicKey, decimals, payer.publicKey, null, TOKEN_2022_PROGRAM_ID),
+    );
+    const sig = await sendAndConfirmTransaction(connection, mintTransaction, [payer, mint]);
+    console.log('Signature:', sig);
+})();

--- a/clients/js-legacy/examples/pausable.ts
+++ b/clients/js-legacy/examples/pausable.ts
@@ -1,0 +1,52 @@
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+    LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import {
+    createInitializeMintInstruction,
+    createInitializePausableConfigInstruction,
+    getMintLen,
+    pause,
+    resume,
+    ExtensionType,
+    TOKEN_2022_PROGRAM_ID,
+} from '../src';
+
+(async () => {
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const payer = Keypair.generate();
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({ signature: airdropSignature, ...(await connection.getLatestBlockhash()) });
+
+    const mintKeypair = Keypair.generate();
+    const decimals = 9;
+    const mintLen = getMintLen([ExtensionType.PausableConfig]);
+    const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mintKeypair.publicKey,
+            space: mintLen,
+            lamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializePausableConfigInstruction(mintKeypair.publicKey, payer.publicKey, TOKEN_2022_PROGRAM_ID),
+        createInitializeMintInstruction(
+            mintKeypair.publicKey,
+            decimals,
+            payer.publicKey,
+            payer.publicKey,
+            TOKEN_2022_PROGRAM_ID,
+        ),
+    );
+    await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
+
+    await pause(connection, payer, mintKeypair.publicKey, payer);
+    await resume(connection, payer, mintKeypair.publicKey, payer);
+})();

--- a/clients/js-legacy/examples/scaledUiAmount.ts
+++ b/clients/js-legacy/examples/scaledUiAmount.ts
@@ -1,0 +1,67 @@
+import {
+    clusterApiUrl,
+    Connection,
+    Keypair,
+    sendAndConfirmTransaction,
+    SystemProgram,
+    Transaction,
+    LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import {
+    createInitializeMintInstruction,
+    createInitializeScaledUiAmountConfigInstruction,
+    getMintLen,
+    updateMultiplier,
+    ExtensionType,
+    TOKEN_2022_PROGRAM_ID,
+} from '../src';
+
+(async () => {
+    const connection = new Connection(clusterApiUrl('devnet'), 'confirmed');
+
+    const payer = Keypair.generate();
+    const airdropSignature = await connection.requestAirdrop(payer.publicKey, 2 * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction({ signature: airdropSignature, ...(await connection.getLatestBlockhash()) });
+
+    const mintKeypair = Keypair.generate();
+    const decimals = 9;
+    const multiplier = 10.1;
+    const mintLen = getMintLen([ExtensionType.ScaledUiAmountConfig]);
+    const lamports = await connection.getMinimumBalanceForRentExemption(mintLen);
+    const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: mintKeypair.publicKey,
+            space: mintLen,
+            lamports,
+            programId: TOKEN_2022_PROGRAM_ID,
+        }),
+        createInitializeScaledUiAmountConfigInstruction(
+            mintKeypair.publicKey,
+            payer.publicKey,
+            multiplier,
+            TOKEN_2022_PROGRAM_ID,
+        ),
+        createInitializeMintInstruction(
+            mintKeypair.publicKey,
+            decimals,
+            payer.publicKey,
+            payer.publicKey,
+            TOKEN_2022_PROGRAM_ID,
+        ),
+    );
+    await sendAndConfirmTransaction(connection, transaction, [payer, mintKeypair]);
+
+    const newMultiplier = 50;
+    await updateMultiplier(
+        connection,
+        payer,
+        mintKeypair.publicKey,
+        payer.publicKey,
+        newMultiplier,
+        BigInt(0),
+        [],
+        undefined,
+        TOKEN_2022_PROGRAM_ID,
+    );
+})();


### PR DESCRIPTION
#### Problem

The group, pausable, and scaled-ui-amount extensions have been in the code for some time, but there aren't any JS examples about how to use them.

#### Summary of changes

Similar to most other examples, add some lines about how to use them with the JS legacy client.