### PR TITLE
docs: update IDL link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pnpm programs:lint
 
 ## IDL
 
-You may use the following [IDL](https://github.com/solana-program/token-2022/blob/main/program/idl.json) in your programs.
+You may use the following [IDL](https://github.com/solana-program/token-2022/blob/main/interface/idl.json) in your programs.
 
 ## Generating clients
 


### PR DESCRIPTION
Updated the outdated IDL markdown link in the README to point to the correct resource. 
This ensures developers have the latest reference when working with the project.