### PR TITLE
CI: Add semver-checks to publish workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,27 +249,6 @@ jobs:
       - name: Run cargo-audit
         run: pnpm rust:audit
 
-  semver_rust:
-    name: Check semver Rust
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup
-        with:
-          cli: true
-          cargo-cache-key: cargo-semver
-
-      - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-semver-checks
-
-      - name: Run semver checks
-        run: pnpm rust:semver
-
   spellcheck_rust:
     name: Spellcheck Rust
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -6,7 +6,17 @@ on:
       package_path:
         description: Path to directory with package to release
         required: true
-        type: string
+        default: 'clients/cli'
+        type: choice
+        options:
+          - clients/cli
+          - clients/rust-legacy
+          - confidential-transfer/ciphertext-arithmetic
+          - confidential-transfer/elgamal-registry
+          - confidential-transfer/proof-extraction
+          - confidential-transfer/proof-generation
+          - confidential-transfer/proof-tests
+          - program
       level:
         description: Level
         required: true
@@ -70,10 +80,45 @@ jobs:
       - name: Test
         run: pnpm zx ./scripts/rust/test.mjs "${{ inputs.package_path }}"
 
+  semver:
+    name: Check Semver
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-publish-semver-${{ inputs.package_path }}
+          cargo-cache-fallback-key: cargo-publish-semver
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks,cargo-release
+
+      - name: Set Git Author (required for cargo-release)
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Set Version
+        run: |
+          if [ "${{ inputs.level }}" == "version" ]; then
+            LEVEL=${{ inputs.version }}
+          else
+            LEVEL=${{ inputs.level }}
+          fi
+          cargo release $LEVEL --manifest-path "${{ inputs.package_path }}/Cargo.toml" --no-tag --no-publish --no-push --no-confirm --execute
+
+      - name: Check semver
+        run: pnpm rust:semver --manifest-path "${{ inputs.package_path }}/Cargo.toml"
+
   publish:
     name: Publish Rust Crate
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, semver]
     permissions:
       contents: write
     steps:
@@ -86,12 +131,13 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
-          cli: true
           cargo-cache-key: cargo-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-publish
 
-      - name: Install Cargo Release
-        run: which cargo-release || cargo install cargo-release
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:


### PR DESCRIPTION
#### Problem

The semver checks job has been failing for a long time, because it's running on every single pull request.

#### Summary of changes

Just like the other program repos, move the checks to the publish step