### PR TITLE
[program] Remove an overly strict validation check on withheld fee destination account

### DIFF
--- a/interface/src/extension/confidential_transfer/mod.rs
+++ b/interface/src/extension/confidential_transfer/mod.rs
@@ -179,6 +179,20 @@ impl ConfidentialTransferAccount {
         Ok(())
     }
 
+    /// Checks if a confidential extension is configured to receive withheld tokens.
+    ///
+    /// Since withheld tokens are credited directly to the available balance,
+    /// we do not need to check the pending balance credit counter.
+    pub fn valid_as_withheld_amount_destination(&self) -> ProgramResult {
+        self.approved()?;
+
+        if !bool::from(self.allow_confidential_credits) {
+            return Err(TokenError::ConfidentialTransferDepositsAndTransfersDisabled.into());
+        }
+
+        Ok(())
+    }
+
     /// Increments a confidential extension pending balance credit counter.
     pub fn increment_pending_balance_credit_counter(&mut self) -> ProgramResult {
         self.pending_balance_credit_counter = (u64::from(self.pending_balance_credit_counter)

--- a/program/src/extension/confidential_transfer_fee/processor.rs
+++ b/program/src/extension/confidential_transfer_fee/processor.rs
@@ -126,7 +126,7 @@ fn process_withdraw_withheld_tokens_from_mint(
     }
     let destination_confidential_transfer_account =
         destination_account.get_extension_mut::<ConfidentialTransferAccount>()?;
-    destination_confidential_transfer_account.valid_as_destination()?;
+    destination_confidential_transfer_account.valid_as_withheld_amount_destination()?;
 
     // The funds are moved from the mint to a destination account. Here, the
     // `source` equates to the withdraw withheld authority associated in the
@@ -228,7 +228,7 @@ fn process_withdraw_withheld_tokens_from_accounts(
     {
         let destination_confidential_transfer_account =
             destination_account.get_extension::<ConfidentialTransferAccount>()?;
-        destination_confidential_transfer_account.valid_as_destination()?;
+        destination_confidential_transfer_account.valid_as_withheld_amount_destination()?;
 
         // The funds are moved from the accounts to a destination account. Here, the
         // `source` equates to the withdraw withheld authority associated in the


### PR DESCRIPTION
#### Problem

The `WithdrawWithheldTokensFromMint` instruction credits tokens directly to the available balance of the destination account and does not update the pending balance or its associated credit counter. Therefore, the instruction should not fail when the destination account’s `pending_balance_credit_counter` equals its `maximum_pending_balance_credit_counter`, since no pending credit is created.

Applying this check incorrectly leads to unnecessary transaction failures and can prevent the `TransferFeeConfig` withdraw-withheld authority from distributing withheld fees to certain accounts. Moreover, because this authority cannot invoke `ApplyPendingBalance` on accounts it does not own, it has no way to reduce their `pending_balance_credit_counter`, meaning such accounts may be permanently unable to receive withheld-fee withdrawals even though the operation is semantically valid.

#### Summary of Changes

Remove the overly strict validation check on withheld fee destination account.