### PR TITLE
[confidential-transfer] Add a clarifying comment on the transfer fee proof

### DIFF
--- a/confidential-transfer/proof-generation/src/transfer_with_fee.rs
+++ b/confidential-transfer/proof-generation/src/transfer_with_fee.rs
@@ -40,6 +40,11 @@ const NET_TRANSFER_AMOUNT_BIT_LENGTH: usize = 64;
 
 /// The proof data required for a confidential transfer instruction when the
 /// mint is extended for fees
+///
+/// NOTE: The proofs certify that the transfer fee is a valid percentage of the
+/// transfer amount, as determined by the fee basis points, or that the fee is
+/// exactly the maximum fee. While the sender is expected to choose the lower of
+/// these two options, the proof does not enforce this choice.
 pub struct TransferWithFeeProofData {
     pub equality_proof_data: CiphertextCommitmentEqualityProofData,
     pub transfer_amount_ciphertext_validity_proof_data_with_ciphertext:


### PR DESCRIPTION
#### Problem
The token22 program supports two fee parameters for transfers: a percentage-based fee and a maximum fee cap. The intended fee is always the lower of these two values.

There is an enforcement discrepancy between the standard and confidential transfer extensions:

Standard Transfers: The program enforces the use of the lower fee. If the calculated percentage fee exceeds the maximum, the maximum fee is used, and vice versa.

Confidential Transfers: The underlying proof logic is more lenient. It only validates that the fee is either a valid percentage or does not exceed the maximum cap. It does not enforce that the sender chose the lower of the two.

This leniency means a sender could create a valid confidential transfer using the maximum fee even when the lower, percentage-based fee was expected.

#### Summary of Changes
This PR adds a documentation note to the `TransferWithFeeProofData` type to clarify this specific behavior.

A more detailed doc on how the transfer with fee proof works is in the works, where I will be explaining this issue as well, but I wanted to get this out first to avoid confusion. I'll follow-up with a more comprehensive doc after this PR.