### PR TITLE
program: Bump local dependencies for publish

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -43,9 +43,9 @@ solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 solana-zk-sdk = "4.0.0"
 spl-elgamal-registry-interface = { version = "0.1.0", path = "../confidential/elgamal-registry-interface" }
 spl-memo-interface = { version = "2.0" }
-spl-token-2022-interface = { version = "2.0", path = "../interface" }
-spl-token-confidential-transfer-ciphertext-arithmetic = { version = "0.4.0", path = "../confidential/ciphertext-arithmetic" }
-spl-token-confidential-transfer-proof-extraction = { version = "0.5.0", path = "../confidential/proof-extraction" }
+spl-token-2022-interface = { version = "2.1.0", path = "../interface" }
+spl-token-confidential-transfer-ciphertext-arithmetic = { version = "0.4.1", path = "../confidential/ciphertext-arithmetic" }
+spl-token-confidential-transfer-proof-extraction = { version = "0.5.1", path = "../confidential/proof-extraction" }
 spl-token-group-interface = { version = "0.7.1" }
 spl-token-metadata-interface = { version = "0.8.0" }
 spl-transfer-hook-interface = { version = "2.0.0" }
@@ -56,7 +56,7 @@ serde_with = { version = "3.14.1", optional = true }
 base64 = { version = "0.22.1", optional = true }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-spl-token-confidential-transfer-proof-generation = { version = "0.5.0", path = "../confidential/proof-generation" }
+spl-token-confidential-transfer-proof-generation = { version = "0.5.1", path = "../confidential/proof-generation" }
 
 [dev-dependencies]
 lazy_static = "1.5.0"


### PR DESCRIPTION
#### Problem

The publish job failed because it was trying to build against v2.0.0 of spl-token-2022-interface, which doesn't contain a change required for the program to work.

#### Summary of changes

Bump the versions of local dependencies.