### PR TITLE
deps: Bump Solana deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,7 +5100,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8293,15 +8293,14 @@ dependencies = [
 
 [[package]]
 name = "solana-program-entrypoint"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6557cf5b5e91745d1667447438a1baa7823c6086e4ece67f8e6ebfa7a8f72660"
+checksum = "84c9b0a1ff494e05f503a08b3d51150b73aa639544631e510279d6375f290997"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall 3.0.0",
- "solana-msg",
+ "solana-define-syscall 4.0.1",
  "solana-program-error",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.0.0",
 ]
 
 [[package]]
@@ -10606,7 +10605,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-sdk-ids",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.0.0",
  "solana-test-validator",
  "solana-transaction-status",
  "spl-associated-token-account-interface",
@@ -10641,21 +10640,21 @@ dependencies = [
  "solana-banks-interface",
  "solana-cli-output",
  "solana-compute-budget-interface",
- "solana-hash 3.1.0",
+ "solana-hash 4.0.1",
  "solana-instruction",
  "solana-message",
  "solana-packet",
  "solana-program-error",
  "solana-program-pack",
  "solana-program-test",
- "solana-pubkey 3.0.0",
+ "solana-pubkey 4.0.0",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
  "solana-sdk-ids",
  "solana-signature",
  "solana-signer",
- "solana-system-interface 2.0.0",
+ "solana-system-interface 3.0.0",
  "solana-transaction",
  "spl-associated-token-account-interface",
  "spl-elgamal-registry",
@@ -10787,9 +10786,9 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfff2798bcdc48ba52be12a47a28cf2d003f6f9846484ad7e6fec68d2578c25"
+checksum = "c34b46b8f39bc64a9ab177a0ea8e9a58826db76f8d9d154a2400ee60baef7b1e"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -30,7 +30,7 @@ solana-commitment-config = "3.0.0"
 solana-logger = "3.0.0"
 solana-remote-wallet = { version = "3.1.0", features = ["agave-unstable-api"] }
 solana-sdk = "3.0.0"
-solana-system-interface = "2"
+solana-system-interface = "3.0.0"
 solana-transaction-status = "3.0.0"
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-pod = { version = "0.7.1" }

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -30,19 +30,19 @@ solana-banks-client = { version = "3.0.0", optional = true }
 solana-banks-interface = { version = "3.0.0", optional = true }
 solana-compute-budget-interface = "3.0.0"
 solana-cli-output = { version = "3.1.0", features = ["agave-unstable-api"], optional = true }
-solana-hash = "3.0.0"
+solana-hash = "4.0.1"
 solana-instruction = "3.0.0"
 solana-message = "3.0.0"
 solana-packet = "3.0.0"
 solana-program-error = "3.0.0"
 solana-program-pack = "3.0.0"
 solana-program-test = { version = "3.0.0", optional = true }
-solana-pubkey = "3.0.0"
+solana-pubkey = "4.0.0"
 solana-rpc-client = "3.0.0"
 solana-rpc-client-api = "3.0.0"
 solana-signature = "3.0.0"
 solana-signer = "3.0.0"
-solana-system-interface = "2"
+solana-system-interface = "3.0.0"
 solana-transaction = "3.0.0"
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-elgamal-registry = { version = "0.4.0", path = "../../confidential/elgamal-registry", features = ["no-entrypoint"] }
@@ -55,7 +55,7 @@ spl-token-2022-interface = { version = "2.0.0", path = "../../interface" }
 spl-token-2022 = { version = "10.0.0", path = "../../program", features = ["no-entrypoint"] }
 spl-token-group-interface = { version = "0.7.0" }
 spl-token-metadata-interface = { version = "0.8.0" }
-spl-transfer-hook-interface = { version = "2.0.0" }
+spl-transfer-hook-interface = { version = "2.1.0" }
 tokio = "1"
 thiserror = "2.0"
 

--- a/confidential/elgamal-registry/Cargo.toml
+++ b/confidential/elgamal-registry/Cargo.toml
@@ -17,7 +17,7 @@ solana-account-info = "3.0.0"
 solana-cpi = "3.1.0"
 solana-instruction = "3.0.0"
 solana-msg = "3.0.0"
-solana-program-entrypoint = "3.1.0"
+solana-program-entrypoint = "3.1.1"
 solana-program-error = "3.0.0"
 solana-pubkey = { version = "4.0.0", features = ["curve25519"] }
 solana-rent = "3.0.0"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -29,7 +29,7 @@ solana-clock = "3.0.0"
 solana-cpi = "3.1.0"
 solana-instruction = "3.0.0"
 solana-msg = "3.0.0"
-solana-program-entrypoint = "3.1.0"
+solana-program-entrypoint = "3.1.1"
 solana-program-error = "3.0.0"
 solana-program-memory = "3.1.0"
 solana-program-option = "3.0.0"
@@ -48,7 +48,7 @@ spl-token-confidential-transfer-ciphertext-arithmetic = { version = "0.4.1", pat
 spl-token-confidential-transfer-proof-extraction = { version = "0.5.1", path = "../confidential/proof-extraction" }
 spl-token-group-interface = { version = "0.7.1" }
 spl-token-metadata-interface = { version = "0.8.0" }
-spl-transfer-hook-interface = { version = "2.0.0" }
+spl-transfer-hook-interface = { version = "2.1.0" }
 spl-pod = { version = "0.7.1" }
 thiserror = "2.0"
 serde = { version = "1.0.219", optional = true }
@@ -64,7 +64,7 @@ mollusk-svm = "0.8"
 proptest = "1.9"
 serial_test = "3.2.0"
 solana-account = "3.2.0"
-solana-hash = "4.0.0"
+solana-hash = "4.0.1"
 solana-keypair = "3.0.0"
 solana-signer = "3.0.0"
 solana-transaction = { version = "3.0.0", features = ["bincode"] }


### PR DESCRIPTION
#### Problem

The repo is still on some older SDK dependencies.

#### Summary of changes

Bump the following dependencies: cpi, hash, program-entrypoint, pubkey, system-interface, transfer-hook-interface