### PR TITLE
fix(js-legacy): Removes transitive dependency on bigint-buffer

### DIFF
--- a/clients/js-legacy/README.md
+++ b/clients/js-legacy/README.md
@@ -72,9 +72,9 @@ cd clients/js-legacy
 pnpm install
 pnpm run build
 ```
-
-6. Run the tests:
+6. Run the tests (start the local test validator first):
 ```shell
+../../scripts/restart-test-validator.sh
 pnpm run test
 ```
 

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -54,13 +54,15 @@
     },
     "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
-        "@solana/buffer-layout-utils": "^0.3.0",
+        "@solana/codecs-core": "^5.1.0",
+        "@solana/codecs-data-structures": "^5.1.0",
+        "@solana/codecs-numbers": "^5.1.0",
         "@solana/spl-token-group": "^0.0.7",
         "@solana/spl-token-metadata": "^0.1.6",
         "buffer": "^6.0.3"
     },
     "devDependencies": {
-        "@solana/codecs-strings": "5.0.0",
+        "@solana/codecs-strings": "^5.1.0",
         "@solana/prettier-config-solana": "0.0.5",
         "@solana/spl-memo": "0.2.5",
         "@solana/web3.js": "^1.95.5",

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@solana/buffer-layout':
         specifier: ^4.0.0
         version: 4.0.1
-      '@solana/buffer-layout-utils':
-        specifier: ^0.3.0
-        version: 0.3.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/codecs-core':
+        specifier: 5.1.0
+        version: 5.1.0(typescript@5.9.3)
+      '@solana/codecs-data-structures':
+        specifier: 5.1.0
+        version: 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers':
+        specifier: 5.1.0
+        version: 5.1.0(typescript@5.9.3)
       '@solana/spl-token-group':
         specifier: ^0.0.7
         version: 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -25,8 +31,8 @@ importers:
         version: 6.0.3
     devDependencies:
       '@solana/codecs-strings':
-        specifier: 5.0.0
-        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: 5.1.0
+        version: 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/prettier-config-solana':
         specifier: 0.0.5
         version: 0.0.5(prettier@3.7.4)
@@ -211,10 +217,6 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@solana/buffer-layout-utils@0.3.0':
-    resolution: {integrity: sha512-MuQOCC1j0np1xH9yAv0ZWWfwvr7Bt7Sz4LId11Wi4wDdAmJ+lobE+vHg/mZmGcihF0BIkqVBNxGmlv8QE5DrtA==}
-    engines: {node: '>= 10'}
-
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
@@ -230,8 +232,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-core@5.0.0':
-    resolution: {integrity: sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA==}
+  '@solana/codecs-core@5.1.0':
+    resolution: {integrity: sha512-vDwi03mxWeWCS5Il6BCdNdifYdOoHVz97YOmbWGIt45b77Ivu5NUYeSD2+ccl6fSw8eYQ6QaqqKXMjbSfsXv4g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -240,6 +242,12 @@ packages:
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
       typescript: '>=5'
+
+  '@solana/codecs-data-structures@5.1.0':
+    resolution: {integrity: sha512-ftAwL/jsurFrk9kFVhkTLdQ8fGZ8I0PcbVH+V1a0dIP2aKDofGePvK0XbwZE/ohizC9gEIZxyBX5IgRKk5PXyg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
 
   '@solana/codecs-numbers@2.0.0-rc.1':
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
@@ -252,8 +260,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/codecs-numbers@5.0.0':
-    resolution: {integrity: sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw==}
+  '@solana/codecs-numbers@5.1.0':
+    resolution: {integrity: sha512-Ea5/9yjDNOrDZcI40UGzzi6Aq1JNsmzM4m5pOk6Xb3JRZ0YdKOv/MwuCqb6jRgzZ7SQjHhkfGL43kHLJA++bOw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
@@ -264,12 +272,15 @@ packages:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5'
 
-  '@solana/codecs-strings@5.0.0':
-    resolution: {integrity: sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw==}
+  '@solana/codecs-strings@5.1.0':
+    resolution: {integrity: sha512-014xwl5T/3VnGW0gceizF47DUs5EURRtgGmbWIR5+Z32yxgQ6hT9Zl0atZbL268RHbUQ03/J8Ush1StQgy7sfQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
       typescript: '>=5.3.3'
+    peerDependenciesMeta:
+      fastestsmallesttextencoderdecoder:
+        optional: true
 
   '@solana/codecs@2.0.0-rc.1':
     resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
@@ -289,8 +300,8 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
-  '@solana/errors@5.0.0':
-    resolution: {integrity: sha512-gTuhzO6E+ydfAAzqmqdPcvFyJwAzFKKIrqtnZPpgAuomcPYu+HSo0tuwSM/cTX0djmHt+GoOsf/julph+nvs2w==}
+  '@solana/errors@5.1.0':
+    resolution: {integrity: sha512-JlTyekErWa6Fdcwu1Hrh+jZxjM4YxyorGCFDRVZlmHZFkp5N00DWKcYnSGZrTF8E6ZZEP9pfS2XwM8y7p7HPww==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -539,16 +550,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  bigint-buffer@1.1.5:
-    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
-    engines: {node: '>= 10.0.0'}
-
-  bignumber.js@9.3.1:
-    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
 
@@ -637,10 +638,6 @@ packages:
   commander@13.0.0:
     resolution: {integrity: sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ==}
     engines: {node: '>=18'}
-
-  commander@14.0.1:
-    resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
-    engines: {node: '>=20'}
 
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
@@ -884,9 +881,6 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   filename-reserved-regex@2.0.0:
     resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
@@ -1783,18 +1777,6 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@solana/buffer-layout-utils@0.3.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      bigint-buffer: 1.1.5
-      bignumber.js: 9.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-
   '@solana/buffer-layout@4.0.1':
     dependencies:
       buffer: 6.0.3
@@ -1809,9 +1791,9 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/codecs-core@5.0.0(typescript@5.9.3)':
+  '@solana/codecs-core@5.1.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.0.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
       typescript: 5.9.3
 
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
@@ -1819,6 +1801,13 @@ snapshots:
       '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@5.1.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
       typescript: 5.9.3
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
@@ -1833,10 +1822,10 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@5.0.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@5.1.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.0.0(typescript@5.9.3)
-      '@solana/errors': 5.0.0(typescript@5.9.3)
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
       typescript: 5.9.3
 
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -1847,13 +1836,14 @@ snapshots:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
 
-  '@solana/codecs-strings@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/codecs-strings@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.0.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.0.0(typescript@5.9.3)
-      '@solana/errors': 5.0.0(typescript@5.9.3)
-      fastestsmallesttextencoderdecoder: 1.0.22
+      '@solana/codecs-core': 5.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.1.0(typescript@5.9.3)
+      '@solana/errors': 5.1.0(typescript@5.9.3)
       typescript: 5.9.3
+    optionalDependencies:
+      fastestsmallesttextencoderdecoder: 1.0.22
 
   '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -1878,10 +1868,10 @@ snapshots:
       commander: 14.0.2
       typescript: 5.9.3
 
-  '@solana/errors@5.0.0(typescript@5.9.3)':
+  '@solana/errors@5.1.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.1
+      commander: 14.0.2
       typescript: 5.9.3
 
   '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -2183,16 +2173,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bigint-buffer@1.1.5:
-    dependencies:
-      bindings: 1.5.0
-
-  bignumber.js@9.3.1: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
   bn.js@5.2.2: {}
 
   borsh@0.7.0:
@@ -2278,8 +2258,6 @@ snapshots:
   commander@12.1.0: {}
 
   commander@13.0.0: {}
-
-  commander@14.0.1: {}
 
   commander@14.0.2: {}
 
@@ -2514,8 +2492,6 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
-
-  file-uri-to-path@1.0.0: {}
 
   filename-reserved-regex@2.0.0: {}
 

--- a/clients/js-legacy/src/actions/uiAmountToAmount.ts
+++ b/clients/js-legacy/src/actions/uiAmountToAmount.ts
@@ -1,4 +1,4 @@
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { Connection, PublicKey, Signer, TransactionError } from '@solana/web3.js';
 import { Transaction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/extensions/cpiGuard/state.ts
+++ b/clients/js-legacy/src/extensions/cpiGuard/state.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { bool } from '@solana/buffer-layout-utils';
+import { bool } from '../../serialization.js';
 import type { Account } from '../../state/account.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';
 

--- a/clients/js-legacy/src/extensions/groupMemberPointer/instructions.ts
+++ b/clients/js-legacy/src/extensions/groupMemberPointer/instructions.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import type { Signer } from '@solana/web3.js';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_2022_PROGRAM_ID, programSupportsExtensions } from '../../constants.js';

--- a/clients/js-legacy/src/extensions/groupMemberPointer/state.ts
+++ b/clients/js-legacy/src/extensions/groupMemberPointer/state.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../../state/mint.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';

--- a/clients/js-legacy/src/extensions/groupPointer/instructions.ts
+++ b/clients/js-legacy/src/extensions/groupPointer/instructions.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import type { Signer } from '@solana/web3.js';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_2022_PROGRAM_ID, programSupportsExtensions } from '../../constants.js';

--- a/clients/js-legacy/src/extensions/groupPointer/state.ts
+++ b/clients/js-legacy/src/extensions/groupPointer/state.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../../state/mint.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';

--- a/clients/js-legacy/src/extensions/interestBearingMint/instructions.ts
+++ b/clients/js-legacy/src/extensions/interestBearingMint/instructions.ts
@@ -1,5 +1,5 @@
 import { s16, struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import type { PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_2022_PROGRAM_ID } from '../../constants.js';

--- a/clients/js-legacy/src/extensions/interestBearingMint/state.ts
+++ b/clients/js-legacy/src/extensions/interestBearingMint/state.ts
@@ -1,5 +1,5 @@
 import { ns64, s16, struct } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import type { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../../state/mint.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';

--- a/clients/js-legacy/src/extensions/memoTransfer/state.ts
+++ b/clients/js-legacy/src/extensions/memoTransfer/state.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { bool } from '@solana/buffer-layout-utils';
+import { bool } from '../../serialization.js';
 import type { Account } from '../../state/account.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';
 

--- a/clients/js-legacy/src/extensions/metadataPointer/instructions.ts
+++ b/clients/js-legacy/src/extensions/metadataPointer/instructions.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import type { Signer } from '@solana/web3.js';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_2022_PROGRAM_ID, programSupportsExtensions } from '../../constants.js';

--- a/clients/js-legacy/src/extensions/metadataPointer/state.ts
+++ b/clients/js-legacy/src/extensions/metadataPointer/state.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../../state/mint.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';

--- a/clients/js-legacy/src/extensions/mintCloseAuthority.ts
+++ b/clients/js-legacy/src/extensions/mintCloseAuthority.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../state/mint.js';
 import { ExtensionType, getExtensionData } from './extensionType.js';

--- a/clients/js-legacy/src/extensions/pausable/instructions.ts
+++ b/clients/js-legacy/src/extensions/pausable/instructions.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import type { Signer } from '@solana/web3.js';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_2022_PROGRAM_ID, programSupportsExtensions } from '../../constants.js';

--- a/clients/js-legacy/src/extensions/pausable/state.ts
+++ b/clients/js-legacy/src/extensions/pausable/state.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { publicKey, bool } from '@solana/buffer-layout-utils';
+import { bool, publicKey } from '../../serialization.js';
 import type { PublicKey } from '@solana/web3.js';
 import type { Account } from '../../state/account.js';
 import type { Mint } from '../../state/mint.js';

--- a/clients/js-legacy/src/extensions/permanentDelegate.ts
+++ b/clients/js-legacy/src/extensions/permanentDelegate.ts
@@ -1,5 +1,5 @@
 import { struct } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../state/mint.js';
 import { ExtensionType, getExtensionData } from './extensionType.js';

--- a/clients/js-legacy/src/extensions/scaledUiAmount/instructions.ts
+++ b/clients/js-legacy/src/extensions/scaledUiAmount/instructions.ts
@@ -1,5 +1,5 @@
 import { struct, u8, f64 } from '@solana/buffer-layout';
-import { publicKey, u64 } from '@solana/buffer-layout-utils';
+import { publicKey, u64 } from '../../serialization.js';
 import { TokenInstruction } from '../../instructions/types.js';
 import type { Signer } from '@solana/web3.js';
 import { TransactionInstruction, PublicKey } from '@solana/web3.js';

--- a/clients/js-legacy/src/extensions/scaledUiAmount/state.ts
+++ b/clients/js-legacy/src/extensions/scaledUiAmount/state.ts
@@ -1,5 +1,5 @@
 import { f64, struct } from '@solana/buffer-layout';
-import { publicKey, u64 } from '@solana/buffer-layout-utils';
+import { publicKey, u64 } from '../../serialization.js';
 import type { PublicKey } from '@solana/web3.js';
 import type { Mint } from '../../state/mint.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';

--- a/clients/js-legacy/src/extensions/tokenGroup/state.ts
+++ b/clients/js-legacy/src/extensions/tokenGroup/state.ts
@@ -1,5 +1,3 @@
-import { struct, u32 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
 import { PublicKey } from '@solana/web3.js';
 import {
     unpackTokenGroup,

--- a/clients/js-legacy/src/extensions/transferFee/instructions.ts
+++ b/clients/js-legacy/src/extensions/transferFee/instructions.ts
@@ -1,5 +1,5 @@
 import { struct, u16, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../../serialization.js';
 import type { AccountMeta, Signer, PublicKey } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID } from '../../constants.js';

--- a/clients/js-legacy/src/extensions/transferFee/state.ts
+++ b/clients/js-legacy/src/extensions/transferFee/state.ts
@@ -1,6 +1,6 @@
 import type { Layout } from '@solana/buffer-layout';
 import { struct, u16 } from '@solana/buffer-layout';
-import { publicKey, u64 } from '@solana/buffer-layout-utils';
+import { publicKey, u64 } from '../../serialization.js';
 import type { PublicKey } from '@solana/web3.js';
 import type { Account } from '../../state/account.js';
 import type { Mint } from '../../state/mint.js';

--- a/clients/js-legacy/src/extensions/transferHook/instructions.ts
+++ b/clients/js-legacy/src/extensions/transferHook/instructions.ts
@@ -5,7 +5,7 @@ import { programSupportsExtensions, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } fr
 import { TokenUnsupportedInstructionError } from '../../errors.js';
 import { addSigners } from '../../instructions/internal.js';
 import { TokenInstruction } from '../../instructions/types.js';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../../serialization.js';
 import { createTransferCheckedInstruction } from '../../instructions/transferChecked.js';
 import { createTransferCheckedWithFeeInstruction } from '../transferFee/instructions.js';
 import { getMint } from '../../state/mint.js';

--- a/clients/js-legacy/src/extensions/transferHook/state.ts
+++ b/clients/js-legacy/src/extensions/transferHook/state.ts
@@ -3,7 +3,7 @@ import type { Mint } from '../../state/mint.js';
 import { ExtensionType, getExtensionData } from '../extensionType.js';
 import type { AccountInfo, AccountMeta, Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
-import { bool, publicKey, u64 } from '@solana/buffer-layout-utils';
+import { bool, publicKey, u64 } from '../../serialization.js';
 import type { Account } from '../../state/account.js';
 import { TokenTransferHookAccountNotFound } from '../../errors.js';
 import { unpackSeeds } from './seeds.js';

--- a/clients/js-legacy/src/instructions/amountToUiAmount.ts
+++ b/clients/js-legacy/src/instructions/amountToUiAmount.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/approve.ts
+++ b/clients/js-legacy/src/instructions/approve.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/approveChecked.ts
+++ b/clients/js-legacy/src/instructions/approveChecked.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/burn.ts
+++ b/clients/js-legacy/src/instructions/burn.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/burnChecked.ts
+++ b/clients/js-legacy/src/instructions/burnChecked.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/initializeAccount2.ts
+++ b/clients/js-legacy/src/instructions/initializeAccount2.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { AccountMeta, PublicKey } from '@solana/web3.js';
 import { SYSVAR_RENT_PUBKEY, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/initializeAccount3.ts
+++ b/clients/js-legacy/src/instructions/initializeAccount3.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { AccountMeta, PublicKey } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/initializeMint.ts
+++ b/clients/js-legacy/src/instructions/initializeMint.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { AccountMeta, PublicKey } from '@solana/web3.js';
 import { SYSVAR_RENT_PUBKEY, TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/initializeMint2.ts
+++ b/clients/js-legacy/src/instructions/initializeMint2.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { AccountMeta, PublicKey } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/initializePermanentDelegate.ts
+++ b/clients/js-legacy/src/instructions/initializePermanentDelegate.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
+import { publicKey } from '../serialization.js';
 import type { AccountMeta } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';

--- a/clients/js-legacy/src/instructions/mintTo.ts
+++ b/clients/js-legacy/src/instructions/mintTo.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/mintToChecked.ts
+++ b/clients/js-legacy/src/instructions/mintToChecked.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/setAuthority.ts
+++ b/clients/js-legacy/src/instructions/setAuthority.ts
@@ -1,5 +1,4 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { publicKey } from '@solana/buffer-layout-utils';
 import type { AccountMeta, Signer, PublicKey } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/transfer.ts
+++ b/clients/js-legacy/src/instructions/transfer.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/instructions/transferChecked.ts
+++ b/clients/js-legacy/src/instructions/transferChecked.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { u64 } from '@solana/buffer-layout-utils';
+import { u64 } from '../serialization.js';
 import type { AccountMeta, PublicKey, Signer } from '@solana/web3.js';
 import { TransactionInstruction } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/serialization.ts
+++ b/clients/js-legacy/src/serialization.ts
@@ -1,75 +1,94 @@
 import { Layout } from '@solana/buffer-layout';
-import { publicKey, u64 } from '@solana/buffer-layout-utils';
-import type { PublicKey } from '@solana/web3.js';
+import type { FixedSizeCodec } from '@solana/codecs-core';
+import { fixCodecSize, transformCodec } from '@solana/codecs-core';
+import { getBytesCodec, getBooleanCodec } from '@solana/codecs-data-structures';
+import { getU64Codec } from '@solana/codecs-numbers';
+import { PublicKey } from '@solana/web3.js';
 
-export class COptionPublicKeyLayout extends Layout<PublicKey | null> {
-    private publicKeyLayout: Layout<PublicKey>;
+class FixedSizeCodecLayout<TDecoded, TEncoded extends TDecoded = TDecoded> extends Layout<TEncoded> {
+    private readonly codec: FixedSizeCodec<TDecoded, TEncoded>;
 
-    constructor(property?: string | undefined) {
-        super(-1, property);
-        this.publicKeyLayout = publicKey();
+    constructor(codec: FixedSizeCodec<TDecoded, TEncoded>, property?: string) {
+        super(codec.fixedSize, property);
+        this.codec = codec;
     }
 
-    decode(buffer: Uint8Array, offset: number = 0): PublicKey | null {
-        const option = buffer[offset];
-        if (option === 0) {
-            return null;
-        }
-        return this.publicKeyLayout.decode(buffer, offset + 1);
+    decode(buffer: Uint8Array, offset = 0): TEncoded {
+        return this.codec.decode(buffer, offset);
     }
 
-    encode(src: PublicKey | null, buffer: Uint8Array, offset: number = 0): number {
-        if (src === null) {
-            buffer[offset] = 0;
-            return 1;
-        } else {
-            buffer[offset] = 1;
-            this.publicKeyLayout.encode(src, buffer, offset + 1);
-            return 33;
-        }
-    }
-
-    getSpan(buffer?: Uint8Array, offset: number = 0): number {
-        if (buffer) {
-            const option = buffer[offset];
-            return option === 0 ? 1 : 1 + this.publicKeyLayout.span;
-        }
-        throw new RangeError('Buffer must be provided');
+    encode(src: TDecoded, buffer: Uint8Array, offset = 0): number {
+        this.codec.write(src, buffer, offset);
+        return this.codec.fixedSize;
     }
 }
 
-export class COptionU64Layout extends Layout<bigint | null> {
-    private u64Layout: Layout<bigint>;
+class OptionCodecLayout<TDecoded, TEncoded extends TDecoded = TDecoded> extends Layout<TEncoded | null> {
+    private readonly codec: FixedSizeCodec<TDecoded, TEncoded>;
 
-    constructor(property?: string | undefined) {
+    constructor(codec: FixedSizeCodec<TDecoded, TEncoded>, property?: string) {
         super(-1, property);
-        this.u64Layout = u64();
+        this.codec = codec;
     }
 
-    decode(buffer: Uint8Array, offset: number = 0): bigint | null {
-        const option = buffer[offset];
-        if (option === 0) {
+    decode(buffer: Uint8Array, offset: number = 0): TEncoded | null {
+        if (buffer[offset] === 0) {
             return null;
         }
-        return this.u64Layout.decode(buffer, offset + 1);
+
+        return this.codec.decode(buffer, offset + 1);
     }
 
-    encode(src: bigint | null, buffer: Uint8Array, offset: number = 0): number {
+    encode(src: TDecoded | null, buffer: Uint8Array, offset: number = 0): number {
         if (src === null) {
             buffer[offset] = 0;
             return 1;
-        } else {
-            buffer[offset] = 1;
-            this.u64Layout.encode(src, buffer, offset + 1);
-            return 9;
         }
+
+        buffer[offset] = 1;
+        this.codec.write(src, buffer, offset + 1);
+
+        return 1 + this.codec.fixedSize;
     }
 
     getSpan(buffer?: Uint8Array, offset: number = 0): number {
-        if (buffer) {
-            const option = buffer[offset];
-            return option === 0 ? 1 : 1 + this.u64Layout.span;
+        if (!buffer) {
+            throw new RangeError('Buffer must be provided');
         }
-        throw new RangeError('Buffer must be provided');
+
+        return buffer[offset] === 0 ? 1 : 1 + this.codec.fixedSize;
+    }
+}
+
+const publicKeyCodec = transformCodec(
+    fixCodecSize(getBytesCodec(), 32),
+    (value: PublicKey) => value.toBytes(),
+    bytes => new PublicKey(bytes),
+);
+
+const boolCodec = getBooleanCodec();
+const u64Codec = getU64Codec();
+
+export function bool(property?: string): Layout<boolean> {
+    return new FixedSizeCodecLayout(boolCodec, property);
+}
+
+export function publicKey(property?: string): Layout<PublicKey> {
+    return new FixedSizeCodecLayout(publicKeyCodec, property);
+}
+
+export function u64(property?: string): Layout<bigint> {
+    return new FixedSizeCodecLayout(u64Codec, property);
+}
+
+export class COptionPublicKeyLayout extends OptionCodecLayout<PublicKey> {
+    constructor(property?: string | undefined) {
+        super(publicKeyCodec, property);
+    }
+}
+
+export class COptionU64Layout extends OptionCodecLayout<bigint> {
+    constructor(property?: string | undefined) {
+        super(u64Codec, property);
     }
 }

--- a/clients/js-legacy/src/state/account.ts
+++ b/clients/js-legacy/src/state/account.ts
@@ -1,5 +1,5 @@
 import { struct, u32, u8 } from '@solana/buffer-layout';
-import { publicKey, u64 } from '@solana/buffer-layout-utils';
+import { publicKey, u64 } from '../serialization.js';
 import type { AccountInfo, Commitment, Connection, PublicKey } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';
 import {

--- a/clients/js-legacy/src/state/mint.ts
+++ b/clients/js-legacy/src/state/mint.ts
@@ -1,5 +1,5 @@
 import { struct, u32, u8 } from '@solana/buffer-layout';
-import { bool, publicKey, u64 } from '@solana/buffer-layout-utils';
+import { bool, publicKey, u64 } from '../serialization.js';
 import type { AccountInfo, Commitment, Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } from '../constants.js';

--- a/clients/js-legacy/src/state/multisig.ts
+++ b/clients/js-legacy/src/state/multisig.ts
@@ -1,5 +1,5 @@
 import { struct, u8 } from '@solana/buffer-layout';
-import { bool, publicKey } from '@solana/buffer-layout-utils';
+import { bool, publicKey } from '../serialization.js';
 import type { AccountInfo, Commitment, Connection, PublicKey } from '@solana/web3.js';
 import { TOKEN_PROGRAM_ID } from '../constants.js';
 import { TokenAccountNotFoundError, TokenInvalidAccountOwnerError, TokenInvalidAccountSizeError } from '../errors.js';


### PR DESCRIPTION
Replaces the use of `@solana/buffer-layout-utils`, which depends on the unmaintained `bigint-buffer` package vulnerable to CVE-2025-3194, with `@solana/codecs` backed Layout implementation.

While `@solana/spl-token` isn't directly vulnerable to buffer overflow as none of its code path uses `toBigIntLE()` from `bigint-buffer`, removing the dependency on `bigint-buffer` removes the high severity vulnerability flag on `@solana/spl-token`.

fixes #453