### PR TITLE
[js-legacy] Fix program check in amountToUiAmount helper functions

### DIFF
--- a/clients/js-legacy/src/actions/amountToUiAmount.ts
+++ b/clients/js-legacy/src/actions/amountToUiAmount.ts
@@ -190,7 +190,7 @@ export async function amountToUiAmountForMintWithoutSimulation(
     const accountInfo = await connection.getAccountInfo(mint);
     const programId = accountInfo?.owner;
 
-    if (programId !== TOKEN_PROGRAM_ID || programId !== TOKEN_2022_PROGRAM_ID) {
+    if (!programId?.equals(TOKEN_PROGRAM_ID) && !programId?.equals(TOKEN_2022_PROGRAM_ID)) {
         throw new Error('Invalid program ID');
     }
 
@@ -317,7 +317,7 @@ export async function uiAmountToAmountForMintWithoutSimulation(
     const accountInfo = await connection.getAccountInfo(mint);
     const programId = accountInfo?.owner;
 
-    if (programId !== TOKEN_PROGRAM_ID || programId !== TOKEN_2022_PROGRAM_ID) {
+    if (!programId?.equals(TOKEN_PROGRAM_ID) && !programId?.equals(TOKEN_2022_PROGRAM_ID)) {
         throw new Error('Invalid program ID');
     }
 

--- a/clients/js-legacy/src/actions/amountToUiAmount.ts
+++ b/clients/js-legacy/src/actions/amountToUiAmount.ts
@@ -190,7 +190,7 @@ export async function amountToUiAmountForMintWithoutSimulation(
     const accountInfo = await connection.getAccountInfo(mint);
     const programId = accountInfo?.owner;
 
-    if (programId !== TOKEN_PROGRAM_ID && programId !== TOKEN_2022_PROGRAM_ID) {
+    if (programId !== TOKEN_PROGRAM_ID || programId !== TOKEN_2022_PROGRAM_ID) {
         throw new Error('Invalid program ID');
     }
 
@@ -317,7 +317,7 @@ export async function uiAmountToAmountForMintWithoutSimulation(
     const accountInfo = await connection.getAccountInfo(mint);
     const programId = accountInfo?.owner;
 
-    if (programId !== TOKEN_PROGRAM_ID && programId !== TOKEN_2022_PROGRAM_ID) {
+    if (programId !== TOKEN_PROGRAM_ID || programId !== TOKEN_2022_PROGRAM_ID) {
         throw new Error('Invalid program ID');
     }
 


### PR DESCRIPTION
# Update Program ID Matching Logic

## Problem
Currently, the code uses strict equality (`===`) to compare program IDs with `TOKEN_PROGRAM_ID` and `TOKEN_2022_PROGRAM_ID`. This can lead to false negatives when comparing `PublicKey` instances, as they may have different object references even when representing the same underlying public key data.

## Solution
Replace the strict equality checks with `PublicKey.equals()` method, which properly compares the underlying public key data rather than object references.

## Changes
- Updated program ID validation in `amountToUiAmountForMintWithoutSimulation`
- Updated program ID validation in `uiAmountToAmountForMintWithoutSimulation`

## Testing
- Verified that the changes correctly identify both Token Program and Token-2022 Program IDs
- Confirmed that the validation works with different `PublicKey` instances representing the same program ID