### PR TITLE
[confidential-transfer] Add docs and additional comments in the proof generation logic

### DIFF
--- a/confidential-transfer/proof-extraction/src/burn.rs
+++ b/confidential-transfer/proof-extraction/src/burn.rs
@@ -83,6 +83,7 @@ impl BurnProofContext {
             *remaining_balance_commitment,
             burn_amount_commitment_lo,
             burn_amount_commitment_hi,
+            // we don't care about the padding commitment, so ignore it
         ];
 
         // range proof context always contains 8 commitments and therefore,

--- a/confidential-transfer/proof-extraction/src/mint.rs
+++ b/confidential-transfer/proof-extraction/src/mint.rs
@@ -83,6 +83,7 @@ impl MintProofContext {
             *new_supply_commitment,
             mint_amount_commitment_lo,
             mint_amount_commitment_hi,
+            // we don't care about the padding commitment, so ignore it
         ];
 
         // range proof context always contains 8 commitments and therefore,

--- a/confidential-transfer/proof-extraction/src/transfer.rs
+++ b/confidential-transfer/proof-extraction/src/transfer.rs
@@ -88,6 +88,7 @@ impl TransferProofContext {
             *new_source_commitment,
             transfer_amount_commitment_lo,
             transfer_amount_commitment_hi,
+            // we don't care about the padding commitment, so ignore it
         ];
 
         // range proof context always contains 8 commitments and therefore,

