### PR TITLE
Fix typo in isUiAmountToAmountInstruction function name

### DIFF
--- a/clients/js-legacy/src/instructions/decode.ts
+++ b/clients/js-legacy/src/instructions/decode.ts
@@ -242,7 +242,7 @@ export function isAmountToUiAmountInstruction(
 }
 
 /** TODO: docs */
-export function isUiamountToAmountInstruction(
+export function isUiAmountToAmountInstruction(
     decoded: DecodedInstruction,
 ): decoded is DecodedUiAmountToAmountInstruction {
     return decoded.data.instruction === TokenInstruction.UiAmountToAmount;


### PR DESCRIPTION
## Summary
Fixes a typo in the `isUiAmountToAmountInstruction` type guard function name.

## Changes
- Renamed `isUiamountToAmountInstruction` → `isUiAmountToAmountInstruction`

## Context
The function was incorrectly named with a lowercase 'a' in "amount" (`isUiamountToAmountInstruction`), which is inconsistent with:
- The enum value: `TokenInstruction.UiAmountToAmount`
- The instruction creator: `createUiAmountToAmountInstruction`  
- The decoded type: `DecodedUiAmountToAmountInstruction`
- All other similar functions in the codebase

This typo would make the function difficult to discover via IDE autocomplete and create confusion for users of the library.

## Testing
- Single character change, no logic affected
- Matches naming convention used throughout the codebase