### PR TITLE
[confidential-transfer] Fix bit-length comments

### DIFF
--- a/confidential/proof-extraction/src/transfer_with_fee.rs
+++ b/confidential/proof-extraction/src/transfer_with_fee.rs
@@ -141,10 +141,11 @@ impl TransferWithFeeProofContext {
         // - the new source available balance (64 bits)
         // - the low bits of the transfer amount (16 bits)
         // - the high bits of the transfer amount (32 bits)
-        // - the delta amount for the fee (48 bits)
-        // - the complement of the delta amount for the fee (48 bits)
+        // - the delta amount for the fee (16 bits)
+        // - the complement of the delta amount for the fee (16 bits)
         // - the low bits of the fee amount (16 bits)
         // - the high bits of the fee amount (32 bits)
+        // - the net transfer amount bit length (64 bits)
         let BatchedRangeProofContext {
             commitments: range_proof_commitments,
             bit_lengths: range_proof_bit_lengths,


### PR DESCRIPTION
#### Problem
The comments regarding the bit-length in range proofs used in transfer-with-fee was not updated in https://github.com/solana-program/token-2022/pull/512. A new net transfer amount bit length was added and the delta and complement delta bit lengths have been updated to 16 bits from 48 bits.

#### Summary of Changes
I fixed these comments.