### PR TITLE
repo: Add `debug = "line-tables-only"` to dev profile to reduce build size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
-# Reduce the size of debug builds for CI
+# Reduce the size of debug builds
 [profile.dev]
-debug = false
+debug = "line-tables-only"
 
 # The curve25519-dalek crate uses the `simd` backend by default in v4 if
 # possible, which has very slow performance on some platforms with opt-level 0,


### PR DESCRIPTION
#### Problem

Some of the CI jobs time out or fail because there's too much disk space used by the build.

#### Summary of changes

Take a hammer to the problem, and just don't emit debug info. On my machine, this reduces the build size from 21GB to 4.1GB for the rust legacy build, which always runs into issues.

We don't have to adopt this option, so let me know what you prefer! I did also try `debug = "line-tables-only"` and that reduced the build to 9.7GB.