### PR TITLE
[cli] fix: use bulk_signers for create-token command with-memo arg

### DIFF
--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -365,7 +365,7 @@ async fn command_create_token(
     }
 
     if let Some(text) = memo {
-        token.with_memo(text, vec![config.default_signer()?.pubkey()]);
+        token.with_memo(text, bulk_signers.iter().map(|s| s.pubkey()).collect());
     }
 
     // CLI checks that only one is set


### PR DESCRIPTION
Using incorrect signers while executing `create-token` command  and  using `--with-memo` argument. For example: 

```shell
spl-token create-token  --with-memo 'bug?' \
  --decimals 6 \
  --program-2022 \
  --enable-confidential-transfers auto \
  --enable-close \
  --enable-transfer-hook \
  /tmp/token.json 
``` 

yields error: 

```text
Creating token blah under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
Error: MissingMemoSigner
```