### PR TITLE
Update comment for pending_balance_hi

### DIFF
--- a/program/src/extension/confidential_transfer/mod.rs
+++ b/program/src/extension/confidential_transfer/mod.rs
@@ -87,7 +87,7 @@ pub struct ConfidentialTransferAccount {
     /// The low 16 bits of the pending balance (encrypted by `elgamal_pubkey`)
     pub pending_balance_lo: EncryptedBalance,
 
-    /// The high 48 bits of the pending balance (encrypted by `elgamal_pubkey`)
+    /// The high 32 bits of the pending balance (encrypted by `elgamal_pubkey`)
     pub pending_balance_hi: EncryptedBalance,
 
     /// The available balance (encrypted by `encryption_pubkey`)


### PR DESCRIPTION
The comment  of pending_balance_hi seems wrong, It's actual the high 32 bits of the pending balance.