### PR TITLE
[program] Disable apply pending balance when the account is frozen

### DIFF
--- a/program/src/extension/confidential_transfer/processor.rs
+++ b/program/src/extension/confidential_transfer/processor.rs
@@ -1218,6 +1218,10 @@ fn process_apply_pending_balance(
         account_info_iter.as_slice(),
     )?;
 
+    if token_account.base.is_frozen() {
+        return Err(TokenError::AccountFrozen.into());
+    }
+
     let confidential_transfer_account =
         token_account.get_extension_mut::<ConfidentialTransferAccount>()?;
 


### PR DESCRIPTION
#### Problem

The `ApplyPendingBalance` instruction of the Token-2022 Confidential Transfer Account extension does not verify the freeze status of the token account. As a result, confidential-transfer balances may still be updated though the account is not supposed to allow any state changes.

According to the Token-2022 specification, once a token account has been frozen, no instruction that alters its state should be executable. A frozen account must remain immutable until explicitly thawed. Allowing `ApplyPendingBalance` to bypass this rule constitutes a violation of the expected behavior defined in the spec.

Furthermore, this flaw causes **external explorers** and other transaction inspectors to incorrectly **interpret frozen accounts as active**, since confidential-transfer state transitions continue to occur despite the frozen status. This misrepresentation can mislead auditors, monitoring tools, and downstream applications relying on on-chain state consistency.

#### Summary of Changes

Disabled apply pending balance when the account is frozen.