### PR TITLE
cli: Added the option to enable transfer-hook without setting an initial program

### DIFF
--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -875,7 +875,14 @@ pub fn app<'a>(
                         .value_name("TRANSFER_HOOK_PROGRAM_ID")
                         .validator(|s| is_valid_pubkey(s))
                         .takes_value(true)
-                        .help("Enable the mint authority to set the transfer hook program for this mint"),
+                        .help("Set a transfer hook program for this mint. The mint authority can set the program id."),
+                )
+                .arg(
+                    Arg::with_name("enable_transfer_hook")
+                        .long("enable-transfer-hook")
+                        .conflicts_with("transfer_hook")
+                        .takes_value(false)
+                        .help("Enables the transfer hook in the mint. The mint authority can set the program id."),
                 )
                 .arg(
                     Arg::with_name("enable_metadata")

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -267,6 +267,7 @@ async fn command_create_token(
     enable_metadata: bool,
     enable_group: bool,
     enable_member: bool,
+    enable_transfer_hook: bool,
     ui_multiplier: Option<f64>,
     pausable: bool,
     bulk_signers: Vec<Arc<dyn Signer>>,
@@ -348,10 +349,10 @@ async fn command_create_token(
         }
     }
 
-    if let Some(program_id) = transfer_hook_program_id {
+    if transfer_hook_program_id.is_some() || enable_transfer_hook {
         extensions.push(ExtensionInitializationParams::TransferHook {
             authority: Some(authority),
-            program_id: Some(program_id),
+            program_id: transfer_hook_program_id,
         });
     }
 
@@ -3788,6 +3789,7 @@ pub async fn process_command(
                 arg_matches.is_present("enable_metadata"),
                 arg_matches.is_present("enable_group"),
                 arg_matches.is_present("enable_member"),
+                arg_matches.is_present("enable_transfer_hook"),
                 ui_multiplier,
                 arg_matches.is_present("enable_pause"),
                 bulk_signers,


### PR DESCRIPTION
Added a spl-token CLI option `--enable-transfer-hook` to enable the transfer-hook extension without setting an initial program id value.