### PR TITLE
CI: Don't make wasm required

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,6 +25,9 @@ inputs:
   purge:
     description: Purge unused directories if `true`. Defaults to `false`.
     required: false
+  wasm:
+    description: Install wasm target for Rust if `true`. Defaults to `false`.
+    required: false
 
 runs:
   using: 'composite'
@@ -105,6 +108,11 @@ runs:
       if: ${{ inputs.cli == 'true' }}
       shell: bash
       run: sudo apt update && sudo apt install libudev-dev protobuf-compiler -y
+
+    - name: Install wasm target
+      if: ${{ inputs.wasm == 'true' }}
+      shell: bash
+      run: rustup target add wasm32-unknown-unknown
 
     - name: Cache Cargo Dependencies
       if: ${{ inputs.cargo-cache-key && !inputs.cargo-cache-fallback-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,6 +269,23 @@ jobs:
       - name: Run cargo-spellcheck
         run: pnpm rust:spellcheck
 
+  wasm:
+    name: Check wasm build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-wasm
+          wasm: true
+
+      - name: Build Token-2022 Wasm
+        run: pnpm programs:build-wasm
+
+
   build_programs:
     name: Build programs
     runs-on: ubuntu-latest
@@ -285,9 +302,6 @@ jobs:
 
       - name: Build Token-2022
         run: pnpm programs:build
-
-      - name: Build Token-2022 Wasm
-        run: pnpm programs:build-wasm
 
       - name: Build ElGamal Registry
         run: pnpm confidential-transfer:elgamal-registry:build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.84.1"
-targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
#### Problem

The wasm build was added as a default additional target, which is only necessary for one CI step.

This means that almost every CI step also ends up downloading the wasm target information. Here's one example:
https://github.com/solana-program/token-2022/actions/runs/14239419386/job/39905681594

#### Summary of changes

* Move the wasm build to a separate CI step, that specifically installs the wasm target.
* Remove the wasm target from the list of default targets