### PR TITLE
Remove default std deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]
@@ -3673,7 +3672,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -3685,8 +3683,6 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
  "rayon",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -5494,26 +5490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5945,30 +5921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6139,17 +6091,8 @@ version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.0.3",
  "serde_core",
- "serde_json",
  "serde_with_macros",
- "time",
 ]
 
 [[package]]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -11,17 +11,17 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [features]
-serde = ["dep:serde", "dep:serde_with", "dep:base64", "solana-address/serde", "solana-address/decode", "solana-nullable/serde", "solana-nullable/serde-with", "solana-zero-copy/serde", "solana-zk-sdk-pod/serde"]
+serde = ["dep:serde", "dep:serde_with", "solana-address/serde", "solana-address/decode", "solana-nullable/serde", "solana-nullable/serde-with", "solana-zero-copy/serde", "solana-zk-sdk-pod/serde"]
 
 [dependencies]
 arrayref = "0.3.9"
 bytemuck = { version = "1.25.0", features = ["derive"] }
 num-derive = "0.4"
-num-traits = "0.2"
-num_enum = "0.7.6"
+num-traits = { version = "0.2", default-features = false }
+num_enum = { version = "0.7.6", default-features = false }
 solana-account-info = "3.1.1"
 solana-address = { version = "2.6.0", features = ["bytemuck", "nullable"] }
-solana-instruction = "3.0.0"
+solana-instruction = { version = "3.0.0", default-features = false }
 solana-nullable = { version = "1.1.0", features = ["bytemuck"] }
 solana-program-error = "3.0.1"
 solana-program-option = "3.1.0"
@@ -34,15 +34,15 @@ spl-token-confidential-transfer-proof-extraction = { version = "0.6.0", path = "
 spl-token-group-interface = "0.7.2"
 spl-token-metadata-interface = "1.0.0"
 spl-type-length-value = { version = "0.9.1" }
-thiserror = "2.0"
-serde = { version = "1.0.219", optional = true }
-serde_with = { version = "3.19.0", optional = true }
-base64 = { version = "0.22.1", optional = true }
+thiserror = { version = "2.0", default-features = false }
+serde = { version = "1.0.219", optional = true, default-features = false }
+serde_with = { version = "3.19.0", optional = true, default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
+base64 = "0.22.1"
 proptest = "1.11"
 serde_json = "1.0.149"
 solana-address = { version = "2.6.0", features = ["curve25519"] }


### PR DESCRIPTION
_continues no-std work from https://github.com/solana-program/token-2022/pull/1151_

Sets `default-features = false` on deps that enable std by default. Also moves base64 dep to dev-deps. 