### PR TITLE
no-std interface

### DIFF
--- a/interface/src/extension/confidential_mint_burn/instruction.rs
+++ b/interface/src/extension/confidential_mint_burn/instruction.rs
@@ -11,6 +11,7 @@ use {
         extension::confidential_transfer::DecryptableBalance,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::{vec, vec::Vec},
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/confidential_transfer/instruction.rs
+++ b/interface/src/extension/confidential_transfer/instruction.rs
@@ -13,6 +13,7 @@ use {
         extension::confidential_transfer::*,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::{vec, vec::Vec},
     bytemuck::Zeroable,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/confidential_transfer_fee/instruction.rs
+++ b/interface/src/extension/confidential_transfer_fee/instruction.rs
@@ -13,7 +13,9 @@ use {
         },
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::{vec, vec::Vec},
     bytemuck::{Pod, Zeroable},
+    core::convert::TryFrom,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
@@ -23,7 +25,6 @@ use {
     solana_zk_elgamal_proof_interface::instruction::ProofInstruction,
     solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey,
     spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation,
-    std::convert::TryFrom,
 };
 
 /// Confidential Transfer extension instructions

--- a/interface/src/extension/cpi_guard/instruction.rs
+++ b/interface/src/extension/cpi_guard/instruction.rs
@@ -5,6 +5,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},

--- a/interface/src/extension/default_account_state/instruction.rs
+++ b/interface/src/extension/default_account_state/instruction.rs
@@ -5,11 +5,12 @@ use {
         check_program_account, error::TokenError, instruction::TokenInstruction,
         state::AccountState,
     },
+    alloc::{vec, vec::Vec},
+    core::convert::TryFrom,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
-    std::convert::TryFrom,
 };
 
 /// Default Account State extension instructions

--- a/interface/src/extension/group_member_pointer/instruction.rs
+++ b/interface/src/extension/group_member_pointer/instruction.rs
@@ -3,6 +3,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/group_pointer/instruction.rs
+++ b/interface/src/extension/group_pointer/instruction.rs
@@ -3,6 +3,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/interest_bearing_mint/instruction.rs
+++ b/interface/src/extension/interest_bearing_mint/instruction.rs
@@ -4,6 +4,7 @@ use {
         extension::interest_bearing_mint::BasisPoints,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/interest_bearing_mint/mod.rs
+++ b/interface/src/extension/interest_bearing_mint/mod.rs
@@ -3,12 +3,13 @@ use {
         extension::{Extension, ExtensionType},
         trim_ui_amount_string,
     },
+    alloc::{format, string::String},
     bytemuck::{Pod, Zeroable},
+    core::convert::TryInto,
     solana_address::Address,
     solana_nullable::MaybeNull,
     solana_program_error::ProgramError,
     solana_zero_copy::unaligned::{I16, I64},
-    std::convert::TryInto,
 };
 #[cfg(feature = "serde")]
 use {

--- a/interface/src/extension/memo_transfer/instruction.rs
+++ b/interface/src/extension/memo_transfer/instruction.rs
@@ -5,6 +5,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},

--- a/interface/src/extension/metadata_pointer/instruction.rs
+++ b/interface/src/extension/metadata_pointer/instruction.rs
@@ -3,6 +3,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/mod.rs
+++ b/interface/src/extension/mod.rs
@@ -31,7 +31,13 @@ use {
         pod::{PodAccount, PodMint},
         state::{Account, Mint, Multisig, PackedSizeOf},
     },
+    alloc::{vec, vec::Vec},
     bytemuck::{Pod, Zeroable},
+    core::{
+        cmp::Ordering,
+        convert::{TryFrom, TryInto},
+        mem::size_of,
+    },
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_account_info::AccountInfo,
     solana_program_error::ProgramError,
@@ -39,11 +45,6 @@ use {
     solana_zero_copy::unaligned::U16,
     spl_token_group_interface::state::{TokenGroup, TokenGroupMember},
     spl_type_length_value::variable_len_pack::VariableLenPack,
-    std::{
-        cmp::Ordering,
-        convert::{TryFrom, TryInto},
-        mem::size_of,
-    },
 };
 
 /// Confidential Transfer extension

