### PR TITLE
[elgamal-registry] Add security txt for elgamal-registry and add SECURITY.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8961,6 +8961,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sdk-ids",
+ "solana-security-txt",
  "solana-system-interface",
  "solana-sysvar",
  "solana-zk-sdk",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,11 +14,11 @@ Expect a response as fast as possible in the advisory, typically within 72 hours
 --
 
 If you do not receive a response in the advisory, send an email to
-<security@solana.com> with the full URL of the advisory you have created. DO NOT
+<security@anza.xyz> with the full URL of the advisory you have created. DO NOT
 include attachments or provide detail sufficient for exploitation regarding the
 security issue in this email. **Only provide such details in the advisory**.
 
-If you do not receive a response from <security@solana.com> please followup with
+If you do not receive a response from <security@anza.xyz> please followup with
 the team directly. You can do this in one of the `#Dev Tooling` channels of the
 [Solana Tech discord server](https://solana.com/discord), by pinging the admins
 in the channel and referencing the fact that you submitted a security problem.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,3 +22,17 @@ If you do not receive a response from <security@anza.xyz> please followup with
 the team directly. You can do this in one of the `#Dev Tooling` channels of the
 [Solana Tech discord server](https://solana.com/discord), by pinging the admins
 in the channel and referencing the fact that you submitted a security problem.
+
+## Security Bug Bounties
+
+The Solana Foundation offer bounties for critical security issues. Please
+see the [Agave Security Bug
+Bounties](https://github.com/anza-xyz/agave/security/policy#security-bug-bounties)
+for details on classes of bugs and payment amounts.
+
+## Scope
+
+Only the `spl-token-2022` program is included in the bounty scope, at [program](https://github.com/solana-program/token-2022/tree/master/program).
+
+If you discover a critical security issue in an out-of-scope component, your finding
+may still be valuable.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting security problems
+
+**DO NOT CREATE A GITHUB ISSUE** to report a security problem.
+
+Instead please use this [Report a Vulnerability](https://github.com/solana-program/token-2022/security/advisories/new) link.
+Provide a helpful title and detailed description of the problem.
+
+If you haven't done so already, please **enable two-factor auth** in your GitHub account.
+
+Expect a response as fast as possible in the advisory, typically within 72 hours.
+
+--
+
+If you do not receive a response in the advisory, send an email to
+<security@solana.com> with the full URL of the advisory you have created. DO NOT
+include attachments or provide detail sufficient for exploitation regarding the
+security issue in this email. **Only provide such details in the advisory**.
+
+If you do not receive a response from <security@solana.com> please followup with
+the team directly. You can do this in one of the `#Dev Tooling` channels of the
+[Solana Tech discord server](https://solana.com/discord), by pinging the admins
+in the channel and referencing the fact that you submitted a security problem.

--- a/confidential-transfer/elgamal-registry/Cargo.toml
+++ b/confidential-transfer/elgamal-registry/Cargo.toml
@@ -23,6 +23,7 @@ solana-program-error = "2.2.1"
 solana-pubkey = { version = "2.2.1", features = ["curve25519"] }
 solana-rent = "2.2.1"
 solana-sdk-ids = "2.2.1"
+solana-security-txt = "1.1.1"
 solana-system-interface = { version = "1.0.0", features = ["bincode"] }
 solana-sysvar = { version = "2.2.1", features = ["bincode"] }
 solana-zk-sdk = "2.2.0"

--- a/confidential-transfer/elgamal-registry/src/entrypoint.rs
+++ b/confidential-transfer/elgamal-registry/src/entrypoint.rs
@@ -4,6 +4,7 @@
 
 use {
     solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
+    solana_security_txt::security_txt,
 };
 
 solana_program_entrypoint::entrypoint!(process_instruction);
@@ -13,4 +14,16 @@ fn process_instruction(
     instruction_data: &[u8],
 ) -> ProgramResult {
     crate::processor::process_instruction(program_id, accounts, instruction_data)
+}
+
+security_txt! {
+    // Required fields
+    name: "SPL Record",
+    project_url: "https://solana-program.com/record",
+    contacts: "link:https://github.com/solana-program/record/security/advisories/new,mailto:security@anza.xyz,discord:https://solana.com/discord",
+    policy: "https://github.com/solana-program/record/blob/master/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-program/record/tree/master/program"
 }

--- a/confidential-transfer/elgamal-registry/src/entrypoint.rs
+++ b/confidential-transfer/elgamal-registry/src/entrypoint.rs
@@ -18,12 +18,12 @@ fn process_instruction(
 
 security_txt! {
     // Required fields
-    name: "SPL Record",
-    project_url: "https://solana-program.com/record",
-    contacts: "link:https://github.com/solana-program/record/security/advisories/new,mailto:security@anza.xyz,discord:https://solana.com/discord",
-    policy: "https://github.com/solana-program/record/blob/master/SECURITY.md",
+    name: "SPL ElGamal Registry",
+    project_url: "https://solana-program.com",
+    contacts: "link:https://github.com/solana-program/token-2022/security/advisories/new,mailto:security@anza.xyz,discord:https://solana.com/discord",
+    policy: "https://github.com/solana-program/token-2022/blob/master/SECURITY.md",
 
     // Optional Fields
     preferred_languages: "en",
-    source_code: "https://github.com/solana-program/record/tree/master/program"
+    source_code: "https://github.com/solana-program/token-2022/tree/master/confidential-transfer/elgamal-registry"
 }


### PR DESCRIPTION
#### Problem

There is no security-txt in the elgamal registry program yet.

#### Summary of Changes

This is analogous to https://github.com/solana-program/record/pull/52. I added security-txt and also SECURITY.md for the repo.