### PR TITLE
[token-2022] Remove `proof-generation` crate from the `token-2022-interface` depency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11204,7 +11204,6 @@ dependencies = [
  "solana-zk-sdk-pod",
  "spl-token-2022-interface 2.1.0",
  "spl-token-confidential-transfer-proof-extraction 0.6.0",
- "spl-token-confidential-transfer-proof-generation 0.6.0",
  "spl-token-group-interface",
  "spl-token-interface",
  "spl-token-metadata-interface 1.0.0",

--- a/clients/rust-legacy/src/zk_proofs/confidential_mint_burn.rs
+++ b/clients/rust-legacy/src/zk_proofs/confidential_mint_burn.rs
@@ -1,4 +1,5 @@
 use {
+    crate::zk_proofs::IntoTokenError,
     solana_zk_elgamal_proof_interface::proof_data::CiphertextCiphertextEqualityProofData,
     solana_zk_sdk::{
         encryption::{
@@ -138,7 +139,7 @@ impl SupplyAccountInfo {
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
         )
-        .map_err(|e| -> TokenError { e.into() })
+        .map_err(|e| -> TokenError { e.into_token_error() })
     }
 
     /// Compute the new decryptable supply.
@@ -206,7 +207,7 @@ impl BurnAccountInfo {
             supply_elgamal_pubkey,
             auditor_elgamal_pubkey,
         )
-        .map_err(|e| -> TokenError { e.into() })
+        .map_err(|e| -> TokenError { e.into_token_error() })
     }
 
     /// Compute the new decryptable supply.

--- a/clients/rust-legacy/src/zk_proofs/confidential_transfer.rs
+++ b/clients/rust-legacy/src/zk_proofs/confidential_transfer.rs
@@ -1,4 +1,5 @@
 use {
+    crate::zk_proofs::IntoTokenError,
     solana_zk_elgamal_proof_interface::proof_data::ZeroCiphertextProofData,
     solana_zk_sdk::{
         encryption::{
@@ -225,7 +226,7 @@ impl WithdrawAccountInfo {
             withdraw_amount,
             elgamal_keypair,
         )
-        .map_err(|e| -> TokenError { e.into() })
+        .map_err(|e| -> TokenError { e.into_token_error() })
     }
 
     /// Update the decryptable available balance.
@@ -301,7 +302,7 @@ impl TransferAccountInfo {
             destination_elgamal_pubkey,
             auditor_elgamal_pubkey,
         )
-        .map_err(|e| -> TokenError { e.into() })
+        .map_err(|e| -> TokenError { e.into_token_error() })
     }
 
     /// Create a transfer proof data that is split into equality, ciphertext
@@ -340,7 +341,7 @@ impl TransferAccountInfo {
             fee_rate_basis_points,
             maximum_fee,
         )
-        .map_err(|e| -> TokenError { e.into() })
+        .map_err(|e| -> TokenError { e.into_token_error() })
     }
 
     /// Update the decryptable available balance.

--- a/clients/rust-legacy/src/zk_proofs/mod.rs
+++ b/clients/rust-legacy/src/zk_proofs/mod.rs
@@ -1,3 +1,24 @@
+use {
+    spl_token_2022_interface::error::TokenError,
+    spl_token_confidential_transfer_proof_generation::errors::TokenProofGenerationError,
+};
+
 pub mod confidential_mint_burn;
 pub mod confidential_transfer;
 pub mod confidential_transfer_fee;
+
+pub trait IntoTokenError {
+    fn into_token_error(self) -> TokenError;
+}
+
+impl IntoTokenError for TokenProofGenerationError {
+    fn into_token_error(self) -> TokenError {
+        match self {
+            TokenProofGenerationError::ProofGeneration(_) => TokenError::ProofGeneration,
+            TokenProofGenerationError::NotEnoughFunds => TokenError::InsufficientFunds,
+            TokenProofGenerationError::IllegalAmountBitLength => TokenError::IllegalBitLength,
+            TokenProofGenerationError::FeeCalculation => TokenError::FeeCalculation,
+            TokenProofGenerationError::CiphertextExtraction => TokenError::MalformedCiphertext,
+        }
+    }
+}

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -39,9 +39,6 @@ serde = { version = "1.0.219", optional = true }
 serde_with = { version = "3.18.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 
-[target.'cfg(not(target_os = "solana"))'.dependencies]
-spl-token-confidential-transfer-proof-generation = { version = "0.6.0", path = "../confidential/proof-generation" }
-
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -1,7 +1,5 @@
 //! Error types
 
-#[cfg(not(target_os = "solana"))]
-use spl_token_confidential_transfer_proof_generation::errors::TokenProofGenerationError;
 use {
     num_derive::FromPrimitive,
     solana_program_error::{ProgramError, ToStr},
@@ -467,19 +465,6 @@ impl ToStr for TokenError {
             TokenError::PendingBalanceNonZero => {
                 "Key rotation attempted while pending balance is not zero"
             }
-        }
-    }
-}
-
-#[cfg(not(target_os = "solana"))]
-impl From<TokenProofGenerationError> for TokenError {
-    fn from(e: TokenProofGenerationError) -> Self {
-        match e {
-            TokenProofGenerationError::ProofGeneration(_) => TokenError::ProofGeneration,
-            TokenProofGenerationError::NotEnoughFunds => TokenError::InsufficientFunds,
-            TokenProofGenerationError::IllegalAmountBitLength => TokenError::IllegalBitLength,
-            TokenProofGenerationError::FeeCalculation => TokenError::FeeCalculation,
-            TokenProofGenerationError::CiphertextExtraction => TokenError::MalformedCiphertext,
         }
     }
 }


### PR DESCRIPTION
#### Problem

https://github.com/solana-program/token-2022/pull/1069#discussion_r3131013521

#### Summary of Changes

I removed `spl-confidential-transfer-proof-generation` from `spl-token-2022-interface` and moved over the type conversion to the rust legacy client.