--- a/confidential-transfer/proof-generation/src/burn.rs
+++ b/confidential-transfer/proof-generation/src/burn.rs
@@ -1,3 +1,39 @@
+//! Generates the zero-knowledge proofs required for a confidential burn.
+//!
+//! A confidential burn operation removes tokens from a user's confidential balance and decreases the
+//! token's total supply. This process requires three distinct zero-knowledge proofs to ensure the
+//! operation is valid, the user is solvent, and the token supply is updated correctly.
+//!
+//! ## Protocol Flow and Proof Components
+//!
+//! 1.  **Encrypt Burn Amount**: The burn amount is encrypted in a grouped (twisted) ElGamal
+//!     ciphertext. This single operation prepares the `burn_amount` to be simultaneously
+//!     subtracted from the user's account and recorded in the mint's `pending_burn` accumulator,
+//!     which will later be subtracted from the total supply.
+//!
+//! 2.  **Homomorphic Calculation**: The client homomorphically computes their new encrypted balance
+//!     by subtracting the source-encrypted component of the `burn_amount` from their current
+//!     `available_balance` ciphertext.
+//!
+//! 3.  **Generate Proofs**: The user generates three proofs:
+//!
+//!     -   **Batched Grouped Ciphertext Validity Proof**:
+//!         This proof certifies that the grouped ElGamal ciphertext for the `burn_amount` is well-formed
+//!         and was correctly encrypted for the source, supply, and auditor public keys.
+//!
+//!     -   **Ciphertext-Commitment Equality Proof**:
+//!         This proof provides the cryptographic link needed for the solvency check. After the user's
+//!         new balance is computed homomorphically, the prover no longer knows the associated
+//!         Pedersen opening. To perform a range proof, the prover creates a *new* Pedersen commitment
+//!         for their `remaining_balance` (for which they know the opening) and uses this proof to
+//!         certify that the ciphertext and the new commitment hide the same value.
+//!
+//!     -   **Range Proof (`BatchedRangeProofU128`)**:
+//!         This proof is the core solvency check. It certifies that the user's `remaining_balance`
+//!         is non-negative (i.e., in the range `[0, 2^64)`), which makes it cryptographically
+//!         impossible to burn more tokens than one possesses. It also proves the `burn_amount` itself
+//!         is a valid 48-bit number.
+
 #[cfg(target_arch = "wasm32")]
 use solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamalCiphertext3Handles;
 use {
@@ -158,6 +194,10 @@ pub fn burn_split_proof_data(
         };
 
     // generate range proof data
+
+    // the total bit lengths for the range proof must be a power-of-2
+    // therefore, create a Pedersen commitment to 0 and use it as a dummy commitment to a 16-bit
+    // value
     let (padding_commitment, padding_opening) = Pedersen::new(0_u64);
     let range_proof_data = BatchedRangeProofU128Data::new(
         vec![

--- a/confidential-transfer/proof-generation/src/withdraw.rs
+++ b/confidential-transfer/proof-generation/src/withdraw.rs
@@ -1,3 +1,44 @@
+//! Generates the zero-knowledge proofs required for a confidential withdraw.
+//!
+//! A confidential withdraw operation converts a user's encrypted, confidential token balance back into a
+//! standard, publicly-visible SPL token balance. To ensure this operation is valid and that a user
+//! cannot create tokens out of thin air, it requires two distinct zero-knowledge proofs.
+//!
+//! ## Protocol Flow and Proof Components
+//!
+//! 1.  **Calculate Remaining Balance**: The client first calculates the remaining confidential balance
+//!     by subtracting the desired `withdraw_amount` from their current known balance.
+//!
+//! 2.  **Homomorphic Calculation**: The client homomorphically computes the new encrypted balance
+//!     ciphertext. This is done by taking the current `available_balance` ciphertext and subtracting
+//!     a newly-encoded ciphertext of the `withdraw_amount`.
+//!
+//! 3.  **Generate Proofs**: The user generates two proofs to certify the validity of the operation:
+//!
+//!     -   **Ciphertext-Commitment Equality Proof (`CiphertextCommitmentEqualityProofData`)**:
+//!         This proof is the cryptographic link between the on-chain state and the solvency check. It
+//!         certifies that the newly computed `remaining_balance_ciphertext` (which will be the new
+//!         on-chain state) and a new Pedersen commitment both hide the exact same numerical value.
+//!         This is essential because the range proof operates on Pedersen commitments, not directly on
+//!         ElGamal ciphertexts.
+//!
+//!     -   **Ciphertext-Commitment Equality Proof (`CiphertextCommitmentEqualityProofData`)**:
+//!         This proof provides a cryptographic link that enables the solvency check. When the
+//!         `remaining_balance_ciphertext` is computed homomorphically, the prover may not know the
+//!         corresponding Pedersen opening (randomness) for the resulting ciphertext. Performing a
+//!         range proof requires knowledge of this opening.
+//!
+//!         To solve this, the prover creates a *new* Pedersen commitment for the remaining balance,
+//!         for which it knows the opening. The equality proof then certifies that the
+//!         homomorphically-derived ciphertext and this new commitment hide the exact same numerical
+//!         value. This allows the range proof to be performed on the new commitment.
+//!
+//!     -   **Range Proof (`BatchedRangeProofU64Data`)**:
+//!         This proof certifies the user's **solvency**. By proving that the value inside the
+//!         Pedersen commitment for the *remaining balance* is non-negative (i.e., it is in the range
+//!         `[0, 2^64)`), it implicitly proves that the user's original balance was greater than or
+//!         equal to the `withdraw_amount`.
+
 use {
     crate::errors::TokenProofGenerationError,
     solana_zk_sdk::{

--- a/confidential-transfer/proof-generation/src/withdraw.rs
+++ b/confidential-transfer/proof-generation/src/withdraw.rs
@@ -16,13 +16,6 @@
 //! 3.  **Generate Proofs**: The user generates two proofs to certify the validity of the operation:
 //!
 //!     -   **Ciphertext-Commitment Equality Proof (`CiphertextCommitmentEqualityProofData`)**:
-//!         This proof is the cryptographic link between the on-chain state and the solvency check. It
-//!         certifies that the newly computed `remaining_balance_ciphertext` (which will be the new
-//!         on-chain state) and a new Pedersen commitment both hide the exact same numerical value.
-//!         This is essential because the range proof operates on Pedersen commitments, not directly on
-//!         ElGamal ciphertexts.
-//!
-//!     -   **Ciphertext-Commitment Equality Proof (`CiphertextCommitmentEqualityProofData`)**:
 //!         This proof provides a cryptographic link that enables the solvency check. When the
 //!         `remaining_balance_ciphertext` is computed homomorphically, the prover may not know the
 //!         corresponding Pedersen opening (randomness) for the resulting ciphertext. Performing a

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -61,3 +61,5 @@ Pedersen
 aes
 plaintext
 pausable
+homomorphic
+homomorphically


### PR DESCRIPTION
#### Summary of Changes
- Added docs in the confidential transfer proof generation logic, which should be pretty straightforward
- Fixed one small logic in the transfer with fee proof generation logic: 
  - If the transfer fee is equal to the percentage-calculated fee, then the "claimed" delta fee has to be the value `fee * 10_000 - transfer_amount * bp`. 
  - If the transfer fee is equal to the max value, then the "claimed" delta fee basically can be anything as long as it is a positive 16-bit number. In this case, in the current logic, I set the claimed fee to be the fee amount, which satisfies this condition, but can be a little confusing because this is a little arbitrary. In this PR, I set this claimed delta fee to be 0 just for clarity.