### PR TITLE
[program] Fix minor typos related to the confidential transfer withdraw instruction

### DIFF
--- a/program/src/extension/confidential_transfer/account_info.rs
+++ b/program/src/extension/confidential_transfer/account_info.rs
@@ -189,7 +189,7 @@ pub struct WithdrawAccountInfo {
     pub decryptable_available_balance: DecryptableBalance,
 }
 impl WithdrawAccountInfo {
-    /// Create the `ApplyPendingBalance` instruction account information from
+    /// Create the `Withdraw` instruction account information from
     /// `ConfidentialTransferAccount`.
     pub fn new(account: &ConfidentialTransferAccount) -> Self {
         Self {

--- a/program/src/extension/confidential_transfer/verify_proof.rs
+++ b/program/src/extension/confidential_transfer/verify_proof.rs
@@ -46,11 +46,11 @@ pub fn verify_withdraw_proof(
     // The `WithdrawProofContext` constructor verifies the consistency of the
     // individual proof context and generates a `WithdrawProofContext` struct
     // that is used to process the rest of the token-2022 logic.
-    let transfer_proof_context =
+    let withdraw_proof_context =
         WithdrawProofContext::verify_and_extract(&equality_proof_context, &range_proof_context)
             .map_err(|e| -> TokenError { e.into() })?;
 
-    Ok(transfer_proof_context)
+    Ok(withdraw_proof_context)
 }
 
 /// Verify zero-knowledge proof needed for a `Transfer` instruction without fee


### PR DESCRIPTION
#### Summary of Changes

Fixing some minor typos related to the withdraw instruction in the program.