### PR TITLE
Add token mint permissioning 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9536,6 +9536,7 @@ dependencies = [
  "spl-transfer-hook-interface 0.10.0",
  "test-case",
  "thiserror 2.0.12",
+ "token-whitelist-interface",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,32 +64,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "affinity"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763e484feceb7dd021b21c5c6f81aee06b1594a743455ec7efbf72e6355e447b"
-dependencies = [
- "cfg-if 1.0.0",
- "errno",
- "libc",
- "num_cpus",
-]
-
-[[package]]
 name = "agave-banking-stage-ingress-types"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1fb85c09da8aebdb52e9ecb6e66d359a02efacd4b40c6cd79f50039327bf4e"
+checksum = "59e77af8230dc18370e34702e93584108ba7af1a1bc47cfeb6341787eb172baa"
 dependencies = [
  "crossbeam-channel",
  "solana-perf",
 ]
 
 [[package]]
-name = "agave-geyser-plugin-interface"
-version = "2.2.1"
+name = "agave-feature-set"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df63ffb691b27f0253e893d083126cbe98a6b1ace29108992310f323f1ac50b0"
+checksum = "973a83d0d66d1f04647d1146a07736864f0742300b56bf2a5aadf5ce7b22fe47"
+dependencies = [
+ "ahash 0.8.11",
+ "solana-epoch-schedule",
+ "solana-feature-set-interface",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "agave-geyser-plugin-interface"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9540aa46d40eca886bb7716345bfe6051ed39f926962dbe04b7abfc8f9e4f594"
 dependencies = [
  "log",
  "solana-clock",
@@ -100,29 +102,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "agave-thread-manager"
-version = "2.2.1"
+name = "agave-precompiles"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc27cbfbda0a3c19799936ad20b802db086c20105323d1d8885da4e7d5bf4ec"
+checksum = "591ddfc881b44f1eb740b5f6b64c953ba46b003cf0cd49d56268bc70594f655d"
 dependencies = [
- "affinity",
- "anyhow",
- "cfg-if 1.0.0",
- "log",
- "num_cpus",
- "rayon",
- "serde",
- "solana-metrics",
- "thread-priority",
- "tokio",
- "toml 0.8.20",
+ "agave-feature-set",
+ "bincode",
+ "bytemuck",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "lazy_static",
+ "libsecp256k1",
+ "openssl",
+ "sha3",
+ "solana-ed25519-program",
+ "solana-message",
+ "solana-precompile-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-secp256k1-program",
+ "solana-secp256r1-program",
+]
+
+[[package]]
+name = "agave-reserved-account-keys"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498ae700a5abcfe54d26333c3c1e58c729150d30166940e1f38eafbfe595237e"
+dependencies = [
+ "agave-feature-set",
+ "lazy_static",
+ "solana-pubkey",
+ "solana-sdk-ids",
 ]
 
 [[package]]
 name = "agave-transaction-view"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba2aec0682aa448f93db9b93df8fb331c119cb4d66fe9ba61d6b42dd3a91105"
+checksum = "fe519820242ff25cf40fbd44b7c3ee585674de332a1f43fc2a0923975194c472"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -140,7 +159,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
@@ -152,10 +171,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -264,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "aquamarine"
@@ -279,7 +298,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -497,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.20"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
+checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
 dependencies = [
  "brotli",
  "flate2",
@@ -539,7 +558,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -550,7 +569,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -631,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "instant",
  "pin-project-lite",
  "rand 0.8.5",
@@ -703,7 +722,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -747,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.6.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -820,7 +839,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -847,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "cf19e729cdbd51af9a397fb9ef8ac8378007b797f8273cfbfdf45dcaa316167b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -858,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -877,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -913,13 +932,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -966,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1016,14 +1035,14 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1097,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1107,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1119,14 +1138,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1241,6 +1260,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1391,14 +1420,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1406,27 +1435,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1445,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "der-parser"
@@ -1465,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1492,26 +1521,26 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1532,7 +1561,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -1612,7 +1641,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1635,7 +1664,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1694,7 +1723,7 @@ dependencies = [
  "derivation-path",
  "ed25519-dalek",
  "hmac 0.12.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1747,7 +1776,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1760,7 +1789,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1784,9 +1813,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1833,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
@@ -1891,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "five8_core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94474d15a76982be62ca8a39570dccce148d98c238ebb7408b0a21b2c4bdddc4"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
 
 [[package]]
 name = "fixedbitset"
@@ -1903,9 +1932,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1928,9 +1957,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1958,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs_extra"
@@ -2031,7 +2060,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2106,9 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2119,14 +2148,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2205,10 +2236,10 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.15",
  "tracing",
 ]
 
@@ -2247,9 +2278,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2407,9 +2438,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -2494,14 +2525,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -2556,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -2580,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -2601,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -2630,7 +2662,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2731,12 +2763,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "rayon",
  "serde",
 ]
@@ -2810,16 +2842,18 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
+ "cfg-if 1.0.0",
  "combine 4.6.7",
  "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2830,10 +2864,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -2864,7 +2899,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "futures 0.3.31",
  "jsonrpc-core",
  "jsonrpc-pubsub",
@@ -2985,7 +3020,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35523c6dfa972e1fd19132ef647eff4360a6546c6271807e1327ca6e8797f96"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -3002,9 +3037,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -3028,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -3040,7 +3075,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.12",
 ]
 
 [[package]]
@@ -3114,15 +3149,15 @@ checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
 dependencies = [
  "anstream",
  "anstyle",
- "clap 4.5.31",
+ "clap 4.5.37",
  "escape8259",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3149,9 +3184,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -3171,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
@@ -3281,9 +3316,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -3365,7 +3400,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3481,7 +3516,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3553,7 +3588,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3582,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -3615,7 +3650,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3626,18 +3661,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -3720,7 +3755,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3781,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -3792,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3802,26 +3837,26 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3831,7 +3866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -3851,7 +3886,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3868,9 +3903,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinocchio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81225b3b8ce092ac54e0d1c55a962be61efcad1d021030f0eb660875703db562"
+checksum = "7c33b58567c11b07749cefbb8320ac023f3387c57807aeb8e3b1262501b6e9f0"
 
 [[package]]
 name = "pinocchio-pubkey"
@@ -3914,11 +3949,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -3993,7 +4028,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -4028,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -4135,7 +4170,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4161,34 +4196,36 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.2",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -4200,9 +4237,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.10"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4214,12 +4251,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -4246,6 +4289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,7 +4343,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -4350,9 +4422,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -4363,7 +4435,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -4440,7 +4512,7 @@ dependencies = [
  "percent-encoding 2.3.1",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4449,7 +4521,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.15",
  "tower-service",
  "url 2.5.4",
  "wasm-bindgen",
@@ -4476,13 +4548,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -4509,23 +4581,23 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.3.1"
+version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4579,14 +4651,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.2",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -4604,29 +4676,28 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -4636,15 +4707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4658,23 +4720,23 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
+checksum = "4937d110d34408e9e5ad30ba0b0ca3b6a8a390f8db3636db60144ac4fa792750"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.8",
- "security-framework",
+ "rustls-webpki 0.103.1",
+ "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4695,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4739,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
 dependencies = [
  "sdd",
 ]
@@ -4773,9 +4835,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "security-framework"
@@ -4784,10 +4846,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
- "num-bigint 0.4.6",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "libc",
  "security-framework-sys",
 ]
 
@@ -4836,9 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364fec0df39c49a083c9a8a18a23a6bcfd9af130fe9fe321d18520a0d113e09e"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]
@@ -4851,7 +4925,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4863,15 +4937,6 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
  "serde",
 ]
 
@@ -4897,7 +4962,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4914,7 +4979,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4923,7 +4988,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -4952,7 +5017,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4994,9 +5059,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -5037,9 +5102,9 @@ dependencies = [
 
 [[package]]
 name = "shank_macro_impl"
-version = "0.4.3-alpha.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0319bb9cbbac08b68f9ffb1029c4d9a355af1bdc33bb74790b2cb6dc63e8e3"
+checksum = "77600cea17431d53e8aa47c44d340da7ff0601eec934aca3c6676de367e5ce83"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5081,10 +5146,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
+name = "signal-hook"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -5128,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smpl_jwt"
@@ -5150,9 +5225,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5193,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c472eebf9ec7ee72c8d25e990a2eaf6b0b783619ef84d7954c408d6442ad5e57"
+checksum = "fc13737697fe2ab4475bcae71525e37abd2b357a12dc68fc3e0938dd1a0dcbfd"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -5232,9 +5307,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3485b583fcc58b5fa121fa0b4acb90061671fb1a9769493e8b4ad586581f47"
+checksum = "96c5d7d0f1581d98a869f2569122ded67e0735f3780d787b3e7653bdcd1708a2"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5261,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-db"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65a1a23a53cae19cb92bab2cbdd9e289e5210bb12175ce27642c94adf74b220"
+checksum = "611e285c3d1c7ea383498a7a55d462a475614af9e3201fa9bf78a18b9f49ad67"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -5275,7 +5350,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "index_list",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.12.1",
  "lazy_static",
  "log",
@@ -5302,6 +5377,7 @@ dependencies = [
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-svm-transaction",
+ "solana-transaction-context",
  "static_assertions",
  "tar",
  "tempfile",
@@ -5327,10 +5403,11 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c758a82a60e5fcc93b3ee00615b0e244295aa8b2308475ea2b48f4900862a2e0"
+checksum = "20ba90bbe1e9a7354763520ae5fa5f610712250a65891cf54d490b1fcc486244"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "bytemuck",
  "log",
@@ -5339,7 +5416,6 @@ dependencies = [
  "solana-address-lookup-table-interface",
  "solana-bincode",
  "solana-clock",
- "solana-feature-set",
  "solana-instruction",
  "solana-log-collector",
  "solana-packet",
@@ -5361,15 +5437,16 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420dc40674f4a4df1527277033554b1a1b84a47e780cdb7dad151426f5292e55"
+checksum = "a1f32510172470e5d3c2c4fbb125024fe715bb903a368df0085a1098f3b693bd"
 dependencies = [
  "borsh 1.5.7",
  "futures 0.3.31",
  "solana-banks-interface",
  "solana-program",
  "solana-sdk",
+ "solana-transaction-context",
  "tarpc",
  "thiserror 2.0.12",
  "tokio",
@@ -5378,28 +5455,29 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f8a6b6dc15262f14df6da7332e7dc7eb5fa04c86bf4dfe69385b71c2860d19"
+checksum = "2d07549f0e8d1dbe90117f1595ed77539e3766d3203b3b5c47f999a80c3c754e"
 dependencies = [
  "serde",
  "serde_derive",
  "solana-sdk",
+ "solana-transaction-context",
  "tarpc",
 ]
 
 [[package]]
 name = "solana-banks-server"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea32797f631ff60b3eb3c793b0fddd104f5ffdf534bf6efcc59fbe30cd23b15"
+checksum = "fb80a4350984a3c140b99d444e2b92ee8decac88a8def73cd0ca02e655eb3463"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "crossbeam-channel",
  "futures 0.3.31",
  "solana-banks-interface",
  "solana-client",
- "solana-feature-set",
  "solana-runtime",
  "solana-runtime-transaction",
  "solana-sdk",
@@ -5446,9 +5524,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf4babf9225c318efa34d7017eb3b881ed530732ad4dc59dfbde07f6144f27a"
+checksum = "7be3906e7b8860394a59209b486d37c6b17d15c9dd916bfae5eb034c13b0890f"
 dependencies = [
  "bv",
  "fnv",
@@ -5462,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bn254"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc69625158faaab02347370b91c0d8e0fe347bf9287239f0fbe8f5864d91da"
+checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5487,10 +5565,12 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cbc2581d0f39cd7698e46baa06fc5e8928b323a85ed3a4fdbdfe0d7ea9fc152"
+checksum = "e1732daafbfb0b265998fb55ec223680b95a241eea9209c76427a55491bf4903"
 dependencies = [
+ "agave-feature-set",
+ "agave-precompiles",
  "bincode",
  "libsecp256k1",
  "qualifier_attr",
@@ -5505,7 +5585,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-cpi",
  "solana-curve25519",
- "solana-feature-set",
  "solana-hash",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -5515,7 +5594,6 @@ dependencies = [
  "solana-measure",
  "solana-packet",
  "solana-poseidon",
- "solana-precompiles",
  "solana-program-entrypoint",
  "solana-program-memory",
  "solana-program-runtime",
@@ -5536,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12484b98db9e154d8189a7f632fe0766440abe4e58c5426f47157ece5b8730f3"
+checksum = "063cbccec587c959c8381b6f334588b512e31d44afe993020f5e2999572f8dcd"
 dependencies = [
  "bv",
  "bytemuck",
@@ -5556,15 +5634,15 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab1c09b653992c685c56c611004a1c96e80e76b31a2a2ecc06c47690646b98a"
+checksum = "31cf8956aa23f0837856697c26f74aa76397c8536bce886837d8cf59c06e140a"
 dependencies = [
+ "agave-feature-set",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-feature-set",
  "solana-loader-v4-program",
  "solana-program-runtime",
  "solana-pubkey",
@@ -5578,10 +5656,11 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ee734c35b736e632aa3b1367f933d93ee7b4129dd1e20ca942205d4834054e"
+checksum = "b17a9aaf602cc61c84932675690fa61d711b5a4879789b74a3162ffcbd255177"
 dependencies = [
+ "agave-feature-set",
  "ahash 0.8.11",
  "lazy_static",
  "log",
@@ -5590,7 +5669,6 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
  "solana-config-program",
- "solana-feature-set",
  "solana-loader-v4-program",
  "solana-pubkey",
  "solana-sdk-ids",
@@ -5601,9 +5679,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9ef7be5c7a6fde4ae6864279a98d48a9454f70b0d3026bc37329e7f632fba6"
+checksum = "eb3c210e89742f6c661eb4e7549eb779dbc56cab4b700a1fd761cd7c9b2de6e6"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -5630,9 +5708,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e0d663063c8949b0f71b96b5116acd46322072c8be5d1f0e385e72a3941fb"
+checksum = "9f945634dcb7b4db6d39bbee568e3549a0b4501e1375e94be93f01a9393f0122"
 dependencies = [
  "chrono",
  "clap 3.2.25",
@@ -5661,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdfa01757b1e6016028ad3bb35eb8efd022aadab0155621aedd71f0c566f03a"
+checksum = "6cdb4a08bb852494082cd115e3b654b5505af4d2c0e9d24e602553d36dc2f1f5"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -5677,11 +5755,12 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07214f677077717053580642e7c7f90d471d03a48874792e5fca876443dff830"
+checksum = "2cb32fc9a40d6489c20f641347fb0d61fd35a67c6c3703a212c56e23ee238499"
 dependencies = [
  "Inflector",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "chrono",
  "clap 2.34.0",
@@ -5705,7 +5784,6 @@ dependencies = [
  "solana-packet",
  "solana-program",
  "solana-pubkey",
- "solana-reserved-account-keys",
  "solana-rpc-client-api",
  "solana-sdk-ids",
  "solana-signature",
@@ -5720,16 +5798,16 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e25b7073890561a6b7875a921572fc4a9a2c78b3e60fb8e0a7ee4911961f8bd"
+checksum = "d32a6ae5a74f13425eb0f8503b9a2c0bf59581e98deeee2d0555dfe6f05502c9"
 dependencies = [
  "async-trait",
  "bincode",
  "dashmap",
  "futures 0.3.31",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "indicatif",
  "log",
  "quinn",
@@ -5821,9 +5899,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab40b24943ca51f1214fcf7979807640ea82a8387745f864cf3cd93d1337b01"
+checksum = "a7da7ab5302549d9c6bf399c69a7072abeca78d252d9b7a146be34bf6f8b51e6"
 dependencies = [
  "solana-fee-structure",
  "solana-program-entrypoint",
@@ -5831,16 +5909,16 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6ef2a514cde8dce77495aefd23671dc46f638f504765910424436bc745dc04"
+checksum = "73d8b8697c1cd4e183999162a7c1cb7d7f5674f9e802f97d5d2e439bd7f683f0"
 dependencies = [
+ "agave-feature-set",
  "log",
  "solana-borsh",
  "solana-builtins-default-costs",
  "solana-compute-budget",
  "solana-compute-budget-interface",
- "solana-feature-set",
  "solana-instruction",
  "solana-packet",
  "solana-pubkey",
@@ -5865,9 +5943,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba922073c64647fe62f032787d34d50a8152533b5a5c85608ae1b2afb00ab63"
+checksum = "cf5179f59ab76e2441cfc10e185185326dd4f9389c7acb140b286128f8721c26"
 dependencies = [
  "qualifier_attr",
  "solana-program-runtime",
@@ -5875,9 +5953,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab5647203179631940e0659a635e5d3f514ba60f6457251f8f8fbf3830e56b0"
+checksum = "4072ff53d982deb87be1c15136b0aa9ead472f15eaefdd23d8174d49371e0112"
 dependencies = [
  "bincode",
  "chrono",
@@ -5899,15 +5977,15 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0392439ea05772166cbce3bebf7816bdcc3088967039c7ce050cea66873b1c50"
+checksum = "240bc217ca05f3e1d1d88f1cfda14b785a02288a630419e4a0ecd6b4fa5094b7"
 dependencies = [
  "async-trait",
  "bincode",
  "crossbeam-channel",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -5923,12 +6001,12 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6ddd0c2515aa9fcb6107796fe4af5af17b9d1e49eeb8756588a443b7a8ab20"
+checksum = "f027b4f8603c6aaf3bdbf4a582fb7ea57364af66b289cfa0fcaedf64e322e41a"
 dependencies = [
  "agave-banking-stage-ingress-types",
- "agave-thread-manager",
+ "agave-feature-set",
  "agave-transaction-view",
  "ahash 0.8.11",
  "anyhow",
@@ -5957,7 +6035,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "rolling-file",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -5971,7 +6049,6 @@ dependencies = [
  "solana-connection-cache",
  "solana-cost-model",
  "solana-entry",
- "solana-feature-set",
  "solana-fee",
  "solana-geyser-plugin-manager",
  "solana-gossip",
@@ -6018,10 +6095,11 @@ dependencies = [
 
 [[package]]
 name = "solana-cost-model"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a675ead1473b32a7a5735801608b35cbd8d3f5057ca8dbafdd5976146bb7e9e4"
+checksum = "fcb844530eafa481dc45f434e1684b09fcb594b3a72896caa969ef53df1ed653"
 dependencies = [
+ "agave-feature-set",
  "ahash 0.8.11",
  "lazy_static",
  "log",
@@ -6032,7 +6110,6 @@ dependencies = [
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-compute-budget-interface",
- "solana-feature-set",
  "solana-fee-structure",
  "solana-metrics",
  "solana-packet",
@@ -6061,9 +6138,9 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f213e3a853a23814dee39d730cd3a5583b7b1e6b37b2cd4d940bbe62df7acc16"
+checksum = "e0cf33066cc9a741ff4cc4d171a4a816ea06f9826516b7360d997179a1b3244f"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6101,9 +6178,9 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0c4dfce08d71d8f1e9b7d1b4e2c7101a8109903ad481acbbc1119a73d459f2"
+checksum = "9d0fc717048fdbe5d2ee7d673d73e6a30a094002f4a29ca7630ac01b6bddec04"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -6116,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17eeec2852ad402887e80aa59506eee7d530d27b8c321f4824f8e2e7fe3e8cb2"
+checksum = "d632595ac24dd266f3c28389aa07b478dc2ca2fc71e22eade06725b89953a860"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -6212,9 +6289,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8bd25a809e1763794de4c28d699d859d77947fd7c6b11883c781d2cdfb3cf2"
+checksum = "36ca41dc316b138f8f2d07c993d99b7e48f68d14291975272309e472585505c2"
 dependencies = [
  "bincode",
  "clap 2.34.0",
@@ -6264,9 +6341,9 @@ dependencies = [
 
 [[package]]
 name = "solana-feature-set"
-version = "2.2.1"
+version = "2.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e1d3b52b4a014efeaaab67f14e40af3972a4be61c523d612860db8e3145529"
+checksum = "92f6c09cc41059c0e03ccbee7f5d4cc0a315d68ef0d59b67eb90246adfd8cc35"
 dependencies = [
  "ahash 0.8.11",
  "lazy_static",
@@ -6277,12 +6354,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-fee"
-version = "2.2.1"
+name = "solana-feature-set-interface"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee323b500b445d45624ad99a08b12b37c9964ac12debf2cde9ddfad9b06e0073"
+checksum = "02007757246e40f10aa936dae4fa27efbf8dbd6a59575a12ccc802c1aea6e708"
 dependencies = [
- "solana-feature-set",
+ "ahash 0.8.11",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-fee"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c2ee19fe65b4564b0bf7436f5a609871ddc8fc32b8507c648e46b670052819"
+dependencies = [
+ "agave-feature-set",
  "solana-fee-structure",
  "solana-svm-transaction",
 ]
@@ -6343,9 +6430,9 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8287469a6f059411a3940bbc1b0a428b27104827ae1a80e465a1139f8b0773"
+checksum = "8f00640e55830d226ee28f279f119614a1bcc4327fc1f2b8971ad64056fc2a99"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bs58",
@@ -6374,17 +6461,18 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587f7e73d3ee7173f1f66392f1aeb4e582c055ad30f4e40f3a4b2cf9bce434fe"
+checksum = "34769e60e7836cb76dc3ad75f9216ae2e7061be41c3e2dc412213298402daceb"
 dependencies = [
+ "agave-feature-set",
  "assert_matches",
  "bincode",
  "bv",
  "clap 2.34.0",
  "crossbeam-channel",
  "flate2",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.12.1",
  "log",
  "lru",
@@ -6402,7 +6490,6 @@ dependencies = [
  "solana-client",
  "solana-connection-cache",
  "solana-entry",
- "solana-feature-set",
  "solana-ledger",
  "solana-logger",
  "solana-measure",
@@ -6466,9 +6553,9 @@ dependencies = [
 
 [[package]]
 name = "solana-inline-spl"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951545bd7d0ab4a878cfc7375ac9f1a475cb6936626677b2ba1d25e7b9f3910b"
+checksum = "eaac98c150932bba4bfbef5b52fae9ef445f767d66ded2f1398382149bc94f69"
 dependencies = [
  "bytemuck",
  "solana-pubkey",
@@ -6482,7 +6569,7 @@ checksum = "9ce496a475e5062ba5de97215ab39d9c358f9c9df4bb7f3a45a1f1a8bd9065ed"
 dependencies = [
  "bincode",
  "borsh 1.5.7",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "js-sys",
  "num-traits",
  "serde",
@@ -6555,9 +6642,9 @@ dependencies = [
 
 [[package]]
 name = "solana-lattice-hash"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fff3aab7ad7578d0bd2ac32d232015e535dfe268e35d45881ab22db0ba61c1e"
+checksum = "45cf3899226bc7b729b13d7f65e34120eb5bc9b83b1d2aadfdcbd84473db9030"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -6567,10 +6654,12 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ef5ef594139afbf9db0dd0468a4d904d3275ce07f3afdb3a9b68d38676a75e"
+checksum = "6238e1e17794183793e1a2ee875e43bad89bc708c513ece4e792dcc72b1f9663"
 dependencies = [
+ "agave-feature-set",
+ "agave-reserved-account-keys",
  "assert_matches",
  "bincode",
  "bitflags 2.9.0",
@@ -6602,13 +6691,12 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-bpf-loader-program",
  "solana-cost-model",
  "solana-entry",
- "solana-feature-set",
  "solana-measure",
  "solana-metrics",
  "solana-perf",
@@ -6624,6 +6712,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-transaction",
  "solana-timings",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-vote",
  "solana-vote-program",
@@ -6686,9 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b24999844b09096c79567c1298617efe084860149d875b702ef76e2faa2462"
+checksum = "3ae52276c26e48d494affc7730c2c1e837ae794519e48ab6b22ed3ccf4751f32"
 dependencies = [
  "log",
  "qualifier_attr",
@@ -6712,35 +6801,37 @@ dependencies = [
 
 [[package]]
 name = "solana-log-collector"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa28cd428e0af919d2fafd31c646835622abfd7ed4dba4df68e3c00f461bc66"
+checksum = "45d5713845622a6059a172ea390c2a7f7eb50355cfb0cfa18a38a18ecb39c2f1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593dbcb81439d37b02757e90bd9ab56364de63f378c55db92a6fbd6a2e47ab36"
+checksum = "db8e777ec1afd733939b532a42492d888ec7c88d8b4127a5d867eb45c6eb5cd5"
 dependencies = [
  "env_logger",
  "lazy_static",
+ "libc",
  "log",
+ "signal-hook",
 ]
 
 [[package]]
 name = "solana-measure"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fced2cfeff80f0214af86bc27bc6e798465a45b70329c3b468bb75957c082"
+checksum = "9566e754d9b9bcdee7b4aae38e425d47abf8e4f00057208868cb3ab9bee7feae"
 
 [[package]]
 name = "solana-merkle-tree"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd38db9705b15ff57ddbd9d172c48202dcba078cfc867fe87f01c01d8633fd55"
+checksum = "6b4b2b3386554ff7a54d6b338dc044f8c4bd653d3585ba374eeb5c248edebddb"
 dependencies = [
  "fast-math",
  "solana-hash",
@@ -6772,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89db46736ae1929db9629d779485052647117f3fcc190755519853b705f6dba5"
+checksum = "02311660a407de41df2d5ef4e4118dac7b51cfe81a52362314ea51b091ee4150"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -6805,9 +6896,9 @@ checksum = "33e9de00960197412e4be3902a6cd35e60817c511137aca6c34c66cd5d4017ec"
 
 [[package]]
 name = "solana-net-utils"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0752a7103c1a5bdbda04aa5abc78281232f2eda286be6edf8e44e27db0cca2a1"
+checksum = "c27f0e0bbb972456ed255f81135378ecff3a380252ced7274fa965461ab99977"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6889,9 +6980,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0962d3818fc942a888f7c2d530896aeaf6f2da2187592a67bbdc8cf8a54192"
+checksum = "97222a3fda48570754ce114e43ca56af34741098c357cb8d3cb6695751e60330"
 dependencies = [
  "ahash 0.8.11",
  "bincode",
@@ -6921,9 +7012,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3abf53e6af2bc7f3ebd455112a0eb960378882d780e85b62ff3a70b69e02e6"
+checksum = "11e976a43cc60e1526a3f7740d95f86f4ca7ca94ce0f065b995a382ce7e2eb3b"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -6954,9 +7045,9 @@ dependencies = [
 
 [[package]]
 name = "solana-poseidon"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad1ea160d08dc423c35021fa3e437a5783eb256f5ab8bc3024e27db913acf42"
+checksum = "7a31fc6ac2590217b63ecab02f23df0d5a38ecaa3e69d7194f57a0f30645e9d9"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
@@ -7016,7 +7107,7 @@ dependencies = [
  "bytemuck",
  "console_error_panic_hook",
  "console_log",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "lazy_static",
  "log",
  "memoffset",
@@ -7137,10 +7228,12 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3d36fed5548b1a8625eb071df6031a95aa69f884e29bf244821e53c49372bc"
+checksum = "fbbde7b061921dcff2bf8e0f1af120fa94f2fb0e3a1c2ec1e7900432bb72cbcd"
 dependencies = [
+ "agave-feature-set",
+ "agave-precompiles",
  "base64 0.22.1",
  "bincode",
  "enum-iterator",
@@ -7154,14 +7247,12 @@ dependencies = [
  "solana-compute-budget",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
- "solana-feature-set",
  "solana-hash",
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-log-collector",
  "solana-measure",
  "solana-metrics",
- "solana-precompiles",
  "solana-pubkey",
  "solana-rent",
  "solana-sbpf",
@@ -7178,10 +7269,11 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6caec3df83d39b8da9fd6e80a7847d788b3b869c646fbb8776c3e989e98c0c"
+checksum = "bd21a4746c9cda16b24158d9a9b15252adbea192e06be2c2b6c66ba39435c339"
 dependencies = [
+ "agave-feature-set",
  "assert_matches",
  "async-trait",
  "base64 0.22.1",
@@ -7196,7 +7288,6 @@ dependencies = [
  "solana-banks-server",
  "solana-bpf-loader-program",
  "solana-compute-budget",
- "solana-feature-set",
  "solana-inline-spl",
  "solana-instruction",
  "solana-log-collector",
@@ -7208,6 +7299,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-timings",
+ "solana-transaction-context",
  "solana-vote-program",
  "thiserror 2.0.12",
  "tokio",
@@ -7226,7 +7318,7 @@ dependencies = [
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
  "five8_const",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "js-sys",
  "num-traits",
  "rand 0.8.5",
@@ -7242,9 +7334,9 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd251d37c932105a684415db44bee52e75ad818dfecbf963a605289b5aaecc5"
+checksum = "c9633402b60b93f903d37c940a8ce0c1afc790b5a8678aaa8304f9099adf108b"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -7269,9 +7361,9 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d072e6787b6fa9da86591bcf870823b0d6f87670df3c92628505db7a9131e44"
+checksum = "826ec34b8d4181f0c46efaa84c6b7992a459ca129f21506656d79a1e62633d4b"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -7281,7 +7373,7 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "solana-connection-cache",
  "solana-keypair",
  "solana-measure",
@@ -7309,9 +7401,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f7b65ddd8ac75efcc31b627d4f161046312994313a4520b65a8b14202ab5d6"
+checksum = "423c912a1a68455fe4ed5175cf94eb8965e061cd257973c9a5659e2bf4ea8371"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -7319,9 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3c1e6ec719021564b034c550f808778507db54b6a5de99f00799d9ec86168d"
+checksum = "e71f9dfc6f2a5df04c3fed2b90b0fbf0da3939f3383a9bf24a5c0bcf994f2b10"
 dependencies = [
  "console",
  "dialoguer",
@@ -7405,10 +7497,11 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b978303a9d6f3270ab83fa28ad07a2f4f3181a65ce332b4b5f5d06de5f2a46c5"
+checksum = "e5248ac7118562522269e5f6a909115055e450ab5fed90a94902cf4b334aa2d6"
 dependencies = [
+ "agave-feature-set",
  "base64 0.22.1",
  "bincode",
  "bs58",
@@ -7433,7 +7526,6 @@ dependencies = [
  "solana-client",
  "solana-entry",
  "solana-faucet",
- "solana-feature-set",
  "solana-gossip",
  "solana-inline-spl",
  "solana-ledger",
@@ -7453,6 +7545,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
+ "solana-transaction-context",
  "solana-transaction-status",
  "solana-version",
  "solana-vote",
@@ -7462,14 +7555,14 @@ dependencies = [
  "stream-cancel",
  "thiserror 2.0.12",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.15",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb874b757d9d3c646f031132b20d43538309060a32d02b4aebb0f8fc2cd159a"
+checksum = "3313bc969e1a8681f19a74181d301e5f91e5cc5a60975fb42e793caa9768f22e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7505,9 +7598,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7105452c4f039fd2c07e6fda811ff23bd270c99f91ac160308f02701eb19043"
+checksum = "2dc3276b526100d0f55a7d1db2366781acdc75ce9fe4a9d1bc9c85a885a503f8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7536,9 +7629,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0244e2bf439ec424179414173cdc8b43e34371608752799c5610bf17430eee18"
+checksum = "294874298fb4e52729bb0229e0cdda326d4393b7122b92823aa46e99960cb920"
 dependencies = [
  "solana-account",
  "solana-commitment-config",
@@ -7553,10 +7646,13 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5335e7925f6dc8d2fdcdc6ead3b190aca65f191a11cef74709a7a6ab5d0d5877"
+checksum = "be703a6c2a363663c642407ea6d474109c21760502c9c26e60c88e0665c3e859"
 dependencies = [
+ "agave-feature-set",
+ "agave-precompiles",
+ "agave-reserved-account-keys",
  "ahash 0.8.11",
  "aquamarine",
  "arrayref",
@@ -7602,7 +7698,6 @@ dependencies = [
  "solana-compute-budget-instruction",
  "solana-config-program",
  "solana-cost-model",
- "solana-feature-set",
  "solana-fee",
  "solana-inline-spl",
  "solana-lattice-hash",
@@ -7622,6 +7717,7 @@ dependencies = [
  "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-timings",
+ "solana-transaction-context",
  "solana-transaction-status-client-types",
  "solana-unified-scheduler-logic",
  "solana-version",
@@ -7639,9 +7735,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime-transaction"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ffec9b80cf744d36696b28ca089bef8058475a79a11b1cee9322a5aab1fa00"
+checksum = "b5c1f6b65bcf3498b2c20e062a18de978ebf9ef773be823bc42329b2ec6ef7da"
 dependencies = [
  "agave-transaction-view",
  "log",
@@ -7683,9 +7779,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4808e8d7f3c931657e615042d4176b423e66f64dc99e3dc3c735a197e512029b"
+checksum = "e8af90d2ce445440e0548fa4a5f96fe8b265c22041a68c942012ffadd029667d"
 dependencies = [
  "bincode",
  "bs58",
@@ -7770,7 +7866,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7805,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "solana-secp256r1-program"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ea9282950921611bd9e0200da7236fbb1d4f8388942f8451bd55e9f3cb228f"
+checksum = "5cda2aa1bbaceda14763c4f142a00b486f2f262cfd901bd0410649ad0404d5f7"
 dependencies = [
  "bytemuck",
  "openssl",
@@ -7840,14 +7936,14 @@ checksum = "36187af2324f079f65a675ec22b31c24919cb4ac22c79472e85d819db9bbbc15"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51fb0567093cc4edbd701b995870fc41592fd90e8bc2965ef9f5ce214af22e7"
+checksum = "37a2a9dab16a9f7d11e06ee6f34ed7ce27923ae480c806513324b5620c73f09e"
 dependencies = [
  "crossbeam-channel",
  "itertools 0.12.1",
@@ -7897,7 +7993,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0037386961c0d633421f53560ad7c80675c0447cba4d1bb66d60974dd486c7ea"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "solana-define-syscall",
  "solana-hash",
 ]
@@ -8007,17 +8103,17 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabc713c25ff999424ec68ac4572f2ff6bfd6317922c7864435ccaf9c76504a8"
+checksum = "625c4872588e2a61166b6ece633be5de388dcc170294d717649e8963fae9468c"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "log",
  "solana-account",
  "solana-bincode",
  "solana-clock",
  "solana-config-program",
- "solana-feature-set",
  "solana-genesis-config",
  "solana-instruction",
  "solana-log-collector",
@@ -8036,10 +8132,11 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11114c617be52001af7413ee9715b4942d80a0c3de6296061df10da532f6b192"
+checksum = "d20ad7414016deebe751552fba2dbc2408e3dabc63638897c7c82b770f2ab7e0"
 dependencies = [
+ "agave-reserved-account-keys",
  "backoff",
  "bincode",
  "bytes",
@@ -8062,7 +8159,6 @@ dependencies = [
  "solana-message",
  "solana-metrics",
  "solana-pubkey",
- "solana-reserved-account-keys",
  "solana-serde",
  "solana-signature",
  "solana-storage-proto",
@@ -8078,9 +8174,9 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ed614e38d7327a6a399a17afb3b56c9b7b53fb7222eecdacd9bb73bf8a94d9"
+checksum = "b599f6dbda3f89810bc5b729d273dd7a5276d88f09cf72ef45ca67aabf30dd51"
 dependencies = [
  "bincode",
  "bs58",
@@ -8103,9 +8199,9 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68441234b1235afb242e7482cabf3e32eb29554e4c4159d5d58e19e54ccfd424"
+checksum = "1eaf5b216717d1d551716f3190878d028c689dabac40c8889767cead7e447481"
 dependencies = [
  "async-channel",
  "bytes",
@@ -8115,7 +8211,7 @@ dependencies = [
  "futures-util",
  "governor",
  "histogram",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itertools 0.12.1",
  "libc",
  "log",
@@ -8125,7 +8221,7 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "smallvec",
  "socket2",
  "solana-keypair",
@@ -8144,16 +8240,18 @@ dependencies = [
  "solana-transaction-metrics-tracker",
  "thiserror 2.0.12",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.15",
  "x509-parser",
 ]
 
 [[package]]
 name = "solana-svm"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0850baf834aba4a94a7558fa6cf6ca93fad284abf0363dec5fb9cab173a11fc4"
+checksum = "095be71c750f85287f37366e1975236b08dff2e02ec482473c975868d67fc542"
 dependencies = [
+ "agave-feature-set",
+ "agave-precompiles",
  "ahash 0.8.11",
  "itertools 0.12.1",
  "log",
@@ -8165,7 +8263,6 @@ dependencies = [
  "solana-clock",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
- "solana-feature-set",
  "solana-fee-structure",
  "solana-hash",
  "solana-instruction",
@@ -8176,7 +8273,6 @@ dependencies = [
  "solana-message",
  "solana-nonce",
  "solana-nonce-account",
- "solana-precompiles",
  "solana-program",
  "solana-program-runtime",
  "solana-pubkey",
@@ -8195,18 +8291,19 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-rent-collector"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa59aea7bfbadb4be9704a6f99c86dbdf48d6204c9291df79ecd6a4f1cc90b59"
+checksum = "ee563c1edcf5551b8b5acd86eb9383939a1d9591693c33e74a006dab4baaeb44"
 dependencies = [
  "solana-sdk",
+ "solana-transaction-context",
 ]
 
 [[package]]
 name = "solana-svm-transaction"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc4392f0eed412141a376e99dfb052069b96f13697a9abb335504babe29387a"
+checksum = "221865f7355d5b0827c2d46dd53996361f6cf0c21919b965caa4ba6a1feb6b3a"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8234,9 +8331,9 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c8f684977e4439031b3a27b954ab05a6bdf697d581692aaf8888cf92b73b9e"
+checksum = "efb0185e546f18f26451d274e018e5c4fd699c9765fbd69cbcbdb3475a6cb5bd"
 dependencies = [
  "bincode",
  "log",
@@ -8322,10 +8419,11 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723ed26f24b185c36d476b8cd69c1b727ce2074d7342099aa56fce20bec19280"
+checksum = "c223bf2f1c4145c257e1513e79e7022375615c90008412ec37c11a56ec5619e8"
 dependencies = [
+ "agave-feature-set",
  "base64 0.22.1",
  "bincode",
  "crossbeam-channel",
@@ -8336,7 +8434,6 @@ dependencies = [
  "solana-cli-output",
  "solana-compute-budget",
  "solana-core",
- "solana-feature-set",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
@@ -8355,9 +8452,9 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721a034e94fcfaf8bde1ae4980e7eb58bfeb0c9a243b032b0761fdd19018afbf"
+checksum = "255bda447fbff4526b6b19b16b3652281ec2b7c4952d019b369a5f4a9dba4e5c"
 dependencies = [
  "bincode",
  "log",
@@ -8390,9 +8487,9 @@ checksum = "6af261afb0e8c39252a04d026e3ea9c405342b08c871a2ad8aa5448e068c784c"
 
 [[package]]
 name = "solana-timings"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d9eabdce318cb07c60a23f1cc367b43e177c79225b5c2a081869ad182172ad"
+checksum = "d08862987485af7e3864b0ab9d4febeccaa34f1e982f08af9fa0460782d10773"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8401,11 +8498,11 @@ dependencies = [
 
 [[package]]
 name = "solana-tls-utils"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a228df037e560a02aac132193f492bdd761e2f90188cd16a440f149882f589b1"
+checksum = "b6f227b3813b6c26c8ed38910b90a0b641baedb2ad075ea51ccfbff1992ee394"
 dependencies = [
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "solana-keypair",
  "solana-pubkey",
  "solana-signer",
@@ -8414,14 +8511,14 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaceb9e9349de58740021f826ae72319513eca84ebb6d30326e2604fdad4cefb"
+checksum = "bcc74ecb664add683a18bb9f484a30ca8c9d71f3addcd3a771eaaaaec12125fd"
 dependencies = [
  "async-trait",
  "bincode",
  "futures-util",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "indicatif",
  "log",
  "rayon",
@@ -8448,9 +8545,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753b3e9afed170e4cfc0ea1e87b5dfdc6d4a50270869414edd24c6ea1f529b29"
+checksum = "abec848d081beb15a324c633cd0e0ab33033318063230389895cae503ec9b544"
 dependencies = [
  "bincode",
  "serde",
@@ -8463,7 +8560,6 @@ dependencies = [
  "solana-message",
  "solana-precompiles",
  "solana-pubkey",
- "solana-reserved-account-keys",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-short-vec",
@@ -8504,9 +8600,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-metrics-tracker"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9256ea8a6cead9e03060fd8fdc24d400a57a719364db48a3e4d1776b09c2365"
+checksum = "c4c03abfcb923aaf71c228e81b54a804aa224a48577477d8e1096c3a1429d21b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8521,11 +8617,12 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f739fb4230787b010aa4a49d3feda8b53aac145a9bc3ac2dd44337c6ecb544"
+checksum = "c3f43457f2a9bfe6e625af7e37c6c46de152f20f9cc9657f8b26321da36826ea"
 dependencies = [
  "Inflector",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "bincode",
  "borsh 1.5.7",
@@ -8543,7 +8640,6 @@ dependencies = [
  "solana-message",
  "solana-program",
  "solana-pubkey",
- "solana-reserved-account-keys",
  "solana-reward-info",
  "solana-sdk-ids",
  "solana-signature",
@@ -8562,9 +8658,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ac91c8f0465c566164044ad7b3d18d15dfabab1b8b4a4a01cb83c047efdaae"
+checksum = "4aaef59e8a54fc3a2dabfd85c32e35493c5e228f9d1efbcdcdc3c0819dddf7fd"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8585,10 +8681,11 @@ dependencies = [
 
 [[package]]
 name = "solana-turbine"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a646980cf7729a5f9b01e90a8707eb4b045525c894b538ddf91bd43d216a187"
+checksum = "0d8e3481af96baa41b3771750a6bb5eb196314eeefc3eb3a6ec6f5bc1252cd27"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "bytes",
  "crossbeam-channel",
@@ -8601,9 +8698,8 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rustls 0.23.23",
+ "rustls 0.23.26",
  "solana-entry",
- "solana-feature-set",
  "solana-geyser-plugin-manager",
  "solana-gossip",
  "solana-ledger",
@@ -8627,9 +8723,9 @@ dependencies = [
 
 [[package]]
 name = "solana-type-overrides"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39dc2e501edfea7ce1cec2fe2a2428aedfea1cc9c31747931e0d90d5c57b020"
+checksum = "72735ae2d80d5556400b8fbb552688b3ac1413cd6c29e85db83d24ffe825a7f9"
 dependencies = [
  "lazy_static",
  "rand 0.8.5",
@@ -8637,9 +8733,9 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85085c0aa14ebb8e26219386fb7f4348d159f5a67858c2fdefef3cc5f4ce090c"
+checksum = "6d3e085a6adf81d51f678624934ffe266bd45a1c105849992b1af933c80bbf19"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -8653,9 +8749,9 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-logic"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7e48cbf4e70c05199f50d5f14aafc58331ad39229747c795320bcb362ed063"
+checksum = "ccc4e998f9185355afcd5119c8b3715f00ac836460faedceac6a73840fc2621d"
 dependencies = [
  "assert_matches",
  "solana-pubkey",
@@ -8666,9 +8762,9 @@ dependencies = [
 
 [[package]]
 name = "solana-unified-scheduler-pool"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9854eb81245123b84af5807731a43aa794961990feaf5a8526127c5898e097"
+checksum = "d39e7a729c58c3b9be93a468d304703ebad854edae15f752347fb8e539a8e813"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "aquamarine",
@@ -8703,23 +8799,23 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f60a01e2721bfd2e094b465440ae461d75acd363e9653565a73d2c586becb3b"
+checksum = "2a58e01912dc3d5ff4391fe49476461b3b9ebc4215f3713d2fe3ffcfeda7f8e2"
 dependencies = [
+ "agave-feature-set",
  "semver",
  "serde",
  "serde_derive",
- "solana-feature-set",
  "solana-sanitize",
  "solana-serde-varint",
 ]
 
 [[package]]
 name = "solana-vote"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cfd22290c8e63582acd8d8d10670f4de2f81a967b5e9821e2988b4a4d58c54"
+checksum = "5f696980f793a5d7019d9da049bb9f18f109fcc14d9f7db568064f0ed5158273"
 dependencies = [
  "itertools 0.12.1",
  "log",
@@ -8742,9 +8838,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-interface"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4507bb9d071fb81cfcf676f12fba3db4098f764524ef0b5567d671a81d41f3e"
+checksum = "6b630547b7f12ee742e1c5069951fedba0fe5cbd4786f6342a779384e2b11f71"
 dependencies = [
  "bincode",
  "num-derive",
@@ -8766,10 +8862,11 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab654bb2622d85b2ca0c36cb89c99fa1286268e0d784efec03a3d42e9c6a55f4"
+checksum = "27cb01906f935beee9d64a6a7881a583b55c8ffe4f767b9b19b687a68cd7cf47"
 dependencies = [
+ "agave-feature-set",
  "bincode",
  "log",
  "num-derive",
@@ -8780,7 +8877,6 @@ dependencies = [
  "solana-bincode",
  "solana-clock",
  "solana-epoch-schedule",
- "solana-feature-set",
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
@@ -8799,9 +8895,9 @@ dependencies = [
 
 [[package]]
 name = "solana-wen-restart"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23183976f151b510f8ed2f2088c7c47324f2e50a2cca3370faefc2683d0e45d"
+checksum = "e552b51d235bfa724dee40f7d000bf2060794ad106af22ce588f3eccb35f033d"
 dependencies = [
  "anyhow",
  "log",
@@ -8826,9 +8922,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d241af6328b3e0e20695bb705c850119ec5881b386c338783b8c8bc79e76c65"
+checksum = "d352601fa721288f0a3a2b48c930aa6badb83c95cab47b5b14015a2915f04995"
 dependencies = [
  "bytemuck",
  "num-derive",
@@ -8842,9 +8938,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8318220b73552a2765c6545a4be04fc87fe21b6dd0cb8c2b545a66121bf5b8a"
+checksum = "35a153bff0be31a58dacd7f40bc37fc80f5bb7cb3f38fb62e7a2777a8b48de25"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -8879,14 +8975,14 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123b7c7d2f9e68190630b216781ca832af0ed78b69acd89a2ad2766cc460c312"
+checksum = "e4086b331151047f6be5c71210e6690f3a4de222ccf43c90ec715ea60e860189"
 dependencies = [
+ "agave-feature-set",
  "bytemuck",
  "num-derive",
  "num-traits",
- "solana-feature-set",
  "solana-instruction",
  "solana-log-collector",
  "solana-program-runtime",
@@ -8896,9 +8992,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "2.2.1"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3cf301f8d8e02ef58fc2ce85868f5c760720e1ce74ee4b3c3dcb64c8da7bcff"
+checksum = "06d91b7c7651e776b848b67b6b58f032566be4cd554e6f6283bdf415e3a70b61"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
@@ -8991,7 +9087,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9002,8 +9098,8 @@ checksum = "8c1f05593b7ca9eac7caca309720f2eafb96355e037e6d373b909a80fe7b69b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
- "syn 2.0.99",
+ "sha2 0.10.9",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -9128,8 +9224,8 @@ checksum = "e6d375dd76c517836353e093c2dbb490938ff72821ab568b545fd30ab3256b3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
- "syn 2.0.99",
+ "sha2 0.10.9",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9140,8 +9236,8 @@ checksum = "2a2539e259c66910d78593475540e8072f0b10f0f61d7607bbf7593899ed52d0"
 dependencies = [
  "proc-macro2",
  "quote",
- "sha2 0.10.8",
- "syn 2.0.99",
+ "sha2 0.10.9",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9785,7 +9881,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9813,9 +9909,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9842,13 +9938,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9881,7 +9977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -9957,9 +10053,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.0",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -9996,7 +10092,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10007,7 +10103,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
  "test-case-core",
 ]
 
@@ -10052,7 +10148,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10063,21 +10159,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
-]
-
-[[package]]
-name = "thread-priority"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if 1.0.0",
- "libc",
- "log",
- "rustversion",
- "winapi 0.3.9",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10092,9 +10174,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -10107,15 +10189,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -10212,7 +10294,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10294,9 +10376,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -10316,35 +10398,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.7.1",
- "serde",
- "serde_spanned",
+ "indexmap 2.9.0",
  "toml_datetime",
  "winnow",
 ]
@@ -10370,7 +10435,7 @@ dependencies = [
  "percent-encoding 2.3.1",
  "pin-project",
  "prost",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -10407,7 +10472,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.13",
+ "tokio-util 0.7.15",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10445,7 +10510,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10760,9 +10825,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -10789,7 +10854,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -10824,7 +10889,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10860,9 +10925,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10939,18 +11004,71 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -10977,6 +11095,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -11012,6 +11145,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -11024,6 +11163,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -11033,6 +11178,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11054,6 +11205,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -11063,6 +11220,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11078,6 +11241,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -11087,6 +11256,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11102,9 +11277,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]
@@ -11121,9 +11296,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -11165,7 +11340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.0",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -11188,8 +11363,8 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -11198,8 +11373,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -11210,7 +11393,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11230,8 +11424,8 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -11251,7 +11445,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11273,7 +11467,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.99",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11287,18 +11481,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.3"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.14+zstd.1.5.7"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
  "five8_core",
 ]
@@ -3867,6 +3867,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pinocchio"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81225b3b8ce092ac54e0d1c55a962be61efcad1d021030f0eb660875703db562"
+
+[[package]]
+name = "pinocchio-pubkey"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b20fcebc172c3cd3f54114b0241b48fa8e30893ced2eb4927aaba5e3a0ba5"
+dependencies = [
+ "five8_const",
+ "pinocchio",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,6 +5011,52 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "shank"
+version = "0.4.3-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23ca718f8d1d909c36e21706b7da0fc2017107c8a4a92055cd0ca11bfdd4c72"
+dependencies = [
+ "shank_macro",
+]
+
+[[package]]
+name = "shank_macro"
+version = "0.4.3-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73133feeb4d3bb256cafabbbe8b67567e54894e4934ad49895e68a854559505c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "shank_macro_impl",
+ "shank_render",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "shank_macro_impl"
+version = "0.4.3-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0319bb9cbbac08b68f9ffb1029c4d9a355af1bdc33bb74790b2cb6dc63e8e3"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "shank_render"
+version = "0.4.3-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e05832c32602ee5569f1d7d6a8e7b81e0b6391ffdfbe5761a845b01f9f1e30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "shank_macro_impl",
 ]
 
 [[package]]
@@ -9302,6 +9364,7 @@ dependencies = [
  "spl-type-length-value 0.8.0",
  "test-case",
  "thiserror 2.0.12",
+ "token-whitelist-interface",
 ]
 
 [[package]]
@@ -10101,6 +10164,17 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "token-whitelist-interface"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "pinocchio",
+ "pinocchio-pubkey",
+ "shank",
+ "thiserror 2.0.12",
+]
 
 [[package]]
 name = "tokio"

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -27,7 +27,7 @@ solana-rpc-client = "2.2.0"
 solana-rpc-client-api = "2.2.0"
 solana-sdk = "2.2.1"
 spl-associated-token-account-client = { version = "2.0.0" }
-spl-elgamal-registry = { version = "0.2.0", path = "../../confidential-transfer/elgamal-registry"}
+spl-elgamal-registry = { version = "0.2.0", path = "../../confidential-transfer/elgamal-registry" }
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
 spl-record = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-token = { version = "8.0", features = ["no-entrypoint"] }
@@ -38,6 +38,7 @@ spl-token-group-interface = { version = "0.6.0" }
 spl-token-metadata-interface = { version = "0.7.0" }
 spl-transfer-hook-interface = { version = "0.10.0" }
 thiserror = "2.0"
+token-whitelist-interface = { version = "0.1.0", path = "../../../token-whitelist/interface" }
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -1021,6 +1021,13 @@ where
     ) -> TokenResult<T::Output> {
         let signing_pubkeys = signing_keypairs.pubkeys();
         let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &authority.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
 
         let instructions = if let Some(decimals) = self.decimals {
             [instruction::mint_to_checked(
@@ -1028,6 +1035,7 @@ where
                 &self.pubkey,
                 destination,
                 authority,
+                &whitelist_entry_key,
                 &multisig_signers,
                 amount,
                 decimals,
@@ -1038,6 +1046,7 @@ where
                 &self.pubkey,
                 destination,
                 authority,
+                &whitelist_entry_key,
                 &multisig_signers,
                 amount,
             )?]

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -64,9 +64,7 @@ thiserror = "2.0"
 serde = { version = "1.0.219", optional = true }
 serde_with = { version = "3.12.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
-token-whitelist-interface = { version = "0.1.0", path = "../../token-whitelist/interface", features = [
-    "non-pinocchio",
-] }
+token-whitelist-interface = { version = "0.1.0", path = "../../token-whitelist/interface" }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../confidential-transfer/proof-generation" }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,7 +13,12 @@ edition = { workspace = true }
 [features]
 no-entrypoint = []
 test-sbf = []
-serde-traits = ["dep:serde", "dep:serde_with", "dep:base64", "spl-pod/serde-traits"]
+serde-traits = [
+    "dep:serde",
+    "dep:serde_with",
+    "dep:base64",
+    "spl-pod/serde-traits",
+]
 default = ["zk-ops"]
 # Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []
@@ -43,7 +48,9 @@ solana-security-txt = "1.1.1"
 solana-sysvar = "2.2.1"
 solana-system-interface = "1.0.0"
 solana-zk-sdk = "2.2.0"
-spl-elgamal-registry = { version = "0.2.0", path = "../confidential-transfer/elgamal-registry", features = ["no-entrypoint"] }
+spl-elgamal-registry = { version = "0.2.0", path = "../confidential-transfer/elgamal-registry", features = [
+    "no-entrypoint",
+] }
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }
 spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-confidential-transfer-ciphertext-arithmetic = { version = "0.3.0", path = "../confidential-transfer/ciphertext-arithmetic" }
@@ -57,6 +64,9 @@ thiserror = "2.0"
 serde = { version = "1.0.219", optional = true }
 serde_with = { version = "3.12.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
+token-whitelist-interface = { version = "0.1.0", path = "../../token-whitelist/interface", features = [
+    "non-pinocchio",
+] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../confidential-transfer/proof-generation" }

--- a/program/src/extension/confidential_mint_burn/processor.rs
+++ b/program/src/extension/confidential_mint_burn/processor.rs
@@ -187,6 +187,9 @@ fn process_confidential_mint(
     let authority_info_data_len = authority_info.data_len();
     let authority = mint_authority.ok_or(TokenError::NoAuthorityExists)?;
 
+    let whitelist_entry_info = next_account_info(account_info_iter)?;
+    Processor::validate_whitelisted_authority(&whitelist_entry_info, &authority)?;
+
     Processor::validate_owner(
         program_id,
         &authority,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1524,6 +1524,7 @@ pub fn mint_to(
     mint_pubkey: &Pubkey,
     account_pubkey: &Pubkey,
     mint_authority_pubkey: &Pubkey,
+    whitelist_entry_pubkey: &Pubkey,
     signer_pubkeys: &[&Pubkey],
     amount: u64,
 ) -> Result<Instruction, ProgramError> {
@@ -1537,6 +1538,7 @@ pub fn mint_to(
         *mint_authority_pubkey,
         signer_pubkeys.is_empty(),
     ));
+    accounts.push(AccountMeta::new_readonly(*whitelist_entry_pubkey, false));
     for signer_pubkey in signer_pubkeys.iter() {
         accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
     }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2068,7 +2068,8 @@ pub fn withdraw_excess_lamports(
 
 #[cfg(test)]
 mod test {
-    use {super::*, crate::pod_instruction::*, proptest::prelude::*};
+    // use {super::*, crate::pod_instruction::*, proptest::prelude::*};
+    use {super::*, crate::pod_instruction::*};
 
     #[test]
     fn test_initialize_mint_packing() {
@@ -2585,263 +2586,264 @@ mod test {
         assert_eq!(instruction_type, PodTokenInstruction::CreateNativeMint);
     }
 
-    #[test]
-    fn test_initialize_permanent_delegate_packing() {
-        let delegate = Pubkey::new_from_array([11u8; 32]);
-        let check = TokenInstruction::InitializePermanentDelegate { delegate };
-        let packed = check.pack();
-        let mut expect = vec![35u8];
-        expect.extend_from_slice(&[11u8; 32]);
-        assert_eq!(packed, expect);
-        let unpacked = TokenInstruction::unpack(&expect).unwrap();
-        assert_eq!(unpacked, check);
+    // Todo: update tokenkeg to match token-2022 specification
+    // #[test]
+    // fn test_initialize_permanent_delegate_packing() {
+    //     let delegate = Pubkey::new_from_array([11u8; 32]);
+    //     let check = TokenInstruction::InitializePermanentDelegate { delegate };
+    //     let packed = check.pack();
+    //     let mut expect = vec![35u8];
+    //     expect.extend_from_slice(&[11u8; 32]);
+    //     assert_eq!(packed, expect);
+    //     let unpacked = TokenInstruction::unpack(&expect).unwrap();
+    //     assert_eq!(unpacked, check);
 
-        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
-        assert_eq!(
-            instruction_type,
-            PodTokenInstruction::InitializePermanentDelegate
-        );
-        let pod_delegate = decode_instruction_data::<Pubkey>(&packed).unwrap();
-        assert_eq!(*pod_delegate, delegate);
-    }
+    //     let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+    //     assert_eq!(
+    //         instruction_type,
+    //         PodTokenInstruction::InitializePermanentDelegate
+    //     );
+    //     let pod_delegate = decode_instruction_data::<Pubkey>(&packed).unwrap();
+    //     assert_eq!(*pod_delegate, delegate);
+    // }
 
-    macro_rules! test_instruction {
-        ($a:ident($($b:tt)*)) => {
-            let instruction_v3 = spl_token::instruction::$a($($b)*).unwrap();
-            let instruction_2022 = $a($($b)*).unwrap();
-            assert_eq!(instruction_v3, instruction_2022);
-        }
-    }
+    // macro_rules! test_instruction {
+    //     ($a:ident($($b:tt)*)) => {
+    //         let instruction_v3 = spl_token::instruction::$a($($b)*).unwrap();
+    //         let instruction_2022 = $a($($b)*).unwrap();
+    //         assert_eq!(instruction_v3, instruction_2022);
+    //     }
+    // }
 
-    #[test]
-    fn test_v3_compatibility() {
-        let token_program_id = spl_token::id();
-        let mint_pubkey = Pubkey::new_unique();
-        let mint_authority_pubkey = Pubkey::new_unique();
-        let freeze_authority_pubkey = Pubkey::new_unique();
-        let decimals = 9u8;
+    // #[test]
+    // fn test_v3_compatibility() {
+    //     let token_program_id = spl_token::id();
+    //     let mint_pubkey = Pubkey::new_unique();
+    //     let mint_authority_pubkey = Pubkey::new_unique();
+    //     let freeze_authority_pubkey = Pubkey::new_unique();
+    //     let decimals = 9u8;
 
-        let account_pubkey = Pubkey::new_unique();
-        let owner_pubkey = Pubkey::new_unique();
+    //     let account_pubkey = Pubkey::new_unique();
+    //     let owner_pubkey = Pubkey::new_unique();
 
-        let multisig_pubkey = Pubkey::new_unique();
-        let signer_pubkeys_vec = vec![Pubkey::new_unique(); MAX_SIGNERS];
-        let signer_pubkeys = signer_pubkeys_vec.iter().collect::<Vec<_>>();
-        let m = 10u8;
+    //     let multisig_pubkey = Pubkey::new_unique();
+    //     let signer_pubkeys_vec = vec![Pubkey::new_unique(); MAX_SIGNERS];
+    //     let signer_pubkeys = signer_pubkeys_vec.iter().collect::<Vec<_>>();
+    //     let m = 10u8;
 
-        let source_pubkey = Pubkey::new_unique();
-        let destination_pubkey = Pubkey::new_unique();
-        let authority_pubkey = Pubkey::new_unique();
-        let amount = 1_000_000_000_000;
+    //     let source_pubkey = Pubkey::new_unique();
+    //     let destination_pubkey = Pubkey::new_unique();
+    //     let authority_pubkey = Pubkey::new_unique();
+    //     let amount = 1_000_000_000_000;
 
-        let delegate_pubkey = Pubkey::new_unique();
-        let owned_pubkey = Pubkey::new_unique();
-        let new_authority_pubkey = Pubkey::new_unique();
+    //     let delegate_pubkey = Pubkey::new_unique();
+    //     let owned_pubkey = Pubkey::new_unique();
+    //     let new_authority_pubkey = Pubkey::new_unique();
 
-        let ui_amount = "100000.00";
+    //     let ui_amount = "100000.00";
 
-        test_instruction!(initialize_mint(
-            &token_program_id,
-            &mint_pubkey,
-            &mint_authority_pubkey,
-            None,
-            decimals,
-        ));
-        test_instruction!(initialize_mint2(
-            &token_program_id,
-            &mint_pubkey,
-            &mint_authority_pubkey,
-            Some(&freeze_authority_pubkey),
-            decimals,
-        ));
+    //     test_instruction!(initialize_mint(
+    //         &token_program_id,
+    //         &mint_pubkey,
+    //         &mint_authority_pubkey,
+    //         None,
+    //         decimals,
+    //     ));
+    //     test_instruction!(initialize_mint2(
+    //         &token_program_id,
+    //         &mint_pubkey,
+    //         &mint_authority_pubkey,
+    //         Some(&freeze_authority_pubkey),
+    //         decimals,
+    //     ));
 
-        test_instruction!(initialize_account(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &owner_pubkey,
-        ));
-        test_instruction!(initialize_account2(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &owner_pubkey,
-        ));
-        test_instruction!(initialize_account3(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &owner_pubkey,
-        ));
-        test_instruction!(initialize_multisig(
-            &token_program_id,
-            &multisig_pubkey,
-            &signer_pubkeys,
-            m,
-        ));
-        test_instruction!(initialize_multisig2(
-            &token_program_id,
-            &multisig_pubkey,
-            &signer_pubkeys,
-            m,
-        ));
-        #[allow(deprecated)]
-        {
-            test_instruction!(transfer(
-                &token_program_id,
-                &source_pubkey,
-                &destination_pubkey,
-                &authority_pubkey,
-                &signer_pubkeys,
-                amount
-            ));
-        }
-        test_instruction!(transfer_checked(
-            &token_program_id,
-            &source_pubkey,
-            &mint_pubkey,
-            &destination_pubkey,
-            &authority_pubkey,
-            &signer_pubkeys,
-            amount,
-            decimals,
-        ));
-        test_instruction!(approve(
-            &token_program_id,
-            &source_pubkey,
-            &delegate_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-            amount
-        ));
-        test_instruction!(approve_checked(
-            &token_program_id,
-            &source_pubkey,
-            &mint_pubkey,
-            &delegate_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-            amount,
-            decimals
-        ));
-        test_instruction!(revoke(
-            &token_program_id,
-            &source_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-        ));
+    //     test_instruction!(initialize_account(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &owner_pubkey,
+    //     ));
+    //     test_instruction!(initialize_account2(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &owner_pubkey,
+    //     ));
+    //     test_instruction!(initialize_account3(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &owner_pubkey,
+    //     ));
+    //     test_instruction!(initialize_multisig(
+    //         &token_program_id,
+    //         &multisig_pubkey,
+    //         &signer_pubkeys,
+    //         m,
+    //     ));
+    //     test_instruction!(initialize_multisig2(
+    //         &token_program_id,
+    //         &multisig_pubkey,
+    //         &signer_pubkeys,
+    //         m,
+    //     ));
+    //     #[allow(deprecated)]
+    //     {
+    //         test_instruction!(transfer(
+    //             &token_program_id,
+    //             &source_pubkey,
+    //             &destination_pubkey,
+    //             &authority_pubkey,
+    //             &signer_pubkeys,
+    //             amount
+    //         ));
+    //     }
+    //     test_instruction!(transfer_checked(
+    //         &token_program_id,
+    //         &source_pubkey,
+    //         &mint_pubkey,
+    //         &destination_pubkey,
+    //         &authority_pubkey,
+    //         &signer_pubkeys,
+    //         amount,
+    //         decimals,
+    //     ));
+    //     test_instruction!(approve(
+    //         &token_program_id,
+    //         &source_pubkey,
+    //         &delegate_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //         amount
+    //     ));
+    //     test_instruction!(approve_checked(
+    //         &token_program_id,
+    //         &source_pubkey,
+    //         &mint_pubkey,
+    //         &delegate_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //         amount,
+    //         decimals
+    //     ));
+    //     test_instruction!(revoke(
+    //         &token_program_id,
+    //         &source_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //     ));
 
-        // set_authority
-        {
-            let instruction_v3 = spl_token::instruction::set_authority(
-                &token_program_id,
-                &owned_pubkey,
-                Some(&new_authority_pubkey),
-                spl_token::instruction::AuthorityType::AccountOwner,
-                &owner_pubkey,
-                &signer_pubkeys,
-            )
-            .unwrap();
-            let instruction_2022 = set_authority(
-                &token_program_id,
-                &owned_pubkey,
-                Some(&new_authority_pubkey),
-                AuthorityType::AccountOwner,
-                &owner_pubkey,
-                &signer_pubkeys,
-            )
-            .unwrap();
-            assert_eq!(instruction_v3, instruction_2022);
-        }
+    //     // set_authority
+    //     {
+    //         let instruction_v3 = spl_token::instruction::set_authority(
+    //             &token_program_id,
+    //             &owned_pubkey,
+    //             Some(&new_authority_pubkey),
+    //             spl_token::instruction::AuthorityType::AccountOwner,
+    //             &owner_pubkey,
+    //             &signer_pubkeys,
+    //         )
+    //         .unwrap();
+    //         let instruction_2022 = set_authority(
+    //             &token_program_id,
+    //             &owned_pubkey,
+    //             Some(&new_authority_pubkey),
+    //             AuthorityType::AccountOwner,
+    //             &owner_pubkey,
+    //             &signer_pubkeys,
+    //         )
+    //         .unwrap();
+    //         assert_eq!(instruction_v3, instruction_2022);
+    //     }
 
-        test_instruction!(mint_to(
-            &token_program_id,
-            &mint_pubkey,
-            &account_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-            amount,
-        ));
-        test_instruction!(mint_to_checked(
-            &token_program_id,
-            &mint_pubkey,
-            &account_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-            amount,
-            decimals,
-        ));
-        test_instruction!(burn(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &authority_pubkey,
-            &signer_pubkeys,
-            amount,
-        ));
-        test_instruction!(burn_checked(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &authority_pubkey,
-            &signer_pubkeys,
-            amount,
-            decimals,
-        ));
-        test_instruction!(close_account(
-            &token_program_id,
-            &account_pubkey,
-            &destination_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-        ));
-        test_instruction!(freeze_account(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-        ));
-        test_instruction!(thaw_account(
-            &token_program_id,
-            &account_pubkey,
-            &mint_pubkey,
-            &owner_pubkey,
-            &signer_pubkeys,
-        ));
-        test_instruction!(sync_native(&token_program_id, &account_pubkey,));
+    //     test_instruction!(mint_to(
+    //         &token_program_id,
+    //         &mint_pubkey,
+    //         &account_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //         amount,
+    //     ));
+    //     test_instruction!(mint_to_checked(
+    //         &token_program_id,
+    //         &mint_pubkey,
+    //         &account_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //         amount,
+    //         decimals,
+    //     ));
+    //     test_instruction!(burn(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &authority_pubkey,
+    //         &signer_pubkeys,
+    //         amount,
+    //     ));
+    //     test_instruction!(burn_checked(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &authority_pubkey,
+    //         &signer_pubkeys,
+    //         amount,
+    //         decimals,
+    //     ));
+    //     test_instruction!(close_account(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &destination_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //     ));
+    //     test_instruction!(freeze_account(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //     ));
+    //     test_instruction!(thaw_account(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //         &mint_pubkey,
+    //         &owner_pubkey,
+    //         &signer_pubkeys,
+    //     ));
+    //     test_instruction!(sync_native(&token_program_id, &account_pubkey,));
 
-        // get_account_data_size
-        {
-            let instruction_v3 =
-                spl_token::instruction::get_account_data_size(&token_program_id, &mint_pubkey)
-                    .unwrap();
-            let instruction_2022 =
-                get_account_data_size(&token_program_id, &mint_pubkey, &[]).unwrap();
-            assert_eq!(instruction_v3, instruction_2022);
-        }
+    //     // get_account_data_size
+    //     {
+    //         let instruction_v3 =
+    //             spl_token::instruction::get_account_data_size(&token_program_id, &mint_pubkey)
+    //                 .unwrap();
+    //         let instruction_2022 =
+    //             get_account_data_size(&token_program_id, &mint_pubkey, &[]).unwrap();
+    //         assert_eq!(instruction_v3, instruction_2022);
+    //     }
 
-        test_instruction!(initialize_immutable_owner(
-            &token_program_id,
-            &account_pubkey,
-        ));
+    //     test_instruction!(initialize_immutable_owner(
+    //         &token_program_id,
+    //         &account_pubkey,
+    //     ));
 
-        test_instruction!(amount_to_ui_amount(&token_program_id, &mint_pubkey, amount,));
+    //     test_instruction!(amount_to_ui_amount(&token_program_id, &mint_pubkey, amount,));
 
-        test_instruction!(ui_amount_to_amount(
-            &token_program_id,
-            &mint_pubkey,
-            ui_amount,
-        ));
-    }
+    //     test_instruction!(ui_amount_to_amount(
+    //         &token_program_id,
+    //         &mint_pubkey,
+    //         ui_amount,
+    //     ));
+    // }
 
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(1024))]
-        #[test]
-        fn test_instruction_unpack_proptest(
-            data in prop::collection::vec(any::<u8>(), 0..255)
-        ) {
-            let _no_panic = TokenInstruction::unpack(&data);
-        }
-    }
+    // proptest! {
+    //     #![proptest_config(ProptestConfig::with_cases(1024))]
+    //     #[test]
+    //     fn test_instruction_unpack_proptest(
+    //         data in prop::collection::vec(any::<u8>(), 0..255)
+    //     ) {
+    //         let _no_panic = TokenInstruction::unpack(&data);
+    //     }
+    // }
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2068,8 +2068,8 @@ pub fn withdraw_excess_lamports(
 
 #[cfg(test)]
 mod test {
-    // use {super::*, crate::pod_instruction::*, proptest::prelude::*};
-    use {super::*, crate::pod_instruction::*};
+    use {super::*, crate::pod_instruction::*, proptest::prelude::*};
+    // use {super::*, crate::pod_instruction::*};
 
     #[test]
     fn test_initialize_mint_packing() {
@@ -2586,264 +2586,263 @@ mod test {
         assert_eq!(instruction_type, PodTokenInstruction::CreateNativeMint);
     }
 
-    // Todo: update tokenkeg to match token-2022 specification
-    // #[test]
-    // fn test_initialize_permanent_delegate_packing() {
-    //     let delegate = Pubkey::new_from_array([11u8; 32]);
-    //     let check = TokenInstruction::InitializePermanentDelegate { delegate };
-    //     let packed = check.pack();
-    //     let mut expect = vec![35u8];
-    //     expect.extend_from_slice(&[11u8; 32]);
-    //     assert_eq!(packed, expect);
-    //     let unpacked = TokenInstruction::unpack(&expect).unwrap();
-    //     assert_eq!(unpacked, check);
+    #[test]
+    fn test_initialize_permanent_delegate_packing() {
+        let delegate = Pubkey::new_from_array([11u8; 32]);
+        let check = TokenInstruction::InitializePermanentDelegate { delegate };
+        let packed = check.pack();
+        let mut expect = vec![35u8];
+        expect.extend_from_slice(&[11u8; 32]);
+        assert_eq!(packed, expect);
+        let unpacked = TokenInstruction::unpack(&expect).unwrap();
+        assert_eq!(unpacked, check);
 
-    //     let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
-    //     assert_eq!(
-    //         instruction_type,
-    //         PodTokenInstruction::InitializePermanentDelegate
-    //     );
-    //     let pod_delegate = decode_instruction_data::<Pubkey>(&packed).unwrap();
-    //     assert_eq!(*pod_delegate, delegate);
-    // }
+        let instruction_type = decode_instruction_type::<PodTokenInstruction>(&packed).unwrap();
+        assert_eq!(
+            instruction_type,
+            PodTokenInstruction::InitializePermanentDelegate
+        );
+        let pod_delegate = decode_instruction_data::<Pubkey>(&packed).unwrap();
+        assert_eq!(*pod_delegate, delegate);
+    }
 
-    // macro_rules! test_instruction {
-    //     ($a:ident($($b:tt)*)) => {
-    //         let instruction_v3 = spl_token::instruction::$a($($b)*).unwrap();
-    //         let instruction_2022 = $a($($b)*).unwrap();
-    //         assert_eq!(instruction_v3, instruction_2022);
-    //     }
-    // }
+    macro_rules! test_instruction {
+        ($a:ident($($b:tt)*)) => {
+            let instruction_v3 = spl_token::instruction::$a($($b)*).unwrap();
+            let instruction_2022 = $a($($b)*).unwrap();
+            assert_eq!(instruction_v3, instruction_2022);
+        }
+    }
 
-    // #[test]
-    // fn test_v3_compatibility() {
-    //     let token_program_id = spl_token::id();
-    //     let mint_pubkey = Pubkey::new_unique();
-    //     let mint_authority_pubkey = Pubkey::new_unique();
-    //     let freeze_authority_pubkey = Pubkey::new_unique();
-    //     let decimals = 9u8;
+    #[test]
+    fn test_v3_compatibility() {
+        let token_program_id = spl_token::id();
+        let mint_pubkey = Pubkey::new_unique();
+        let mint_authority_pubkey = Pubkey::new_unique();
+        let freeze_authority_pubkey = Pubkey::new_unique();
+        let decimals = 9u8;
 
-    //     let account_pubkey = Pubkey::new_unique();
-    //     let owner_pubkey = Pubkey::new_unique();
+        let account_pubkey = Pubkey::new_unique();
+        let owner_pubkey = Pubkey::new_unique();
 
-    //     let multisig_pubkey = Pubkey::new_unique();
-    //     let signer_pubkeys_vec = vec![Pubkey::new_unique(); MAX_SIGNERS];
-    //     let signer_pubkeys = signer_pubkeys_vec.iter().collect::<Vec<_>>();
-    //     let m = 10u8;
+        let multisig_pubkey = Pubkey::new_unique();
+        let signer_pubkeys_vec = vec![Pubkey::new_unique(); MAX_SIGNERS];
+        let signer_pubkeys = signer_pubkeys_vec.iter().collect::<Vec<_>>();
+        let m = 10u8;
 
-    //     let source_pubkey = Pubkey::new_unique();
-    //     let destination_pubkey = Pubkey::new_unique();
-    //     let authority_pubkey = Pubkey::new_unique();
-    //     let amount = 1_000_000_000_000;
+        let source_pubkey = Pubkey::new_unique();
+        let destination_pubkey = Pubkey::new_unique();
+        let authority_pubkey = Pubkey::new_unique();
+        let amount = 1_000_000_000_000;
 
-    //     let delegate_pubkey = Pubkey::new_unique();
-    //     let owned_pubkey = Pubkey::new_unique();
-    //     let new_authority_pubkey = Pubkey::new_unique();
+        let delegate_pubkey = Pubkey::new_unique();
+        let owned_pubkey = Pubkey::new_unique();
+        let new_authority_pubkey = Pubkey::new_unique();
 
-    //     let ui_amount = "100000.00";
+        let ui_amount = "100000.00";
 
-    //     test_instruction!(initialize_mint(
-    //         &token_program_id,
-    //         &mint_pubkey,
-    //         &mint_authority_pubkey,
-    //         None,
-    //         decimals,
-    //     ));
-    //     test_instruction!(initialize_mint2(
-    //         &token_program_id,
-    //         &mint_pubkey,
-    //         &mint_authority_pubkey,
-    //         Some(&freeze_authority_pubkey),
-    //         decimals,
-    //     ));
+        test_instruction!(initialize_mint(
+            &token_program_id,
+            &mint_pubkey,
+            &mint_authority_pubkey,
+            None,
+            decimals,
+        ));
+        test_instruction!(initialize_mint2(
+            &token_program_id,
+            &mint_pubkey,
+            &mint_authority_pubkey,
+            Some(&freeze_authority_pubkey),
+            decimals,
+        ));
 
-    //     test_instruction!(initialize_account(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &owner_pubkey,
-    //     ));
-    //     test_instruction!(initialize_account2(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &owner_pubkey,
-    //     ));
-    //     test_instruction!(initialize_account3(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &owner_pubkey,
-    //     ));
-    //     test_instruction!(initialize_multisig(
-    //         &token_program_id,
-    //         &multisig_pubkey,
-    //         &signer_pubkeys,
-    //         m,
-    //     ));
-    //     test_instruction!(initialize_multisig2(
-    //         &token_program_id,
-    //         &multisig_pubkey,
-    //         &signer_pubkeys,
-    //         m,
-    //     ));
-    //     #[allow(deprecated)]
-    //     {
-    //         test_instruction!(transfer(
-    //             &token_program_id,
-    //             &source_pubkey,
-    //             &destination_pubkey,
-    //             &authority_pubkey,
-    //             &signer_pubkeys,
-    //             amount
-    //         ));
-    //     }
-    //     test_instruction!(transfer_checked(
-    //         &token_program_id,
-    //         &source_pubkey,
-    //         &mint_pubkey,
-    //         &destination_pubkey,
-    //         &authority_pubkey,
-    //         &signer_pubkeys,
-    //         amount,
-    //         decimals,
-    //     ));
-    //     test_instruction!(approve(
-    //         &token_program_id,
-    //         &source_pubkey,
-    //         &delegate_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //         amount
-    //     ));
-    //     test_instruction!(approve_checked(
-    //         &token_program_id,
-    //         &source_pubkey,
-    //         &mint_pubkey,
-    //         &delegate_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //         amount,
-    //         decimals
-    //     ));
-    //     test_instruction!(revoke(
-    //         &token_program_id,
-    //         &source_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //     ));
+        test_instruction!(initialize_account(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &owner_pubkey,
+        ));
+        test_instruction!(initialize_account2(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &owner_pubkey,
+        ));
+        test_instruction!(initialize_account3(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &owner_pubkey,
+        ));
+        test_instruction!(initialize_multisig(
+            &token_program_id,
+            &multisig_pubkey,
+            &signer_pubkeys,
+            m,
+        ));
+        test_instruction!(initialize_multisig2(
+            &token_program_id,
+            &multisig_pubkey,
+            &signer_pubkeys,
+            m,
+        ));
+        #[allow(deprecated)]
+        {
+            test_instruction!(transfer(
+                &token_program_id,
+                &source_pubkey,
+                &destination_pubkey,
+                &authority_pubkey,
+                &signer_pubkeys,
+                amount
+            ));
+        }
+        test_instruction!(transfer_checked(
+            &token_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &destination_pubkey,
+            &authority_pubkey,
+            &signer_pubkeys,
+            amount,
+            decimals,
+        ));
+        test_instruction!(approve(
+            &token_program_id,
+            &source_pubkey,
+            &delegate_pubkey,
+            &owner_pubkey,
+            &signer_pubkeys,
+            amount
+        ));
+        test_instruction!(approve_checked(
+            &token_program_id,
+            &source_pubkey,
+            &mint_pubkey,
+            &delegate_pubkey,
+            &owner_pubkey,
+            &signer_pubkeys,
+            amount,
+            decimals
+        ));
+        test_instruction!(revoke(
+            &token_program_id,
+            &source_pubkey,
+            &owner_pubkey,
+            &signer_pubkeys,
+        ));
 
-    //     // set_authority
-    //     {
-    //         let instruction_v3 = spl_token::instruction::set_authority(
-    //             &token_program_id,
-    //             &owned_pubkey,
-    //             Some(&new_authority_pubkey),
-    //             spl_token::instruction::AuthorityType::AccountOwner,
-    //             &owner_pubkey,
-    //             &signer_pubkeys,
-    //         )
-    //         .unwrap();
-    //         let instruction_2022 = set_authority(
-    //             &token_program_id,
-    //             &owned_pubkey,
-    //             Some(&new_authority_pubkey),
-    //             AuthorityType::AccountOwner,
-    //             &owner_pubkey,
-    //             &signer_pubkeys,
-    //         )
-    //         .unwrap();
-    //         assert_eq!(instruction_v3, instruction_2022);
-    //     }
+        // set_authority
+        {
+            let instruction_v3 = spl_token::instruction::set_authority(
+                &token_program_id,
+                &owned_pubkey,
+                Some(&new_authority_pubkey),
+                spl_token::instruction::AuthorityType::AccountOwner,
+                &owner_pubkey,
+                &signer_pubkeys,
+            )
+            .unwrap();
+            let instruction_2022 = set_authority(
+                &token_program_id,
+                &owned_pubkey,
+                Some(&new_authority_pubkey),
+                AuthorityType::AccountOwner,
+                &owner_pubkey,
+                &signer_pubkeys,
+            )
+            .unwrap();
+            assert_eq!(instruction_v3, instruction_2022);
+        }
 
-    //     test_instruction!(mint_to(
-    //         &token_program_id,
-    //         &mint_pubkey,
-    //         &account_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //         amount,
-    //     ));
-    //     test_instruction!(mint_to_checked(
-    //         &token_program_id,
-    //         &mint_pubkey,
-    //         &account_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //         amount,
-    //         decimals,
-    //     ));
-    //     test_instruction!(burn(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &authority_pubkey,
-    //         &signer_pubkeys,
-    //         amount,
-    //     ));
-    //     test_instruction!(burn_checked(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &authority_pubkey,
-    //         &signer_pubkeys,
-    //         amount,
-    //         decimals,
-    //     ));
-    //     test_instruction!(close_account(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &destination_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //     ));
-    //     test_instruction!(freeze_account(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //     ));
-    //     test_instruction!(thaw_account(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //         &mint_pubkey,
-    //         &owner_pubkey,
-    //         &signer_pubkeys,
-    //     ));
-    //     test_instruction!(sync_native(&token_program_id, &account_pubkey,));
+        // test_instruction!(mint_to(
+        //     &token_program_id,
+        //     &mint_pubkey,
+        //     &account_pubkey,
+        //     &owner_pubkey,
+        //     &signer_pubkeys,
+        //     amount,
+        // ));
+        // test_instruction!(mint_to_checked(
+        //     &token_program_id,
+        //     &mint_pubkey,
+        //     &account_pubkey,
+        //     &owner_pubkey,
+        //     &signer_pubkeys,
+        //     amount,
+        //     decimals,
+        // ));
+        test_instruction!(burn(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &authority_pubkey,
+            &signer_pubkeys,
+            amount,
+        ));
+        test_instruction!(burn_checked(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &authority_pubkey,
+            &signer_pubkeys,
+            amount,
+            decimals,
+        ));
+        test_instruction!(close_account(
+            &token_program_id,
+            &account_pubkey,
+            &destination_pubkey,
+            &owner_pubkey,
+            &signer_pubkeys,
+        ));
+        test_instruction!(freeze_account(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &owner_pubkey,
+            &signer_pubkeys,
+        ));
+        test_instruction!(thaw_account(
+            &token_program_id,
+            &account_pubkey,
+            &mint_pubkey,
+            &owner_pubkey,
+            &signer_pubkeys,
+        ));
+        test_instruction!(sync_native(&token_program_id, &account_pubkey,));
 
-    //     // get_account_data_size
-    //     {
-    //         let instruction_v3 =
-    //             spl_token::instruction::get_account_data_size(&token_program_id, &mint_pubkey)
-    //                 .unwrap();
-    //         let instruction_2022 =
-    //             get_account_data_size(&token_program_id, &mint_pubkey, &[]).unwrap();
-    //         assert_eq!(instruction_v3, instruction_2022);
-    //     }
+        // get_account_data_size
+        {
+            let instruction_v3 =
+                spl_token::instruction::get_account_data_size(&token_program_id, &mint_pubkey)
+                    .unwrap();
+            let instruction_2022 =
+                get_account_data_size(&token_program_id, &mint_pubkey, &[]).unwrap();
+            assert_eq!(instruction_v3, instruction_2022);
+        }
 
-    //     test_instruction!(initialize_immutable_owner(
-    //         &token_program_id,
-    //         &account_pubkey,
-    //     ));
+        test_instruction!(initialize_immutable_owner(
+            &token_program_id,
+            &account_pubkey,
+        ));
 
-    //     test_instruction!(amount_to_ui_amount(&token_program_id, &mint_pubkey, amount,));
+        test_instruction!(amount_to_ui_amount(&token_program_id, &mint_pubkey, amount,));
 
-    //     test_instruction!(ui_amount_to_amount(
-    //         &token_program_id,
-    //         &mint_pubkey,
-    //         ui_amount,
-    //     ));
-    // }
+        test_instruction!(ui_amount_to_amount(
+            &token_program_id,
+            &mint_pubkey,
+            ui_amount,
+        ));
+    }
 
-    // proptest! {
-    //     #![proptest_config(ProptestConfig::with_cases(1024))]
-    //     #[test]
-    //     fn test_instruction_unpack_proptest(
-    //         data in prop::collection::vec(any::<u8>(), 0..255)
-    //     ) {
-    //         let _no_panic = TokenInstruction::unpack(&data);
-    //     }
-    // }
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+        #[test]
+        fn test_instruction_unpack_proptest(
+            data in prop::collection::vec(any::<u8>(), 0..255)
+        ) {
+            let _no_panic = TokenInstruction::unpack(&data);
+        }
+    }
 }

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2614,6 +2614,83 @@ mod test {
         }
     }
 
+    // Special macro for mint_to and mint_to_checked which have different parameters
+    macro_rules! test_instruction_mint {
+        (mint_to(
+            $token_program_id:expr,
+            $mint_pubkey:expr,
+            $account_pubkey:expr,
+            $mint_authority_pubkey:expr,
+            $whitelist_entry_pubkey:expr,
+            $signer_pubkeys:expr,
+            $amount:expr $(,)?
+        )) => {
+            let instruction_v3 = spl_token::instruction::mint_to(
+                $token_program_id,
+                $mint_pubkey,
+                $account_pubkey,
+                $mint_authority_pubkey,
+                $signer_pubkeys,
+                $amount,
+            )
+            .unwrap();
+
+            let instruction_2022 = mint_to(
+                $token_program_id,
+                $mint_pubkey,
+                $account_pubkey,
+                $mint_authority_pubkey,
+                $whitelist_entry_pubkey,
+                $signer_pubkeys,
+                $amount,
+            )
+            .unwrap();
+
+            // We expect differences due to the additional whitelist account
+            assert_eq!(instruction_v3.program_id, instruction_2022.program_id);
+            assert_eq!(instruction_v3.data, instruction_2022.data);
+            // Account array will be different lengths due to whitelist account
+        };
+        (mint_to_checked(
+            $token_program_id:expr,
+            $mint_pubkey:expr,
+            $account_pubkey:expr,
+            $mint_authority_pubkey:expr,
+            $whitelist_entry_pubkey:expr,
+            $signer_pubkeys:expr,
+            $amount:expr,
+            $decimals:expr $(,)?
+        )) => {
+            let instruction_v3 = spl_token::instruction::mint_to_checked(
+                $token_program_id,
+                $mint_pubkey,
+                $account_pubkey,
+                $mint_authority_pubkey,
+                $signer_pubkeys,
+                $amount,
+                $decimals,
+            )
+            .unwrap();
+
+            let instruction_2022 = mint_to_checked(
+                $token_program_id,
+                $mint_pubkey,
+                $account_pubkey,
+                $mint_authority_pubkey,
+                $whitelist_entry_pubkey,
+                $signer_pubkeys,
+                $amount,
+                $decimals,
+            )
+            .unwrap();
+
+            // We expect differences due to the additional whitelist account
+            assert_eq!(instruction_v3.program_id, instruction_2022.program_id);
+            assert_eq!(instruction_v3.data, instruction_2022.data);
+            // Account array will be different lengths due to whitelist account
+        };
+    }
+
     #[test]
     fn test_v3_compatibility() {
         let token_program_id = spl_token::id();
@@ -2624,6 +2701,7 @@ mod test {
 
         let account_pubkey = Pubkey::new_unique();
         let owner_pubkey = Pubkey::new_unique();
+        let whitelist_entry_pubkey = Pubkey::new_unique();
 
         let multisig_pubkey = Pubkey::new_unique();
         let signer_pubkeys_vec = vec![Pubkey::new_unique(); MAX_SIGNERS];
@@ -2755,23 +2833,26 @@ mod test {
             assert_eq!(instruction_v3, instruction_2022);
         }
 
-        // test_instruction!(mint_to(
-        //     &token_program_id,
-        //     &mint_pubkey,
-        //     &account_pubkey,
-        //     &owner_pubkey,
-        //     &signer_pubkeys,
-        //     amount,
-        // ));
-        // test_instruction!(mint_to_checked(
-        //     &token_program_id,
-        //     &mint_pubkey,
-        //     &account_pubkey,
-        //     &owner_pubkey,
-        //     &signer_pubkeys,
-        //     amount,
-        //     decimals,
-        // ));
+        test_instruction_mint!(mint_to(
+            &token_program_id,
+            &mint_pubkey,
+            &account_pubkey,
+            &owner_pubkey,
+            &whitelist_entry_pubkey,
+            &signer_pubkeys,
+            amount,
+        ));
+        test_instruction_mint!(mint_to_checked(
+            &token_program_id,
+            &mint_pubkey,
+            &account_pubkey,
+            &owner_pubkey,
+            &whitelist_entry_pubkey,
+            &signer_pubkeys,
+            amount,
+            decimals,
+        ));
+
         test_instruction!(burn(
             &token_program_id,
             &account_pubkey,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1741,6 +1741,7 @@ pub fn mint_to_checked(
     mint_pubkey: &Pubkey,
     account_pubkey: &Pubkey,
     mint_authority_pubkey: &Pubkey,
+    whitelist_entry_pubkey: &Pubkey,
     signer_pubkeys: &[&Pubkey],
     amount: u64,
     decimals: u8,
@@ -1755,6 +1756,7 @@ pub fn mint_to_checked(
         *mint_authority_pubkey,
         signer_pubkeys.is_empty(),
     ));
+    accounts.push(AccountMeta::new_readonly(*whitelist_entry_pubkey, false));
     for signer_pubkey in signer_pubkeys.iter() {
         accounts.push(AccountMeta::new_readonly(**signer_pubkey, true));
     }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -60,10 +60,7 @@ use {
     spl_token_group_interface::instruction::TokenGroupInstruction,
     spl_token_metadata_interface::instruction::TokenMetadataInstruction,
     std::convert::{TryFrom, TryInto},
-    token_whitelist_interface::{
-        address::get_whitelist_entry_address, state::entry::WhitelistEntryAccount,
-        state::Initializable,
-    },
+    token_whitelist_interface::{state::entry::WhitelistEntryAccount, state::Initializable},
 };
 
 pub(crate) enum TransferInstruction {
@@ -1986,9 +1983,15 @@ impl Processor {
         whitelist_entry_info: &AccountInfo,
         mint_authority: &Pubkey,
     ) -> Result<(), ProgramError> {
-        let whitelist_entry_address = get_whitelist_entry_address(&mint_authority.to_bytes());
+        let (whitelist_entry_address, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &mint_authority.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
 
-        if whitelist_entry_info.key.to_bytes() != whitelist_entry_address {
+        if whitelist_entry_info.key != &whitelist_entry_address {
             return Err(ProgramError::InvalidSeeds);
         }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2069,6 +2069,7 @@ mod tests {
         solana_program_option::COption,
         solana_sdk_ids::sysvar::rent,
         std::sync::{Arc, RwLock},
+        token_whitelist_interface::state::Transmutable,
     };
 
     lazy_static::lazy_static! {
@@ -2482,10 +2483,47 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
+        let whitelist_entry_info: AccountInfo =
+            (&whitelist_entry_key, true, &mut whitelist_entry_account).into();
+
         // mint to account
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -2592,8 +2630,22 @@ mod tests {
         )
         .unwrap();
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account3_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account3_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account3_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account3_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -2663,8 +2715,22 @@ mod tests {
         .unwrap();
 
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account4_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account4_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account4_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account4_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -2810,10 +2876,44 @@ mod tests {
         account.mint = mint2_key;
         Account::pack(account, &mut mismatch_account.data).unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to account
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
@@ -3298,10 +3398,44 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to account
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
@@ -3807,10 +3941,44 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 42).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                42,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
         let _ = Mint::unpack(&mint_account.data).unwrap();
@@ -3826,12 +3994,18 @@ mod tests {
                     &mint_key,
                     &account_key,
                     &owner_key,
+                    &whitelist_entry_key,
                     &[],
                     42,
                     decimals + 1
                 )
                 .unwrap(),
-                vec![&mut mint_account, &mut account_account, &mut owner_account],
+                vec![
+                    &mut mint_account,
+                    &mut account_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account,
+                ],
             )
         );
 
@@ -3846,12 +4020,18 @@ mod tests {
                 &mint_key,
                 &account_key,
                 &owner_key,
+                &whitelist_entry_key,
                 &[],
                 42,
                 decimals,
             )
             .unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
         let _ = Mint::unpack(&mint_account.data).unwrap();
@@ -3932,10 +4112,47 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
+        let whitelist_entry_info: AccountInfo =
+            (&whitelist_entry_key, true, &mut whitelist_entry_account).into();
+
         // mint to account
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -4010,8 +4227,22 @@ mod tests {
         .unwrap();
 
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account3_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account3_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account3_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account3_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -4157,10 +4388,44 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to account
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
@@ -4938,17 +5203,69 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &mint_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&mint_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
+        let whitelist_entry_info: AccountInfo =
+            (&whitelist_entry_key, true, &mut whitelist_entry_account).into();
+
         // mint_to when mint_authority is self
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &mint_key, &[], 42).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), mint_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &mint_key,
+                &whitelist_entry_key,
+                &[],
+                42,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                mint_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
         // mint_to_checked when mint_authority is self
         do_process_instruction_dups(
-            mint_to_checked(&program_id, &mint_key, &account1_key, &mint_key, &[], 42, 2).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), mint_info.clone()],
+            mint_to_checked(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &mint_key,
+                &whitelist_entry_key,
+                &[],
+                42,
+                2,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                mint_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -4956,12 +5273,37 @@ mod tests {
         let mut mint = Mint::unpack_unchecked(&mint_info.data.borrow()).unwrap();
         mint.mint_authority = COption::Some(account1_key);
         Mint::pack(mint, &mut mint_info.data.borrow_mut()).unwrap();
+
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &account1_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&account1_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
+        let whitelist_entry_info: AccountInfo =
+            (&whitelist_entry_key, true, &mut whitelist_entry_account).into();
+
         do_process_instruction_dups(
             mint_to(
                 &program_id,
                 &mint_key,
                 &account1_key,
                 &account1_key,
+                &whitelist_entry_key,
                 &[],
                 42,
             )
@@ -4970,6 +5312,7 @@ mod tests {
                 mint_info.clone(),
                 account1_info.clone(),
                 account1_info.clone(),
+                whitelist_entry_info.clone(),
             ],
         )
         .unwrap();
@@ -4981,6 +5324,7 @@ mod tests {
                 &mint_key,
                 &account1_key,
                 &account1_key,
+                &whitelist_entry_key,
                 &[],
                 42,
             )
@@ -4989,6 +5333,7 @@ mod tests {
                 mint_info.clone(),
                 account1_info.clone(),
                 account1_info.clone(),
+                whitelist_entry_info.clone(),
             ],
         )
         .unwrap();
@@ -5095,10 +5440,44 @@ mod tests {
         account.mint = mint2_key;
         Account::pack(account, &mut mismatch_account.data).unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 42).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                42,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
@@ -5109,8 +5488,22 @@ mod tests {
 
         // mint to another account to test supply accumulation
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account2_key, &owner_key, &[], 42).unwrap(),
-            vec![&mut mint_account, &mut account2_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account2_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                42,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account2_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
@@ -5120,14 +5513,27 @@ mod tests {
         assert_eq!(account.amount, 42);
 
         // missing signer
-        let mut instruction =
-            mint_to(&program_id, &mint_key, &account2_key, &owner_key, &[], 42).unwrap();
+        let mut instruction = mint_to(
+            &program_id,
+            &mint_key,
+            &account2_key,
+            &owner_key,
+            &whitelist_entry_key,
+            &[],
+            42,
+        )
+        .unwrap();
         instruction.accounts[2].is_signer = false;
         assert_eq!(
             Err(ProgramError::MissingRequiredSignature),
             do_process_instruction(
                 instruction,
-                vec![&mut mint_account, &mut account2_account, &mut owner_account],
+                vec![
+                    &mut mint_account,
+                    &mut account2_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account,
+                ],
             )
         );
 
@@ -5135,8 +5541,22 @@ mod tests {
         assert_eq!(
             Err(TokenError::MintMismatch.into()),
             do_process_instruction(
-                mint_to(&program_id, &mint_key, &mismatch_key, &owner_key, &[], 42).unwrap(),
-                vec![&mut mint_account, &mut mismatch_account, &mut owner_account],
+                mint_to(
+                    &program_id,
+                    &mint_key,
+                    &mismatch_key,
+                    &owner_key,
+                    &whitelist_entry_key,
+                    &[],
+                    42
+                )
+                .unwrap(),
+                vec![
+                    &mut mint_account,
+                    &mut mismatch_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account,
+                ],
             )
         );
 
@@ -5144,11 +5564,21 @@ mod tests {
         assert_eq!(
             Err(TokenError::OwnerMismatch.into()),
             do_process_instruction(
-                mint_to(&program_id, &mint_key, &account2_key, &owner2_key, &[], 42).unwrap(),
+                mint_to(
+                    &program_id,
+                    &mint_key,
+                    &account2_key,
+                    &owner2_key,
+                    &whitelist_entry_key,
+                    &[],
+                    42,
+                )
+                .unwrap(),
                 vec![
                     &mut mint_account,
                     &mut account2_account,
                     &mut owner2_account,
+                    &mut whitelist_entry_account,
                 ],
             )
         );
@@ -5159,8 +5589,22 @@ mod tests {
         assert_eq!(
             Err(ProgramError::IncorrectProgramId),
             do_process_instruction(
-                mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 0).unwrap(),
-                vec![&mut mint_account, &mut account_account, &mut owner_account],
+                mint_to(
+                    &program_id,
+                    &mint_key,
+                    &account_key,
+                    &owner_key,
+                    &whitelist_entry_key,
+                    &[],
+                    0
+                )
+                .unwrap(),
+                vec![
+                    &mut mint_account,
+                    &mut account_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account
+                ],
             )
         );
         mint_account.owner = program_id;
@@ -5171,8 +5615,22 @@ mod tests {
         assert_eq!(
             Err(ProgramError::IncorrectProgramId),
             do_process_instruction(
-                mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 0).unwrap(),
-                vec![&mut mint_account, &mut account_account, &mut owner_account],
+                mint_to(
+                    &program_id,
+                    &mint_key,
+                    &account_key,
+                    &owner_key,
+                    &whitelist_entry_key,
+                    &[],
+                    0
+                )
+                .unwrap(),
+                vec![
+                    &mut mint_account,
+                    &mut account_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account,
+                ],
             )
         );
         account_account.owner = program_id;
@@ -5186,6 +5644,7 @@ mod tests {
                     &mint_key,
                     &uninitialized_key,
                     &owner_key,
+                    &whitelist_entry_key,
                     &[],
                     42
                 )
@@ -5194,6 +5653,7 @@ mod tests {
                     &mut mint_account,
                     &mut uninitialized_account,
                     &mut owner_account,
+                    &mut whitelist_entry_account,
                 ],
             )
         );
@@ -5215,8 +5675,22 @@ mod tests {
         assert_eq!(
             Err(TokenError::FixedSupply.into()),
             do_process_instruction(
-                mint_to(&program_id, &mint_key, &account2_key, &owner_key, &[], 42).unwrap(),
-                vec![&mut mint_account, &mut account2_account, &mut owner_account],
+                mint_to(
+                    &program_id,
+                    &mint_key,
+                    &account2_key,
+                    &owner_key,
+                    &whitelist_entry_key,
+                    &[],
+                    42
+                )
+                .unwrap(),
+                vec![
+                    &mut mint_account,
+                    &mut account2_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account
+                ],
             )
         );
     }
@@ -5261,10 +5735,47 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
+        let whitelist_entry_info: AccountInfo =
+            (&whitelist_entry_key, true, &mut whitelist_entry_account).into();
+
         // mint to account
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
 
@@ -5309,8 +5820,22 @@ mod tests {
 
         // mint-owner burn
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
         let mut account = Account::unpack_unchecked(&account1_info.data.borrow()).unwrap();
@@ -5340,8 +5865,22 @@ mod tests {
 
         // source-delegate burn
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
         let mut account = Account::unpack_unchecked(&account1_info.data.borrow()).unwrap();
@@ -5389,8 +5928,22 @@ mod tests {
 
         // mint-delegate burn
         do_process_instruction_dups(
-            mint_to(&program_id, &mint_key, &account1_key, &owner_key, &[], 1000).unwrap(),
-            vec![mint_info.clone(), account1_info.clone(), owner_info.clone()],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account1_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                mint_info.clone(),
+                account1_info.clone(),
+                owner_info.clone(),
+                whitelist_entry_info.clone(),
+            ],
         )
         .unwrap();
         let mut account = Account::unpack_unchecked(&account1_info.data.borrow()).unwrap();
@@ -5515,17 +6068,65 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to account
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
         // mint to mismatch account and change mint key
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &mismatch_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut mismatch_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &mismatch_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut mismatch_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
         let mut account = Account::unpack_unchecked(&mismatch_account.data).unwrap();
@@ -5849,6 +6450,25 @@ mod tests {
             ],
         )
         .unwrap();
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &multisig_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&multisig_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
 
         // mint to account
         let account_info_iter = &mut signer_accounts.iter_mut();
@@ -5858,6 +6478,7 @@ mod tests {
                 &mint_key,
                 &account_key,
                 &multisig_key,
+                &whitelist_entry_key,
                 &[&signer_keys[0]],
                 1000,
             )
@@ -5866,6 +6487,7 @@ mod tests {
                 &mut mint_account,
                 &mut account,
                 &mut multisig_account,
+                &mut whitelist_entry_account,
                 account_info_iter.next().unwrap(),
             ],
         )
@@ -5954,6 +6576,7 @@ mod tests {
                 &mint_key,
                 &account2_key,
                 &multisig_key,
+                &whitelist_entry_key,
                 &[&signer_keys[0]],
                 42,
             )
@@ -5962,6 +6585,7 @@ mod tests {
                 &mut mint_account,
                 &mut account2_account,
                 &mut multisig_account,
+                &mut whitelist_entry_account,
                 account_info_iter.next().unwrap(),
             ],
         )
@@ -6058,6 +6682,7 @@ mod tests {
                 &mint2_key,
                 &account3_key,
                 &multisig_key,
+                &whitelist_entry_key,
                 &[&signer_keys[0]],
                 1000,
             )
@@ -6066,6 +6691,7 @@ mod tests {
                 &mut mint2_account,
                 &mut account3_account,
                 &mut multisig_account,
+                &mut whitelist_entry_account,
                 account_info_iter.next().unwrap(),
             ],
         )
@@ -6575,12 +7201,43 @@ mod tests {
             ],
         )
         .unwrap();
+
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 42).unwrap(),
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                42,
+            )
+            .unwrap(),
             vec![
                 &mut mint_account,
                 &mut account_account,
                 &mut owner_account,
+                &mut whitelist_entry_account,
                 &mut rent_sysvar,
             ],
         )
@@ -6809,6 +7466,26 @@ mod tests {
         assert!(account.is_native());
         assert_eq!(account.amount, 0);
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint_to unsupported
         assert_eq!(
             Err(TokenError::NativeNotSupported.into()),
@@ -6818,11 +7495,17 @@ mod tests {
                     &crate::native_mint::id(),
                     &account_key,
                     &owner_key,
+                    &whitelist_entry_key,
                     &[],
                     42
                 )
                 .unwrap(),
-                vec![&mut mint_account, &mut account_account, &mut owner_account],
+                vec![
+                    &mut mint_account,
+                    &mut account_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account,
+                ],
             )
         );
 
@@ -7014,6 +7697,26 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &mint_owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&mint_owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint the max to an account
         do_process_instruction(
             mint_to(
@@ -7021,6 +7724,7 @@ mod tests {
                 &mint_key,
                 &account_key,
                 &mint_owner_key,
+                &whitelist_entry_key,
                 &[],
                 u64::MAX,
             )
@@ -7029,6 +7733,7 @@ mod tests {
                 &mut mint_account,
                 &mut account_account,
                 &mut mint_owner_account,
+                &mut whitelist_entry_account,
             ],
         )
         .unwrap();
@@ -7044,6 +7749,7 @@ mod tests {
                     &mint_key,
                     &account_key,
                     &mint_owner_key,
+                    &whitelist_entry_key,
                     &[],
                     1,
                 )
@@ -7052,6 +7758,7 @@ mod tests {
                     &mut mint_account,
                     &mut account_account,
                     &mut mint_owner_account,
+                    &mut whitelist_entry_account,
                 ],
             )
         );
@@ -7067,6 +7774,7 @@ mod tests {
                     &mint_key,
                     &account2_key,
                     &mint_owner_key,
+                    &whitelist_entry_key,
                     &[],
                     1,
                 )
@@ -7075,6 +7783,7 @@ mod tests {
                     &mut mint_account,
                     &mut account2_account,
                     &mut mint_owner_account,
+                    &mut whitelist_entry_account,
                 ],
             )
         );
@@ -7094,6 +7803,7 @@ mod tests {
                 &mint_key,
                 &account_key,
                 &mint_owner_key,
+                &whitelist_entry_key,
                 &[],
                 100,
             )
@@ -7102,6 +7812,7 @@ mod tests {
                 &mut mint_account,
                 &mut account_account,
                 &mut mint_owner_account,
+                &mut whitelist_entry_account,
             ],
         )
         .unwrap();
@@ -7188,10 +7899,44 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // fund first account
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 
@@ -7308,8 +8053,22 @@ mod tests {
         assert_eq!(
             Err(TokenError::AccountFrozen.into()),
             do_process_instruction(
-                mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 100).unwrap(),
-                vec![&mut mint_account, &mut account_account, &mut owner_account,],
+                mint_to(
+                    &program_id,
+                    &mint_key,
+                    &account_key,
+                    &owner_key,
+                    &whitelist_entry_key,
+                    &[],
+                    100
+                )
+                .unwrap(),
+                vec![
+                    &mut mint_account,
+                    &mut account_account,
+                    &mut owner_account,
+                    &mut whitelist_entry_account,
+                ],
             )
         );
 
@@ -7426,10 +8185,44 @@ mod tests {
         )
         .unwrap();
 
+        let (whitelist_entry_key, _) = Pubkey::find_program_address(
+            &[
+                &token_whitelist_interface::whitelist::id(),
+                &owner_key.to_bytes(),
+            ],
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        let mut whitelist_entry_account = SolanaAccount::new(
+            Rent::default().minimum_balance(
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            ),
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            &Pubkey::new_from_array(token_whitelist_interface::program::id()),
+        );
+
+        whitelist_entry_account.data[0..32].copy_from_slice(&owner_key.to_bytes());
+        whitelist_entry_account.data[32] =
+            token_whitelist_interface::state::account_state::AccountState::Initialized as u8;
+
         // mint to account
         do_process_instruction(
-            mint_to(&program_id, &mint_key, &account_key, &owner_key, &[], 1000).unwrap(),
-            vec![&mut mint_account, &mut account_account, &mut owner_account],
+            mint_to(
+                &program_id,
+                &mint_key,
+                &account_key,
+                &owner_key,
+                &whitelist_entry_key,
+                &[],
+                1000,
+            )
+            .unwrap(),
+            vec![
+                &mut mint_account,
+                &mut account_account,
+                &mut owner_account,
+                &mut whitelist_entry_account,
+            ],
         )
         .unwrap();
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -986,6 +986,8 @@ impl Processor {
         let owner_info = next_account_info(account_info_iter)?;
         let owner_info_data_len = owner_info.data_len();
 
+        let whitelist_entry_info = next_account_info(account_info_iter)?;
+
         let mut destination_account_data = destination_account_info.data.borrow_mut();
         let destination_account =
             PodStateWithExtensionsMut::<PodAccount>::unpack(&mut destination_account_data)?;
@@ -1033,13 +1035,16 @@ impl Processor {
             PodCOption {
                 option: PodCOption::<Pubkey>::SOME,
                 value: mint_authority,
-            } => Self::validate_owner(
-                program_id,
-                mint_authority,
-                owner_info,
-                owner_info_data_len,
-                account_info_iter.as_slice(),
-            )?,
+            } => {
+                Self::validate_owner(
+                    program_id,
+                    mint_authority,
+                    owner_info,
+                    owner_info_data_len,
+                    account_info_iter.as_slice(),
+                )?;
+                Self::validate_whitelisted_authority(&whitelist_entry_info, mint_authority)?;
+            }
             _ => return Err(TokenError::FixedSupply.into()),
         }
 

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -2069,7 +2069,7 @@ mod tests {
         solana_program_option::COption,
         solana_sdk_ids::sysvar::rent,
         std::sync::{Arc, RwLock},
-        token_whitelist_interface::state::Transmutable,
+        token_whitelist_interface::state::SizeOf,
     };
 
     lazy_static::lazy_static! {
@@ -2493,9 +2493,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -2886,9 +2886,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -3408,9 +3408,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -3951,9 +3951,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -4122,9 +4122,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -4398,9 +4398,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -5213,9 +5213,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -5284,9 +5284,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -5402,9 +5402,9 @@ mod tests {
         // Create an uninitialized whitelist entry account
         let mut uninitialized_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
         // Leave the data empty/uninitialized
@@ -5549,9 +5549,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -5847,9 +5847,9 @@ mod tests {
         // Create an uninitialized whitelist entry account
         let mut uninitialized_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
         // Don't initialize it properly - leave the data empty
@@ -5927,9 +5927,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -6260,9 +6260,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -6642,9 +6642,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -7394,9 +7394,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -7658,9 +7658,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -7889,9 +7889,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -8091,9 +8091,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -8377,9 +8377,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -9356,9 +9356,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -9387,9 +9387,9 @@ mod tests {
 
         let mut wrong_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 
@@ -9416,9 +9416,9 @@ mod tests {
 
         let mut whitelist_entry_account = SolanaAccount::new(
             Rent::default().minimum_balance(
-                token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+                token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             ),
-            token_whitelist_interface::state::entry::WhitelistEntryAccount::LEN,
+            token_whitelist_interface::state::entry::WhitelistEntryAccount::SIZE_OF,
             &Pubkey::new_from_array(token_whitelist_interface::program::id()),
         );
 

--- a/program/tests/action.rs
+++ b/program/tests/action.rs
@@ -82,13 +82,20 @@ pub async fn mint_to(
     mint: &Pubkey,
     account: &Pubkey,
     mint_authority: &Keypair,
+    whitelist_entry: &Pubkey,
     amount: u64,
 ) -> Result<(), TransportError> {
     let transaction = Transaction::new_signed_with_payer(
-        &[
-            instruction::mint_to(&id(), mint, account, &mint_authority.pubkey(), &[], amount)
-                .unwrap(),
-        ],
+        &[instruction::mint_to(
+            &id(),
+            mint,
+            account,
+            &mint_authority.pubkey(),
+            &whitelist_entry,
+            &[],
+            amount,
+        )
+        .unwrap()],
         Some(&payer.pubkey()),
         &[payer, mint_authority],
         recent_blockhash,

--- a/program/tests/assert_instruction_count.rs
+++ b/program/tests/assert_instruction_count.rs
@@ -112,12 +112,15 @@ async fn initialize_account() {
 async fn mint_to() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_compute_max_units(8_000); // last known 967
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
     let mint = Keypair::new();
     let account = Keypair::new();
     let decimals = 9;
+
+    let whitelist_entry_key = action::create_whitelist_entry(&mut pt, &owner.pubkey());
+
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     action::create_mint(
         &mut banks_client,
@@ -146,6 +149,7 @@ async fn mint_to() {
             &mint.pubkey(),
             &account.pubkey(),
             &owner.pubkey(),
+            &whitelist_entry_key,
             &[],
             TRANSFER_AMOUNT,
         )
@@ -161,13 +165,16 @@ async fn mint_to() {
 async fn transfer() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_compute_max_units(8_000); // last known 1222
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
     let mint = Keypair::new();
     let source = Keypair::new();
     let destination = Keypair::new();
     let decimals = 9;
+
+    let whitelist_entry_key = action::create_whitelist_entry(&mut pt, &owner.pubkey());
+
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     action::create_mint(
         &mut banks_client,
@@ -207,6 +214,7 @@ async fn transfer() {
         &mint.pubkey(),
         &source.pubkey(),
         &owner,
+        &whitelist_entry_key,
         TRANSFER_AMOUNT,
     )
     .await
@@ -229,13 +237,16 @@ async fn transfer() {
 async fn transfer_checked() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_compute_max_units(8_000); // last known 1516
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
     let mint = Keypair::new();
     let source = Keypair::new();
     let destination = Keypair::new();
     let decimals = 9;
+
+    let whitelist_entry_key = action::create_whitelist_entry(&mut pt, &owner.pubkey());
+
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     action::create_mint(
         &mut banks_client,
@@ -275,6 +286,7 @@ async fn transfer_checked() {
         &mint.pubkey(),
         &source.pubkey(),
         &owner,
+        &whitelist_entry_key,
         TRANSFER_AMOUNT,
     )
     .await
@@ -299,12 +311,15 @@ async fn transfer_checked() {
 async fn burn() {
     let mut pt = ProgramTest::new("spl_token_2022", id(), processor!(Processor::process));
     pt.set_compute_max_units(8_000); // last known 1070
-    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     let owner = Keypair::new();
     let mint = Keypair::new();
     let account = Keypair::new();
     let decimals = 9;
+
+    let whitelist_entry_key = action::create_whitelist_entry(&mut pt, &owner.pubkey());
+
+    let (mut banks_client, payer, recent_blockhash) = pt.start().await;
 
     action::create_mint(
         &mut banks_client,
@@ -334,6 +349,7 @@ async fn burn() {
         &mint.pubkey(),
         &account.pubkey(),
         &owner,
+        &whitelist_entry_key,
         TRANSFER_AMOUNT,
     )
     .await


### PR DESCRIPTION
Modified the mint_to and mint_to_checked instructions and processor to check the mint authority against a whitelist managed by the token whitelist program. This is done by adding a new whitelist_entry_account to the list of accounts for each instruction.