### PR TITLE
chore: bump toolchain -> 1.90.0

### DIFF
--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -561,15 +561,12 @@ where
             num_retries += 1;
         }
 
-        Err(TokenError::Client(Box::new(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
-                start.elapsed().as_millis(),
-                num_retries,
-                blockhash
-            ),
-        ))))
+        Err(TokenError::Client(Box::new(io::Error::other(format!(
+            "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
+            start.elapsed().as_millis(),
+            num_retries,
+            blockhash
+        )))))
     }
 
     fn get_multisig_signers<'a>(

--- a/confidential/proof-extraction/src/transfer_with_fee.rs
+++ b/confidential/proof-extraction/src/transfer_with_fee.rs
@@ -196,7 +196,7 @@ impl TransferWithFeeProofContext {
         // (`zip` will not be short-circuited)
         if !range_proof_commitments
             .iter()
-            .zip(expected_commitments.into_iter())
+            .zip(expected_commitments)
             .all(|(proof_commitment, expected_commitment)| {
                 bytes_of(proof_commitment) == expected_commitment
             })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.90.0"


### PR DESCRIPTION
**Description**

[Solana toolchain](https://github.com/anza-xyz/agave/blob/master/rust-toolchain.toml) has been updated to 1.90.0, we should do the same with token-2022.

Just fixes some clippy rule errors apart from the toolchain bump.