### PR TITLE
Fixed --transfer-hook CLI option not allowing default Pubkey as value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9934,6 +9934,7 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account-client",
  "spl-memo",
+ "spl-pod",
  "spl-token",
  "spl-token-2022 9.0.0",
  "spl-token-client",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -32,6 +32,7 @@ solana-sdk = "2.2.1"
 solana-system-interface = "1"
 solana-transaction-status = "2.3.4"
 spl-associated-token-account-client = { version = "2.0.0" }
+spl-pod = { version = "0.5.1" }
 spl-token = { version = "8.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "9.0.0", path = "../../program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.16.1", path = "../rust-legacy" }

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -351,11 +351,9 @@ async fn command_create_token(
     }
 
     if transfer_hook_program_id.is_some() || enable_transfer_hook {
-        let program_id: OptionalNonZeroPubkey = if let Some(program_id) = transfer_hook_program_id {
-            OptionalNonZeroPubkey(program_id)
-        } else {
-            OptionalNonZeroPubkey::default()
-        };
+        let program_id = transfer_hook_program_id
+            .map(OptionalNonZeroPubkey)
+            .unwrap_or_default();
         extensions.push(ExtensionInitializationParams::TransferHook {
             authority: Some(authority),
             program_id: program_id.into(),

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -35,6 +35,7 @@ use {
     },
     solana_system_interface::program as system_program,
     spl_associated_token_account_client::address::get_associated_token_address_with_program_id,
+    spl_pod::optional_keys::OptionalNonZeroPubkey,
     spl_token_2022::{
         extension::{
             confidential_transfer::{
@@ -350,9 +351,14 @@ async fn command_create_token(
     }
 
     if transfer_hook_program_id.is_some() || enable_transfer_hook {
+        let program_id: OptionalNonZeroPubkey = if let Some(program_id) = transfer_hook_program_id {
+            OptionalNonZeroPubkey(program_id)
+        } else {
+            OptionalNonZeroPubkey::default()
+        };
         extensions.push(ExtensionInitializationParams::TransferHook {
             authority: Some(authority),
-            program_id: transfer_hook_program_id,
+            program_id: program_id.into(),
         });
     }
 


### PR DESCRIPTION
Running `spl-token create-token --program-2022 --transfer-hook 11111111111111111111111111111111`  would error out, when its expected to be a valid value that represents the lack of a transfer-hook program. This PR fixes this.