### PR TITLE
program: Properly gate zk-ops feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -285,7 +285,6 @@ jobs:
       - name: Build Token-2022 Wasm
         run: pnpm programs:build-wasm
 
-
   build_programs:
     name: Build programs
     runs-on: ubuntu-latest
@@ -318,6 +317,26 @@ jobs:
         with:
           path: ./target/deploy/*.so
           key: ${{ runner.os }}-builds-${{ github.sha }}
+
+  build_programs_no_default_features:
+    name: Build programs without default features
+    runs-on: ubuntu-latest
+    needs: format_and_lint_programs
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-programs-no-default-features
+          solana: true
+
+      - name: Build Token-2022
+        run: pnpm programs:build --no-default-features
+
+      - name: Build ElGamal Registry
+        run: pnpm confidential-transfer:elgamal-registry:build --no-default-features
 
   test_programs:
     name: Test Programs

--- a/program/src/extension/confidential_transfer/processor.rs
+++ b/program/src/extension/confidential_transfer/processor.rs
@@ -1,13 +1,14 @@
 // Remove feature once zk ops syscalls are enabled on all networks
 #[cfg(feature = "zk-ops")]
 use {
+    crate::check_auditor_ciphertext,
     crate::extension::confidential_mint_burn::ConfidentialMintBurn,
     crate::extension::non_transferable::NonTransferableAccount,
     spl_token_confidential_transfer_ciphertext_arithmetic as ciphertext_arithmetic,
 };
 use {
     crate::{
-        check_auditor_ciphertext, check_elgamal_registry_program_account, check_program_account,
+        check_elgamal_registry_program_account, check_program_account,
         error::TokenError,
         extension::{
             confidential_transfer::{instruction::*, verify_proof::*, *},


### PR DESCRIPTION
#### Problem

The program currently doesn't build if the zk-ops feature is disabled.

#### Summary of changes

Fix gating on the imports confidential-mint-burn and confidential-transfer functions on the `zk-ops` feature.