### PR TITLE
Fix extension data for PausableAccount and ConfidentialMintBurn

### DIFF
--- a/clients/js/src/generated/types/extension.ts
+++ b/clients/js/src/generated/types/extension.ts
@@ -706,7 +706,7 @@ export function getExtensionEncoder(): Encoder<ExtensionArgs> {
                     getU16Encoder(),
                 ),
             ],
-            ['ConfidentialMintBurn', getUnitEncoder()],
+            ['ConfidentialMintBurn', addEncoderSizePrefix(getStructEncoder([]), getU16Encoder())],
             [
                 'ScaledUiAmountConfig',
                 addEncoderSizePrefix(
@@ -729,7 +729,7 @@ export function getExtensionEncoder(): Encoder<ExtensionArgs> {
                     getU16Encoder(),
                 ),
             ],
-            ['PausableAccount', getUnitEncoder()],
+            ['PausableAccount', addEncoderSizePrefix(getStructEncoder([]), getU16Encoder())],
             [
                 'PermissionedBurn',
                 addEncoderSizePrefix(
@@ -950,7 +950,7 @@ export function getExtensionDecoder(): Decoder<Extension> {
                     getU16Decoder(),
                 ),
             ],
-            ['ConfidentialMintBurn', getUnitDecoder()],
+            ['ConfidentialMintBurn', addDecoderSizePrefix(getStructDecoder([]), getU16Decoder())],
             [
                 'ScaledUiAmountConfig',
                 addDecoderSizePrefix(
@@ -973,7 +973,7 @@ export function getExtensionDecoder(): Decoder<Extension> {
                     getU16Decoder(),
                 ),
             ],
-            ['PausableAccount', getUnitDecoder()],
+            ['PausableAccount', addDecoderSizePrefix(getStructDecoder([]), getU16Decoder())],
             [
                 'PermissionedBurn',
                 addDecoderSizePrefix(
@@ -1090,6 +1090,7 @@ export function extension(
 ): GetDiscriminatedUnionVariant<ExtensionArgs, '__kind', 'TokenGroupMember'>;
 export function extension(
     kind: 'ConfidentialMintBurn',
+    data: GetDiscriminatedUnionVariantContent<ExtensionArgs, '__kind', 'ConfidentialMintBurn'>,
 ): GetDiscriminatedUnionVariant<ExtensionArgs, '__kind', 'ConfidentialMintBurn'>;
 export function extension(
     kind: 'ScaledUiAmountConfig',
@@ -1101,6 +1102,7 @@ export function extension(
 ): GetDiscriminatedUnionVariant<ExtensionArgs, '__kind', 'PausableConfig'>;
 export function extension(
     kind: 'PausableAccount',
+    data: GetDiscriminatedUnionVariantContent<ExtensionArgs, '__kind', 'PausableAccount'>,
 ): GetDiscriminatedUnionVariant<ExtensionArgs, '__kind', 'PausableAccount'>;
 export function extension(
     kind: 'PermissionedBurn',

--- a/clients/js/test/getMintSize.test.ts
+++ b/clients/js/test/getMintSize.test.ts
@@ -27,3 +27,10 @@ test('it returns the size including all provided extensions', t => {
             68 /* TransferHook extension size */,
     );
 });
+
+test('it returns the correct size for the confidential mint burn extension', t => {
+    t.is(
+        getMintSize([extension('ConfidentialMintBurn', {})]),
+        166 /* extended mint base size */ + 4 /* ConfidentialMintBurn extension size */,
+    );
+});

--- a/clients/js/test/getTokenSize.test.ts
+++ b/clients/js/test/getTokenSize.test.ts
@@ -13,8 +13,15 @@ test('it returns the extended base size when an empty array of extensions is pro
 test('it returns the size including all provided extensions', t => {
     t.is(
         getTokenSize([extension('ImmutableOwner', {}), extension('TransferFeeAmount', { withheldAmount: 100n })]),
-        166 /* extended mint base size */ +
+        166 /* extended token base size */ +
             4 /* ImmutableOwner extension size */ +
             12 /* TransferFeeAmount extension size */,
+    );
+});
+
+test('it returns the correct size for the pausable account extension', t => {
+    t.is(
+        getTokenSize([extension('PausableAccount', {})]),
+        166 /* extended token base size */ + 4 /* PausableAccount extension size */,
     );
 });

--- a/interface/idl.json
+++ b/interface/idl.json
@@ -9957,8 +9957,20 @@
                             }
                         },
                         {
-                            "kind": "enumEmptyVariantTypeNode",
-                            "name": "confidentialMintBurn"
+                            "kind": "enumStructVariantTypeNode",
+                            "name": "confidentialMintBurn",
+                            "struct": {
+                                "kind": "sizePrefixTypeNode",
+                                "type": {
+                                    "kind": "structTypeNode",
+                                    "fields": []
+                                },
+                                "prefix": {
+                                    "kind": "numberTypeNode",
+                                    "format": "u16",
+                                    "endian": "le"
+                                }
+                            }
                         },
                         {
                             "kind": "enumStructVariantTypeNode",
@@ -10057,8 +10069,20 @@
                             }
                         },
                         {
-                            "kind": "enumEmptyVariantTypeNode",
-                            "name": "pausableAccount"
+                            "kind": "enumStructVariantTypeNode",
+                            "name": "pausableAccount",
+                            "struct": {
+                                "kind": "sizePrefixTypeNode",
+                                "type": {
+                                    "kind": "structTypeNode",
+                                    "fields": []
+                                },
+                                "prefix": {
+                                    "kind": "numberTypeNode",
+                                    "format": "u16",
+                                    "endian": "le"
+                                }
+                            }
                         },
                         {
                             "kind": "enumStructVariantTypeNode",


### PR DESCRIPTION
This PR fixes the serialization data for the `PausableAccount` and `ConfidentialMintBurn` extensions. Instead of having no data after their discriminator, they should contain a zero `u16` indicating that they have no data. This was causing size computations to fail for mint and/or token accounts that contained these extensions.

Shout out to [Andy](https://linktr.ee/solandy) for flagging this in [one of his latest videos](https://youtu.be/xXtpaQ7HnEQ?si=Et0XGiNZU2-3U_fc).