### PR TITLE
[program] Make auditor public key check consistent in confidential mint/burn

### DIFF
--- a/program/src/extension/confidential_mint_burn/processor.rs
+++ b/program/src/extension/confidential_mint_burn/processor.rs
@@ -221,10 +221,8 @@ fn process_confidential_mint(
         return Err(ProgramError::InvalidInstructionData);
     }
 
-    if let Some(auditor_pubkey) = Option::<PodElGamalPubkey>::from(auditor_elgamal_pubkey) {
-        if auditor_pubkey != proof_context.mint_pubkeys.auditor {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+    if !auditor_elgamal_pubkey.equals(&proof_context.mint_pubkeys.auditor) {
+        return Err(TokenError::ConfidentialTransferElGamalPubkeyMismatch.into());
     }
 
     let proof_context_auditor_ciphertext_lo = proof_context


### PR DESCRIPTION
#### Problem

The confidential operations in token-2022 handle auditor pubkey validation
inconsistently. Confidential mint and burn operations only verify the auditor pubkey when the mint has one explicitly configured, while confidential transfer operations always enforce an exact match regardless of configuration state.

In the `process_confidential_mint` and `process_confidential_burn` functions, the auditor pubkey check is conditional. The code first converts the stored pubkey to an `Option` and only performs validation if Some variant is present.

```
if let Some (auditor_pubkey) = Option::<PodElGamalPubkey>::from(auditor_elgamal_pubkey) {
    if auditor_pubkey != proof_context.mint_pubkeys.auditor {
        return Err (ProgramError::InvalidInstructionData);
    }
}
```

In contrast, the process_transfer function and the transfer-with-fee path use the `.equals()` method, which always enforces that the proof's auditor pubkey matches the mint's configured value.

This behavioral diﬀerence means that when no auditor is configured on the mint, confidential mint/burn operations accept proofs generated with any arbitrary auditor pubkey, while confidential transfers require the proof to explicitly encode a zeroed/none auditor. Although this does not create an exploitable vulnerability, since the proof still binds to the pubkey used during generation, the inconsistency could lead to confusion for integrators or subtle interoperability issues when constructing proofs across diﬀerent
operation types.

#### Summary of Changes

Updated the auditor pubkey validation in `process_confidential_mint` and
`process_confidential_burn` to use the same `.equals()` pattern as confidential
transfer.