### PR TITLE
CI: Add `interface` to the list of publishable crates

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -16,6 +16,7 @@ on:
           - confidential-transfer/proof-extraction
           - confidential-transfer/proof-generation
           - confidential-transfer/proof-tests
+          - interface
           - program
       level:
         description: Level


### PR DESCRIPTION
#### Problem

The interface crate is not on the list of publishable crates in the publish job, so it can't be published through GitHub Actions.

#### Summary of changes

Add it to the list