### PR TITLE
Update IDL: Add Authority Types

### DIFF
--- a/clients/js/src/generated/types/authorityType.ts
+++ b/clients/js/src/generated/types/authorityType.ts
@@ -20,6 +20,19 @@ export enum AuthorityType {
   FreezeAccount,
   AccountOwner,
   CloseAccount,
+  TransferFeeConfig,
+  WithheldWithdraw,
+  CloseMint,
+  InterestRate,
+  PermanentDelegate,
+  ConfidentialTransferMint,
+  TransferHookProgramId,
+  ConfidentialTransferFeeConfig,
+  MetadataPointer,
+  GroupPointer,
+  GroupMemberPointer,
+  ScaledUiAmount,
+  Pause,
 }
 
 export type AuthorityTypeArgs = AuthorityType;

--- a/program/idl.json
+++ b/program/idl.json
@@ -8286,6 +8286,58 @@
             {
               "kind": "enumEmptyVariantTypeNode",
               "name": "closeAccount"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "transferFeeConfig"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "withheldWithdraw"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "closeMint"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "interestRate"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "permanentDelegate"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "confidentialTransferMint"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "transferHookProgramId"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "confidentialTransferFeeConfig"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "metadataPointer"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "groupPointer"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "groupMemberPointer"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "scaledUiAmount"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "pause"
             }
           ],
           "size": {


### PR DESCRIPTION

# Update IDL: Add Authority Types & Regenerate TypeScript Client

This PR updates the on-chain Interface Definition Language (IDL) to explicitly model **authority-related types** and regenerates the ts client to reflect those changes.

## What’s New

### IDL (`program/idl.json`)
1. Added **authorityType**:
-   TransferFeeConfig,
-   WithheldWithdraw,
-   CloseMint,
-   InterestRate,
-   PermanentDelegate,
-   ConfidentialTransferMint,
-   TransferHookProgramId,
-   ConfidentialTransferFeeConfig,
-   MetadataPointer,
-   GroupPointer,
-   GroupMemberPointer,
-   ScaledUiAmount,
-   Pause,

### Generated TS Client
`pnpm generate:clients`