### PR TITLE
workspace: Set Solana version for solana-verify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,5 @@ pre-release-commit-message = "Publish {{crate_name}} v{{version}}"
 tag-message = "Publish {{crate_name}} v{{version}}"
 consolidate-commits = false
 
-[patch.crates-io]
-spl-token-confidential-transfer-proof-extraction = { path = "confidential/proof-extraction" }
-spl-token-confidential-transfer-proof-generation = { path = "confidential/proof-generation" }
+[workspace.metadata.cli]
+solana = "3.1.8"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RUST_TOOLCHAIN_NIGHTLY = nightly-2026-01-22
-SOLANA_CLI_VERSION = 3.1.8
+SOLANA_CLI_VERSION = $(shell toml get ./Cargo.toml workspace.metadata.cli.solana)
 
 nightly = +${RUST_TOOLCHAIN_NIGHTLY}
 


### PR DESCRIPTION
#### Problem

There's no Solana CLI version set on the repo, so solana-verify defaults to v3.0.0, which is incorrect.

#### Summary of changes

Use the same version as the Makefile, which is 3.1.8.

At the same time, remove a patch that's no longer needed.