--- a/interface/src/extension/pausable/instruction.rs
+++ b/interface/src/extension/pausable/instruction.rs
@@ -5,6 +5,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/permissioned_burn/instruction.rs
+++ b/interface/src/extension/permissioned_burn/instruction.rs
@@ -23,6 +23,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::{vec, vec::Vec},
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/scaled_ui_amount/instruction.rs
+++ b/interface/src/extension/scaled_ui_amount/instruction.rs
@@ -4,6 +4,7 @@ use {
         extension::scaled_ui_amount::{PodF64, UnixTimestamp},
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/extension/scaled_ui_amount/mod.rs
+++ b/interface/src/extension/scaled_ui_amount/mod.rs
@@ -3,6 +3,7 @@ use {
         extension::{Extension, ExtensionType},
         trim_ui_amount_string,
     },
+    alloc::{format, string::String},
     bytemuck::{Pod, Zeroable},
     solana_address::Address,
     solana_nullable::MaybeNull,

--- a/interface/src/extension/transfer_fee/instruction.rs
+++ b/interface/src/extension/transfer_fee/instruction.rs
@@ -5,11 +5,12 @@ use {
 };
 use {
     crate::{check_program_account, error::TokenError, instruction::TokenInstruction},
+    alloc::{vec, vec::Vec},
+    core::convert::TryFrom,
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
     solana_program_option::COption,
-    std::convert::TryFrom,
 };
 
 /// Transfer Fee extension instructions

--- a/interface/src/extension/transfer_fee/mod.rs
+++ b/interface/src/extension/transfer_fee/mod.rs
@@ -4,14 +4,14 @@ use {
         extension::{Extension, ExtensionType},
     },
     bytemuck::{Pod, Zeroable},
+    core::{
+        cmp,
+        convert::{TryFrom, TryInto},
+    },
     solana_address::Address,
     solana_nullable::MaybeNull,
     solana_program_error::ProgramResult,
     solana_zero_copy::unaligned::{U16, U64},
-    std::{
-        cmp,
-        convert::{TryFrom, TryInto},
-    },
 };
 #[cfg(feature = "serde")]
 use {
@@ -195,7 +195,7 @@ impl Extension for TransferFeeAmount {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use {super::*, proptest::prelude::*, solana_address::Address, std::convert::TryFrom};
+    use {super::*, core::convert::TryFrom, proptest::prelude::*, solana_address::Address};
 
     const NEWER_EPOCH: u64 = 100;
     const OLDER_EPOCH: u64 = 1;

--- a/interface/src/extension/transfer_hook/instruction.rs
+++ b/interface/src/extension/transfer_hook/instruction.rs
@@ -3,6 +3,7 @@ use {
         check_program_account,
         instruction::{encode_instruction, TokenInstruction},
     },
+    alloc::vec,
     bytemuck::{Pod, Zeroable},
     num_enum::{IntoPrimitive, TryFromPrimitive},
     solana_address::Address,

--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -15,16 +15,17 @@ use {
         check_program_account, check_spl_token_program_account, error::TokenError,
         extension::ExtensionType,
     },
+    alloc::{vec, vec::Vec},
     bytemuck::Pod,
+    core::{
+        convert::{TryFrom, TryInto},
+        mem::size_of,
+    },
     solana_address::{Address, ADDRESS_BYTES},
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
     solana_program_option::COption,
     solana_sdk_ids::{system_program, sysvar},
-    std::{
-        convert::{TryFrom, TryInto},
-        mem::size_of,
-    },
 };
 
 /// Minimum number of multisignature signers (min N)
@@ -1104,7 +1105,7 @@ impl<'a> TokenInstruction<'a> {
                 (Self::AmountToUiAmount { amount }, rest)
             }
             24 => {
-                let ui_amount = std::str::from_utf8(rest).map_err(|_| InvalidInstruction)?;
+                let ui_amount = core::str::from_utf8(rest).map_err(|_| InvalidInstruction)?;
                 (Self::UiAmountToAmount { ui_amount }, &[])
             }
             25 => {

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,8 +1,11 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![deny(missing_docs)]
+#![no_std]
 #![cfg_attr(not(test), warn(unsafe_code))]
 
 //! An ERC20-like Token program for the Solana blockchain
+
+extern crate alloc;
 
 pub mod error;
 pub mod extension;
@@ -18,6 +21,7 @@ pub mod state;
 // version
 pub use solana_zk_elgamal_proof_interface;
 use {
+    alloc::string::{String, ToString},
     solana_address::Address,
     solana_program_error::{ProgramError, ProgramResult},
 };

--- a/interface/src/pod.rs
+++ b/interface/src/pod.rs
@@ -177,7 +177,7 @@ where
 
     /// Create a `PodCOption` equivalent of `Option::None`
     ///
-    /// This could be made `const` by using `std::mem::zeroed`, but that would
+    /// This could be made `const` by using `core::mem::zeroed`, but that would
     /// require `unsafe` code, which is prohibited at the crate level.
     pub fn none() -> Self {
         Self {

--- a/interface/src/serialization.rs
+++ b/interface/src/serialization.rs
@@ -4,16 +4,17 @@
 /// Helper function to serialize / deserialize `COption` wrapped values
 pub mod coption_fromstr {
     use {
+        alloc::string::ToString,
+        core::{
+            fmt::{self, Display},
+            marker::PhantomData,
+            str::FromStr,
+        },
         serde::{
             de::{Error, Unexpected, Visitor},
             Deserializer, Serializer,
         },
         solana_program_option::COption,
-        std::{
-            fmt::{self, Display},
-            marker::PhantomData,
-            str::FromStr,
-        },
     };
 
     /// Serialize values supporting `Display` trait wrapped in `COption`
@@ -79,12 +80,12 @@ pub mod coption_fromstr {
 /// Helper function to serialize / deserialize a `COption` u64 value
 pub mod coption_u64_fromval {
     use {
+        core::fmt,
         serde::{
             de::{Error, Visitor},
             Deserializer, Serializer,
         },
         solana_program_option::COption,
-        std::fmt,
     };
 
     /// Serialize u64 wrapped in `COption`
@@ -143,6 +144,7 @@ pub mod coption_u64_fromval {
 pub mod batch_fromstr {
     use {
         crate::{error::TokenError, instruction::TokenInstruction},
+        alloc::vec::Vec,
         serde::{
             de::Error as deError,
             ser::{Error as seError, SerializeSeq},
@@ -242,12 +244,13 @@ pub mod batch_fromstr {
 /// Helper to serialize / deserialize `PodAeCiphertext` values
 pub mod aeciphertext_fromstr {
     use {
+        alloc::string::ToString,
+        core::{fmt, str::FromStr},
         serde::{
             de::{Error, Visitor},
             Deserializer, Serializer,
         },
         solana_zk_sdk_pod::encryption::auth_encryption::PodAeCiphertext,
-        std::{fmt, str::FromStr},
     };
 
     /// Serialize `AeCiphertext` values supporting `Display` trait
@@ -287,12 +290,13 @@ pub mod aeciphertext_fromstr {
 /// Helper to serialize / deserialize `PodElGamalPubkey` values
 pub mod elgamalpubkey_fromstr {
     use {
+        alloc::string::ToString,
+        core::{fmt, str::FromStr},
         serde::{
             de::{Error, Visitor},
             Deserializer, Serializer,
         },
         solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey,
-        std::{fmt, str::FromStr},
     };
 
     /// Serialize `ElGamalPubkey` values supporting `Display` trait
@@ -332,12 +336,13 @@ pub mod elgamalpubkey_fromstr {
 /// Helper to serialize / deserialize `PodElGamalCiphertext` values
 pub mod elgamalciphertext_fromstr {
     use {
+        alloc::string::ToString,
+        core::{fmt, str::FromStr},
         serde::{
             de::{Error, Visitor},
             Deserializer, Serializer,
         },
         solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext,
-        std::{fmt, str::FromStr},
     };
 
     /// Serialize `ElGamalCiphertext` values supporting `Display` trait

--- a/interface/src/state.rs
+++ b/interface/src/state.rs
@@ -327,7 +327,7 @@ impl GenericTokenAccount for Account {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use {super::*, crate::generic_token_account::ACCOUNT_INITIALIZED_INDEX};
+    use {super::*, crate::generic_token_account::ACCOUNT_INITIALIZED_INDEX, alloc::vec};
 
     pub const TEST_MINT: Mint = Mint {
         mint_authority: COption::Some(Address::new_from_array([1; 32])),


### PR DESCRIPTION
Make `spl-token-2022-interface` compile as a `no_std` crate. Direct std imports replaced with core/alloc equivalents.