### PR TITLE
program: Prohibit ConfidentialMintBurn in process_burn

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1207,6 +1207,10 @@ impl Processor {
             }
         }
 
+        if mint.get_extension::<ConfidentialMintBurn>().is_ok() {
+            return Err(TokenError::IllegalMintBurnConversion.into());
+        }
+
         let maybe_permanent_delegate = get_permanent_delegate(&mint);
 
         if let Ok(cpi_guard) = source_account.get_extension::<CpiGuard>() {


### PR DESCRIPTION
## Summary
`process_mint_to` explicitly blocks regular minting on `ConfidentialMintBurn` 
mints using `IllegalMintBurnConversion`. However, `process_burn` has no 
equivalent check.

## Change
Added the same guard in `process_burn` after the `PausableConfig` check, 
consistent with how `process_mint_to` handles it.

## Impact
Not a security vulnerability — other guards (`InsufficientFunds`, `Overflow`) 
already protect the burn path in practice. This is a defense in depth and 
consistency fix to make both functions behave explicitly the same way.
