### PR TITLE
CI: Fix auto-publish

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
+          cli: true
           cargo-cache-key: cargo-publish-semver-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-publish-semver
 
@@ -131,6 +132,7 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
         with:
+          cli: true
           cargo-cache-key: cargo-publish-${{ inputs.package_path }}
           cargo-cache-fallback-key: cargo-publish
 


### PR DESCRIPTION
#### Problem

The auto-publish job failed for spl-token-client because of some missing system dependencies:
https://github.com/solana-program/token-2022/actions/runs/14783911331/job/41508609680

#### Summary of changes

Also install the CLI deps in the semver and publish steps.