### PR TITLE
audit: Update tracing-subscriber to v0.3.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10411,7 +10411,7 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account-client",
  "spl-memo",
- "spl-pod",
+ "spl-pod 0.5.1",
  "spl-token",
  "spl-token-2022 9.0.0",
  "spl-token-client",
@@ -11537,9 +11537,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "sharded-slab",
  "thread_local",


### PR DESCRIPTION
#### Problem

The repo is using v0.3.19 of tracing-susbcriber, which has a security advisory.

#### Summary of changes

Bump tracing-subscriber to v0.3.20.

NOTE: There's an extra version fix, nothing to worry about there.