### PR TITLE
deps: Downgrade curve25519-dalek to 4.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.2.0"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b7c5dbd637569a2cca66e8d66b8c446a1e7bf064ea321d265d7b3dfe7c97e"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1990,9 +1990,9 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.3.0"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -6418,7 +6418,7 @@ checksum = "be64f4005f30cb8de8850a0e03356521da7e35b8c06d85bc79d78f9a74df028a"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "solana-define-syscall",
  "subtle",
  "thiserror 2.0.12",
@@ -7270,7 +7270,7 @@ dependencies = [
  "bv",
  "bytes",
  "caps",
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "dlopen2",
  "fnv",
  "libc",
@@ -7623,7 +7623,7 @@ dependencies = [
  "borsh 1.5.7",
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "five8",
  "five8_const",
  "getrandom 0.2.15",
@@ -9447,7 +9447,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "js-sys",
  "merlin",
@@ -9500,7 +9500,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "bytemuck_derive",
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "itertools 0.12.1",
  "merlin",
  "num-derive",
@@ -9990,7 +9990,7 @@ version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "solana-curve25519",
  "solana-zk-sdk",
  "spl-token-confidential-transfer-proof-generation 0.4.0",
@@ -10050,7 +10050,7 @@ dependencies = [
 name = "spl-token-confidential-transfer-proof-generation"
 version = "0.4.0"
 dependencies = [
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
  "thiserror 2.0.12",
 ]
@@ -10061,7 +10061,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5b124840d4aed474cef101d946a798b806b46a509ee4df91021e1ab1cef3ef"
 dependencies = [
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
  "thiserror 2.0.12",
 ]
@@ -10070,7 +10070,7 @@ dependencies = [
 name = "spl-token-confidential-transfer-proof-test"
 version = "0.0.1"
 dependencies = [
- "curve25519-dalek 4.2.0",
+ "curve25519-dalek 4.1.3",
  "solana-zk-sdk",
  "spl-token-confidential-transfer-proof-extraction 0.4.0",
  "spl-token-confidential-transfer-proof-generation 0.4.0",

--- a/confidential-transfer/ciphertext-arithmetic/Cargo.toml
+++ b/confidential-transfer/ciphertext-arithmetic/Cargo.toml
@@ -16,4 +16,4 @@ solana-zk-sdk = "2.3.4"
 
 [dev-dependencies]
 spl-token-confidential-transfer-proof-generation = { version = "0.4.0", path = "../proof-generation" }
-curve25519-dalek = "4.2.0"
+curve25519-dalek = "4.1.3"

--- a/confidential-transfer/proof-generation/Cargo.toml
+++ b/confidential-transfer/proof-generation/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-curve25519-dalek = "4.2.0"
+curve25519-dalek = "4.1.3"
 solana-zk-sdk = "2.3.4"
 thiserror = "2.0.12"
 

--- a/confidential-transfer/proof-tests/Cargo.toml
+++ b/confidential-transfer/proof-tests/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dev-dependencies]
-curve25519-dalek = "4.2.0"
+curve25519-dalek = "4.1.3"
 solana-zk-sdk = "2.3.4"
 thiserror = "2.0.12"
 spl-token-confidential-transfer-proof-extraction = { version = "0.4.0", path = "../proof-extraction" }


### PR DESCRIPTION
#### Problem

As noted at #588, version 4.2.0 of curve25519-dalek has been yanked, but this repo is still using that version.

#### Summary of changes

Downgrade the dependency to 4.1.3.

Fixes #588