### PR TITLE
confidential: Bump solana-curve25519 to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10028,7 +10028,7 @@ dependencies = [
  "base64 0.22.1",
  "bytemuck",
  "curve25519-dalek 4.1.3",
- "solana-curve25519 2.3.4",
+ "solana-curve25519 3.0.7",
  "solana-zk-sdk",
  "spl-token-confidential-transfer-proof-generation 0.5.0",
 ]
@@ -10039,7 +10039,7 @@ version = "0.5.0"
 dependencies = [
  "bytemuck",
  "solana-account-info",
- "solana-curve25519 2.3.4",
+ "solana-curve25519 3.0.7",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",

--- a/confidential/ciphertext-arithmetic/Cargo.toml
+++ b/confidential/ciphertext-arithmetic/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 [dependencies]
 base64 = "0.22.1"
 bytemuck = "1.24.0"
-solana-curve25519 = "2.3.4"
+solana-curve25519 = "3.0.0"
 solana-zk-sdk = "4.0.0"
 
 [dev-dependencies]

--- a/confidential/proof-extraction/Cargo.toml
+++ b/confidential/proof-extraction/Cargo.toml
@@ -11,7 +11,7 @@ edition = { workspace = true }
 [dependencies]
 bytemuck = "1.24.0"
 solana-account-info = "3.0.0"
-solana-curve25519 = "2.3.4"
+solana-curve25519 = "3.0.0"
 solana-instruction = "3.0.0"
 solana-instructions-sysvar = "3.0.0"
 solana-msg = "3.0.0"


### PR DESCRIPTION
#### Problem

The confidential crates are still using solana-curve25519 v2 because that crate is still part of Agave, and v3 wasn't available when the interface crates were bumped. Thankfully, it didn't cause an issue at the time.

#### Summary of changes

Get things consistent, and bump the crate to v3 everywhere. In the future, we should consider moving the code down to the SDK or finding some other solution to avoid circular dependencies.