### PR TITLE
CI: Fix publish names for confidential packages

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -11,12 +11,12 @@ on:
         options:
           - clients/cli
           - clients/rust-legacy
-          - confidential-transfer/ciphertext-arithmetic
-          - confidential-transfer/elgamal-registry
-          - confidential-transfer/elgamal-registry-interface
-          - confidential-transfer/proof-extraction
-          - confidential-transfer/proof-generation
-          - confidential-transfer/proof-tests
+          - confidential/ciphertext-arithmetic
+          - confidential/elgamal-registry
+          - confidential/elgamal-registry-interface
+          - confidential/proof-extraction
+          - confidential/proof-generation
+          - confidential/proof-tests
           - interface
           - program
       level:


### PR DESCRIPTION
#### Problem

The publish paths are incorrect in the publish job for the confidential transfer packages.

#### Summary of changes

Fix them by removing `-transfer` in each option.