### PR TITLE
Makefile: Add `--all-features` to clippy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ spellcheck:
 clippy-%:
 	cargo $(nightly) clippy --manifest-path $(call make-path,$*)/Cargo.toml \
 	  --all-targets \
+	  --all-features \
 		-- \
 		--deny=warnings \
 		--deny=clippy::default_trait_access \


### PR DESCRIPTION
#### Problem

The clippy target doesn't enable all features, which means we can miss warnings.

#### Summary of changes

Add `--all-features` to the clippy target.