### PR TITLE
Publish spl-token-confidential-transfer-proof-generation v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9383,7 +9383,7 @@ dependencies = [
  "spl-token 8.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spl-token-confidential-transfer-proof-extraction 0.3.0",
- "spl-token-confidential-transfer-proof-generation 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spl-token-confidential-transfer-proof-generation 0.4.0",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",
  "spl-transfer-hook-interface 0.10.0",
@@ -9440,7 +9440,7 @@ dependencies = [
  "spl-token 8.0.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic 0.3.0",
  "spl-token-confidential-transfer-proof-extraction 0.4.0",
- "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.1",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",
  "spl-transfer-hook-interface 0.10.0",
@@ -9478,7 +9478,7 @@ dependencies = [
  "spl-token 8.0.0",
  "spl-token-2022 9.0.0",
  "spl-token-client",
- "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.1",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",
  "strum 0.27.1",
@@ -9516,7 +9516,7 @@ dependencies = [
  "spl-token 8.0.0",
  "spl-token-2022 9.0.0",
  "spl-token-confidential-transfer-proof-extraction 0.4.0",
- "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.1",
  "spl-token-group-interface 0.6.0",
  "spl-token-metadata-interface 0.7.0",
  "spl-transfer-hook-interface 0.10.0",
@@ -9545,7 +9545,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-curve25519",
  "solana-zk-sdk",
- "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.1",
 ]
 
 [[package]]
@@ -9637,6 +9637,8 @@ dependencies = [
 [[package]]
 name = "spl-token-confidential-transfer-proof-generation"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
@@ -9645,9 +9647,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-confidential-transfer-proof-generation"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
+version = "0.4.1"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
@@ -9661,7 +9661,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
  "spl-token-confidential-transfer-proof-extraction 0.4.0",
- "spl-token-confidential-transfer-proof-generation 0.4.0",
+ "spl-token-confidential-transfer-proof-generation 0.4.1",
  "thiserror 2.0.12",
 ]
 

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -34,7 +34,7 @@ spl-associated-token-account-client = { version = "2.0.0" }
 spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "9.0.0", path = "../../program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.16.1", path = "../rust-legacy" }
-spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../../confidential-transfer/proof-generation" }
+spl-token-confidential-transfer-proof-generation = { version = "0.4.1", path = "../../confidential-transfer/proof-generation" }
 spl-token-metadata-interface = { version = "0.7.0" }
 spl-token-group-interface = { version = "0.6.0" }
 spl-memo = { version = "6.0", features = ["no-entrypoint"] }

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -32,7 +32,7 @@ spl-memo = { version = "6.0", features = ["no-entrypoint"] }
 spl-record = { version = "0.3.0", features = ["no-entrypoint"] }
 spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-confidential-transfer-proof-extraction = { version = "0.4.0", path = "../../confidential-transfer/proof-extraction" }
-spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../../confidential-transfer/proof-generation" }
+spl-token-confidential-transfer-proof-generation = { version = "0.4.1", path = "../../confidential-transfer/proof-generation" }
 spl-token-2022 = { version = "9.0.0", features = ["no-entrypoint"], path = "../../program" }
 spl-token-group-interface = { version = "0.6.0" }
 spl-token-metadata-interface = { version = "0.7.0" }

--- a/confidential-transfer/ciphertext-arithmetic/Cargo.toml
+++ b/confidential-transfer/ciphertext-arithmetic/Cargo.toml
@@ -15,5 +15,5 @@ solana-curve25519 = "2.2.0"
 solana-zk-sdk = "2.2.0"
 
 [dev-dependencies]
-spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../proof-generation" }
+spl-token-confidential-transfer-proof-generation = { version = "0.4.1", path = "../proof-generation" }
 curve25519-dalek = "4.1.3"

--- a/confidential-transfer/proof-generation/Cargo.toml
+++ b/confidential-transfer/proof-generation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-confidential-transfer-proof-generation"
-version = "0.4.0"
+version = "0.4.1"
 description = "Solana Program Library Confidential Transfer Proof Generation"
 authors = { workspace = true }
 repository = { workspace = true }

--- a/confidential-transfer/proof-tests/Cargo.toml
+++ b/confidential-transfer/proof-tests/Cargo.toml
@@ -13,4 +13,4 @@ curve25519-dalek = "4.1.3"
 solana-zk-sdk = "2.2.0"
 thiserror = "2.0.12"
 spl-token-confidential-transfer-proof-extraction = { version = "0.4.0", path = "../proof-extraction" }
-spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../proof-generation" }
+spl-token-confidential-transfer-proof-generation = { version = "0.4.1", path = "../proof-generation" }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -59,7 +59,7 @@ serde_with = { version = "3.13.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../confidential-transfer/proof-generation" }
+spl-token-confidential-transfer-proof-generation = { version = "0.4.1", path = "../confidential-transfer/proof-generation" }
 
 [dev-dependencies]
 lazy_static = "1.5.0"


### PR DESCRIPTION
Attempted to build the SPL SDK for the `wasm32` target, bug failed due to https://github.com/solana-program/token-2022/issues/293
This issue appears to be fixed in commit 1d37eb9cf34418d570c9f6108a1a70545b9a3d6a but the fix has not yet been published to crates.io.

This PR requests that the fix be published so that downstream projects targeting `wasm32` can build successfully.