### PR TITLE
[program] Fix `verify_mint_proof` and `verify_burn_proof` to handle mixed-mode calls correctly

### DIFF
--- a/program/src/extension/confidential_mint_burn/verify_proof.rs
+++ b/program/src/extension/confidential_mint_burn/verify_proof.rs
@@ -24,7 +24,10 @@ pub fn verify_mint_proof(
     ciphertext_validity_proof_instruction_offset: i8,
     range_proof_instruction_offset: i8,
 ) -> Result<MintProofContext, ProgramError> {
-    let sysvar_account_info = if equality_proof_instruction_offset != 0 {
+    let sysvar_account_info = if equality_proof_instruction_offset != 0
+        || ciphertext_validity_proof_instruction_offset != 0
+        || range_proof_instruction_offset != 0
+    {
         Some(next_account_info(account_info_iter)?)
     } else {
         None
@@ -72,7 +75,10 @@ pub fn verify_burn_proof(
     ciphertext_validity_proof_instruction_offset: i8,
     range_proof_instruction_offset: i8,
 ) -> Result<BurnProofContext, ProgramError> {
-    let sysvar_account_info = if equality_proof_instruction_offset != 0 {
+    let sysvar_account_info = if equality_proof_instruction_offset != 0
+        || ciphertext_validity_proof_instruction_offset != 0
+        || range_proof_instruction_offset != 0
+    {
         Some(next_account_info(account_info_iter)?)
     } else {
         None


### PR DESCRIPTION
#### Problem

Currently, in the confidential mint burn extension, the verify proof functions only check the offset for the first proof (equality proof) to decide if it should fetch the instructions sysvar account. If a subsequent proof uses instruction introspection (non-zero offset) but the first one uses a context state account (zero offset), the sysvar account is not fetched at the start. This causes downstream functions to read the wrong account (expecting a sysvar but getting a context state or vice versa).

#### Summary of Changes

Update the functions so that they check if any of the proof offsets are non-zero. If so, we fetch the sysvar account immediately. This is already correctly handled in other extensions like the confidential transfer extension.