### PR TITLE
[confidential-transfer] Deprecate `try_combine_lo_hi_u64` function

### DIFF
--- a/confidential/proof-generation/src/lib.rs
+++ b/confidential/proof-generation/src/lib.rs
@@ -48,6 +48,10 @@ pub fn try_split_u64(amount: u64, bit_length: usize) -> Option<(u64, u64)> {
 /// Combine two numbers that are interpreted as the low and high bits of a
 /// target number. The `bit_length` parameter specifies the number of bits that
 /// `amount_hi` is to be shifted by.
+#[deprecated(
+    since = "0.6.0",
+    note = "This function is deprecated as it contains logical errors and is unused in the crate"
+)]
 pub fn try_combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> Option<u64> {
     match bit_length {
         0 => Some(amount_hi),


### PR DESCRIPTION
#### Problem
The function `try_combine_lo_hi_u64` contains logic error. The intended behavior is to shift `amount_hi` with the bit-length and add it with `amount_lo`.

The function is actually not used anywhere in the crate and I think we just missed removing this function during refactoring. This is why this function did not affect the tests.

#### Summary of Changes
I considered fixing this function, but since it is not used anywhere in the crate, I thought it would actually be best to just remove it. The current crate version is v0.5.0, so I deprecated the function for v0.6.0.