### PR TITLE
rust-legacy: Only simulate if a compute unit price is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10569,7 +10569,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-option",
  "solana-program-pack",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-zk-sdk",
  "spl-pod",

--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -676,22 +676,22 @@ where
             instructions.push(ComputeBudgetInstruction::set_compute_unit_price(
                 compute_unit_price,
             ));
-        }
 
-        // The simulation to find out the compute unit usage must be run after
-        // all instructions have been added to the transaction, so be sure to
-        // keep this instruction as the last one before creating and sending the
-        // transaction.
-        match self.compute_unit_limit {
-            ComputeUnitLimit::Default => {}
-            ComputeUnitLimit::Simulated => {
-                self.add_compute_unit_limit_from_simulation(&mut instructions, &blockhash)
-                    .await?;
-            }
-            ComputeUnitLimit::Static(compute_unit_limit) => {
-                instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
-                    compute_unit_limit,
-                ));
+            // The simulation to find out the compute unit usage must be run after
+            // all instructions have been added to the transaction, so be sure to
+            // keep this instruction as the last one before creating and sending the
+            // transaction.
+            match self.compute_unit_limit {
+                ComputeUnitLimit::Default => {}
+                ComputeUnitLimit::Simulated => {
+                    self.add_compute_unit_limit_from_simulation(&mut instructions, &blockhash)
+                        .await?;
+                }
+                ComputeUnitLimit::Static(compute_unit_limit) => {
+                    instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
+                        compute_unit_limit,
+                    ));
+                }
             }
         }
 

--- a/clients/rust-legacy/tests/confidential_transfer.rs
+++ b/clients/rust-legacy/tests/confidential_transfer.rs
@@ -2118,6 +2118,7 @@ async fn confidential_transfer_transfer_with_fee_with_option(option: Confidentia
         decimals,
         ..
     } = context.token_context.unwrap();
+    let token = token.with_compute_unit_price(0);
 
     let alice_meta = ConfidentialTokenAccountMeta::new_with_tokens(
         &token,
@@ -2506,6 +2507,7 @@ async fn confidential_transfer_transfer_with_fee_and_memo_option(
         decimals,
         ..
     } = context.token_context.unwrap();
+    let token = token.with_compute_unit_price(0);
 
     let alice_meta = ConfidentialTokenAccountMeta::new_with_tokens(
         &token,


### PR DESCRIPTION
#### Problem

As pointed out at
https://github.com/solana-program/token-2022/commit/87e02c9263ec0f47a6d250fe1876341969cf9bba#r176221663, we always add compute budget instructions, which can break some flows like Ledger clear-signing.

#### Summary of changes

Do the same thing as the `solana` CLI, and only simulate if a compute unit price has been set.

Note that this does cause problems for some CU-intensive transactions, such as confidential-transfer-with-fee. However, we can take care of that within the CLI by setting a compute unit price of 0.

cc @steveluscher -- this will take some time to release unfortunately, because we have a lot of unaudited changes in the repo.