### PR TITLE
fix: use findProgramAddressSync instead of deprecated findProgramAddress

### DIFF
--- a/clients/js-legacy/src/state/mint.ts
+++ b/clients/js-legacy/src/state/mint.ts
@@ -168,7 +168,7 @@ export async function getAssociatedTokenAddress(
 ): Promise<PublicKey> {
     if (!allowOwnerOffCurve && !PublicKey.isOnCurve(owner.toBuffer())) throw new TokenOwnerOffCurveError();
 
-    const [address] = await PublicKey.findProgramAddress(
+    const [address] = PublicKey.findProgramAddressSync(
         [owner.toBuffer(), programId.toBuffer(), mint.toBuffer()],
         associatedTokenProgramId,
     );


### PR DESCRIPTION
The current implementation uses the deprecated `findProgramAddress` method from @solana/web3.js. This PR updates the code to use the recommended `findProgramAddressSync` method instead, which provides the same functionality in a synchronous manner. This change improves code maintainability and follows current best practices