### PR TITLE
Makefile: Make format checks consistent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           pnpm: true
 
       - name: Format
-        run: make format-${{ matrix.package }}
+        run: make format-check-${{ matrix.package }}
 
       - name: Lint
         run: make lint-${{ matrix.package }}

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -70,7 +70,7 @@ jobs:
           cargo-cache-fallback-key: cargo-publish-js-test
 
       - name: Format
-        run: make format-${{ needs.set_env.outputs.TARGET }}
+        run: make format-check-${{ needs.set_env.outputs.TARGET }}
 
       - name: Lint
         run: make lint-${{ needs.set_env.outputs.TARGET }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -88,7 +88,7 @@ jobs:
           cargo-cache-fallback-key: cargo-test-publish
 
       - name: Format
-        run: make format-${{ needs.set_env.outputs.TARGET }}
+        run: make format-check-${{ needs.set_env.outputs.TARGET }}
 
       - name: Lint
         run: make lint-${{ needs.set_env.outputs.TARGET }}

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ test-%:
 # Make defaults % to .o if nothing is provided there, and then tries to build it
 # as a C project, so we do something a bit hacky, and assume that any target
 # starting with "j" is actually for "js".
-format-j%:
+format-check-j%:
 	cd ./clients/j$* && pnpm install && pnpm format
 
 lint-j%:


### PR DESCRIPTION
#### Problem

The publish job failed because it was trying to use `format-clients-cli`, but it should be `format-check-clients-cli`. There's an inconsistency between Rust and JS here.

#### Summary of changes

Make all of the format checks called `format-check-*`, and use the correct name in all workflows.