### PR TITLE
Skip `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ audit:
 			--ignore RUSTSEC-2022-0093 \
 			--ignore RUSTSEC-2024-0421 \
 			--ignore RUSTSEC-2024-0344 \
+			--ignore RUSTSEC-2026-0098 \
+			--ignore RUSTSEC-2026-0099 \
 			$(ARGS)
 
 spellcheck:


### PR DESCRIPTION
#### Problem

The CI is failing due to `cargo audit`, which is caused by a transitive dependency on `reqwest`. I think we can add an exception for this for now to unblock CI.

#### Summary of Changes

Added exceptions to `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099`.