### PR TITLE
Remove serde-traits feature

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,7 +13,6 @@ edition = { workspace = true }
 [features]
 no-entrypoint = []
 test-sbf = []
-serde = ["spl-token-2022-interface/serde"]
 default = ["zk-ops"]
 # Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 [features]
 no-entrypoint = []
 test-sbf = []
-serde-traits = ["spl-token-2022-interface/serde"]
+serde = ["spl-token-2022-interface/serde"]
 default = ["zk-ops"]
 # Remove this feature once the underlying syscalls are released on all networks
 zk-ops = []


### PR DESCRIPTION
Follow up from: https://github.com/solana-program/token-2022/pull/1069#discussion_r3130949164. Totally unused.

Requires major version bump.