### PR TITLE
deps: Bump all SPL deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -784,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -3023,7 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if 1.0.0",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5160,10 +5160,10 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-sysvar",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.6.0",
  "thiserror 2.0.12",
  "zstd",
 ]
@@ -6565,7 +6565,7 @@ dependencies = [
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
  "strum 0.24.1",
@@ -7395,7 +7395,7 @@ dependencies = [
  "solana-version",
  "solana-vote",
  "solana-vote-program",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cancel",
  "thiserror 2.0.12",
@@ -8491,10 +8491,10 @@ dependencies = [
  "solana-transaction-status-client-types",
  "spl-associated-token-account",
  "spl-memo",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.6.0",
  "thiserror 2.0.12",
 ]
 
@@ -8894,7 +8894,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-associated-token-account-client",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-2022 6.0.0",
  "thiserror 1.0.69",
 ]
@@ -9162,6 +9162,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-token"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053067c6a82c705004f91dae058b11b4780407e9ccd6799dc9e7d0fab5f242da"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sysvar",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "spl-token-2022"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9178,12 +9206,12 @@ dependencies = [
  "spl-elgamal-registry 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo",
  "spl-pod",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-confidential-transfer-proof-extraction 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-confidential-transfer-proof-generation 0.2.0",
  "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.6.0",
  "spl-transfer-hook-interface 0.9.0",
  "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
@@ -9235,14 +9263,14 @@ dependencies = [
  "spl-memo",
  "spl-pod",
  "spl-tlv-account-resolution 0.10.0",
- "spl-token",
+ "spl-token 8.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1",
  "spl-token-confidential-transfer-proof-extraction 0.2.1",
  "spl-token-confidential-transfer-proof-generation 0.3.0",
  "spl-token-group-interface 0.6.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.7.0",
  "spl-transfer-hook-interface 0.10.0",
- "spl-type-length-value 0.7.0",
+ "spl-type-length-value 0.8.0",
  "test-case",
  "thiserror 2.0.12",
 ]
@@ -9264,12 +9292,12 @@ dependencies = [
  "spl-elgamal-registry 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-memo",
  "spl-pod",
- "spl-token",
+ "spl-token 7.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-confidential-transfer-proof-extraction 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-confidential-transfer-proof-generation 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-group-interface 0.5.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.6.0",
  "spl-transfer-hook-interface 0.9.0",
  "spl-type-length-value 0.7.0",
  "thiserror 2.0.12",
@@ -9301,12 +9329,12 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account-client",
  "spl-memo",
- "spl-token",
+ "spl-token 8.0.0",
  "spl-token-2022 7.0.0",
  "spl-token-client",
  "spl-token-confidential-transfer-proof-generation 0.3.0",
  "spl-token-group-interface 0.6.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.7.0",
  "strum 0.27.1",
  "strum_macros 0.27.1",
  "tempfile",
@@ -9339,12 +9367,12 @@ dependencies = [
  "spl-pod",
  "spl-record",
  "spl-tlv-account-resolution 0.10.0",
- "spl-token",
+ "spl-token 8.0.0",
  "spl-token-2022 7.0.0",
  "spl-token-confidential-transfer-proof-extraction 0.2.1",
  "spl-token-confidential-transfer-proof-generation 0.3.0",
  "spl-token-group-interface 0.6.0",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.7.0",
  "spl-transfer-hook-interface 0.10.0",
  "test-case",
  "thiserror 2.0.12",
@@ -9505,6 +9533,27 @@ dependencies = [
  "spl-pod",
  "spl-type-length-value 0.7.0",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304d6e06f0de0c13a621464b1fd5d4b1bebf60d15ca71a44d3839958e0da16ee"
+dependencies = [
+ "borsh 1.5.6",
+ "num-derive",
+ "num-traits",
+ "solana-borsh",
+ "solana-decode-error",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+ "spl-discriminator",
+ "spl-pod",
+ "spl-type-length-value 0.8.0",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -31,11 +31,11 @@ solana-remote-wallet = "2.2.0"
 solana-sdk = "2.2.1"
 solana-transaction-status = "2.2.0"
 spl-associated-token-account-client = { version = "2.0.0" }
-spl-token = { version = "7.0", features = ["no-entrypoint"] }
+spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "7.0.0", path = "../../program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.14.0", path = "../rust-legacy" }
 spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "../../confidential-transfer/proof-generation" }
-spl-token-metadata-interface = { version = "0.6.0" }
+spl-token-metadata-interface = { version = "0.7.0" }
 spl-token-group-interface = { version = "0.6.0" }
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
 strum = "0.27"

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -30,12 +30,12 @@ spl-associated-token-account-client = { version = "2.0.0" }
 spl-elgamal-registry = { version = "0.1.1", path = "../../confidential-transfer/elgamal-registry"}
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
 spl-record = { version = "0.3.0", features = ["no-entrypoint"] }
-spl-token = { version = "7.0", features = ["no-entrypoint"] }
+spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-confidential-transfer-proof-extraction = { version = "0.2.1", path = "../../confidential-transfer/proof-extraction" }
 spl-token-confidential-transfer-proof-generation = { version = "0.3.0", path = "../../confidential-transfer/proof-generation" }
 spl-token-2022 = { version = "7.0.0", path = "../../program" }
 spl-token-group-interface = { version = "0.6.0" }
-spl-token-metadata-interface = { version = "0.6.0" }
+spl-token-metadata-interface = { version = "0.7.0" }
 spl-transfer-hook-interface = { version = "0.10.0" }
 thiserror = "2.0"
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -45,13 +45,13 @@ solana-system-interface = "1.0.0"
 solana-zk-sdk = "2.2.0"
 spl-elgamal-registry = { version = "0.1.1", path = "../confidential-transfer/elgamal-registry", features = ["no-entrypoint"] }
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
-spl-token = { version = "7.0", features = ["no-entrypoint"] }
+spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-confidential-transfer-ciphertext-arithmetic = { version = "0.2.1", path = "../confidential-transfer/ciphertext-arithmetic" }
 spl-token-confidential-transfer-proof-extraction = { version = "0.2.1", path = "../confidential-transfer/proof-extraction" }
 spl-token-group-interface = { version = "0.6.0" }
-spl-token-metadata-interface = { version = "0.6.0" }
+spl-token-metadata-interface = { version = "0.7.0" }
 spl-transfer-hook-interface = { version = "0.10.0" }
-spl-type-length-value = { version = "0.7.0" }
+spl-type-length-value = { version = "0.8.0" }
 spl-pod = { version = "0.5.1" }
 thiserror = "2.0"
 serde = { version = "1.0.219", optional = true }


### PR DESCRIPTION
#### Problem

All of the SPL deps have finally been upgraded to use the component crates rather than solana-program, but token-2022 still has a transitive dependency on solana-program.

#### Summary of changes

Bump all SPL deps and make the spl-token-2022 crate smaller! This brings down the number of deps built from 188 to 155, and drops the build time from 21s to 18s on my machine.