### PR TITLE
CI: Bump git-cliff action

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -176,13 +176,10 @@ jobs:
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
-          args: |
-            "${{ steps.publish.outputs.old_git_tag }}"..main
-            --include-path "${{ inputs.package_path }}/**"
-            --github-repo "${{ github.repository }}"
+          args: ${{ steps.publish.outputs.old_git_tag }}..HEAD --include-path "${{ inputs.package_path }}/**" --github-repo ${{ github.repository }}
         env:
           OUTPUT: TEMP_CHANGELOG.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
#### Problem

The git-cliff action is failing because it's on an old version.

#### Summary of changes

Update it, similar to all the other program repos.