### PR TITLE
[program] Improve error messages associated with confidential transfer

### DIFF
--- a/program/src/extension/confidential_mint_burn/account_info.rs
+++ b/program/src/extension/confidential_mint_burn/account_info.rs
@@ -61,7 +61,7 @@ impl SupplyAccountInfo {
         let current_decryptable_supply = AeCiphertext::try_from(self.decryptable_supply)
             .map_err(|_| TokenError::MalformedCiphertext)?
             .decrypt(aes_key)
-            .ok_or(TokenError::MalformedCiphertext)?;
+            .ok_or(TokenError::AccountDecryption)?;
 
         // get the difference between the supply ciphertext and the decryptable supply
         // explanation see https://github.com/solana-labs/solana-program-library/pull/6881#issuecomment-2385579058
@@ -74,7 +74,7 @@ impl SupplyAccountInfo {
         let decryptable_to_current_diff = elgamal_keypair
             .secret()
             .decrypt_u32(&supply_delta_ciphertext)
-            .ok_or(TokenError::MalformedCiphertext)?;
+            .ok_or(TokenError::AccountDecryption)?;
 
         // compute the current supply
         current_decryptable_supply
@@ -216,7 +216,7 @@ impl BurnAccountInfo {
         let current_available_balance = AeCiphertext::try_from(self.decryptable_available_balance)
             .map_err(|_| TokenError::MalformedCiphertext)?
             .decrypt(aes_key)
-            .ok_or(TokenError::MalformedCiphertext)?;
+            .ok_or(TokenError::AccountDecryption)?;
         let new_decryptable_balance = current_available_balance
             .checked_sub(burn_amount)
             .ok_or(TokenError::Overflow)?;

--- a/program/src/extension/confidential_transfer/processor.rs
+++ b/program/src/extension/confidential_transfer/processor.rs
@@ -380,7 +380,7 @@ fn process_empty_account(
     }
     if confidential_transfer_account.available_balance != proof_context.ciphertext {
         msg!("Available balance mismatch");
-        return Err(ProgramError::InvalidInstructionData);
+        return Err(TokenError::ConfidentialTransferBalanceMismatch.into());
     }
     confidential_transfer_account.available_balance = EncryptedBalance::zeroed();
 

--- a/program/src/extension/confidential_transfer_fee/account_info.rs
+++ b/program/src/extension/confidential_transfer_fee/account_info.rs
@@ -36,7 +36,7 @@ impl WithheldTokensInfo {
         let withheld_amount_in_mint: ElGamalCiphertext = self
             .withheld_amount
             .try_into()
-            .map_err(|_| TokenError::AccountDecryption)?;
+            .map_err(|_| TokenError::MalformedCiphertext)?;
 
         let decrypted_withheld_amount_in_mint = withheld_amount_in_mint
             .decrypt_u32(withdraw_withheld_authority_elgamal_keypair.secret())

--- a/program/src/extension/confidential_transfer_fee/processor.rs
+++ b/program/src/extension/confidential_transfer_fee/processor.rs
@@ -155,7 +155,7 @@ fn process_withdraw_withheld_tokens_from_mint(
         &destination_confidential_transfer_account.available_balance,
         &proof_context.second_ciphertext,
     )
-    .ok_or(ProgramError::InvalidInstructionData)?;
+    .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
     destination_confidential_transfer_account.decryptable_available_balance =
         *new_decryptable_available_balance;
@@ -234,7 +234,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
                 &aggregate_withheld_amount,
                 &destination_confidential_transfer_fee_amount.withheld_amount,
             )
-            .ok_or(ProgramError::InvalidInstructionData)?;
+            .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
             destination_confidential_transfer_fee_amount.withheld_amount =
                 EncryptedWithheldAmount::zeroed();
@@ -245,7 +245,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
                         &aggregate_withheld_amount,
                         &encrypted_withheld_amount,
                     )
-                    .ok_or(ProgramError::InvalidInstructionData)?;
+                    .ok_or(TokenError::CiphertextArithmeticFailed)?;
                 }
                 Err(e) => {
                     msg!("Error harvesting from {}: {}", account_info.key, e);
@@ -348,7 +348,7 @@ fn process_harvest_withheld_tokens_to_mint(accounts: &[AccountInfo]) -> ProgramR
                     &confidential_transfer_fee_mint.withheld_amount,
                     &withheld_amount,
                 )
-                .ok_or(ProgramError::InvalidInstructionData)?;
+                .ok_or(TokenError::CiphertextArithmeticFailed)?;
 
                 confidential_transfer_fee_mint.withheld_amount = new_mint_withheld_amount;
             }


### PR DESCRIPTION
#### Problem
Some of the error codes in the program are not precise and can be replaced by a more suitable error variant.

#### Summary of  Changes
Fixed these error variants.