### PR TITLE
CI: Make packages into proper JSON

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ on:
     branches: [main]
 
 env:
-  JS_PACKAGES: "['clients-js', 'clients-js-legacy']"
-  SBPF_PROGRAM_PACKAGES: "['confidential-elgamal-registry', 'program']"
-  RUST_PACKAGES: "['clients-cli', 'clients-rust-legacy', 'interface', 'program', 'confidential-ciphertext-arithmetic', 'confidential-elgamal-registry', 'confidential-proof-extraction', 'confidential-proof-generation', 'confidential-proof-tests']"
-  WASM_PACKAGES: "['interface', 'program']"
+  JS_PACKAGES: '["clients-js", "clients-js-legacy"]'
+  SBPF_PROGRAM_PACKAGES: '["confidential-elgamal-registry", "program"]'
+  RUST_PACKAGES: '["clients-cli", "clients-rust-legacy", "interface", "program", "confidential-ciphertext-arithmetic", "confidential-elgamal-registry", "confidential-proof-extraction", "confidential-proof-generation", "confidential-proof-tests"]'
+  WASM_PACKAGES: '["interface", "program"]'
 
 jobs:
   set_env:


### PR DESCRIPTION
#### Problem

The builds requiring sbpf programs are failing because the program build is failing to parse the JSON string. This is because we aren't using valid JSON in the definitions.

#### Summary of changes

Make the strings valid JSON.