### PR TITLE
no-std floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,6 +4605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -17,7 +17,7 @@ serde = ["dep:serde", "dep:serde_with", "solana-address/serde", "solana-address/
 arrayref = "0.3.9"
 bytemuck = { version = "1.25.0", features = ["derive"] }
 num-derive = "0.4"
-num-traits = { version = "0.2", default-features = false }
+num-traits = { version = "0.2", features = ["libm"], default-features = false }
 num_enum = { version = "0.7.6", default-features = false }
 solana-account-info = "3.1.1"
 solana-address = { version = "2.6.0", features = ["bytemuck", "nullable"] }

--- a/interface/src/extension/interest_bearing_mint/mod.rs
+++ b/interface/src/extension/interest_bearing_mint/mod.rs
@@ -6,6 +6,7 @@ use {
     alloc::{format, string::String},
     bytemuck::{Pod, Zeroable},
     core::convert::TryInto,
+    num_traits::{pow, Float},
     solana_address::Address,
     solana_nullable::MaybeNull,
     solana_program_error::ProgramError,
@@ -62,7 +63,7 @@ impl InterestBearingConfig {
         let numerator = (i16::from(self.pre_update_average_rate) as i128)
             .checked_mul(self.pre_update_timespan()? as i128)? as f64;
         let exponent = numerator / SECONDS_PER_YEAR / ONE_IN_BASIS_POINTS;
-        Some(exponent.exp())
+        Some(Float::exp(exponent))
     }
 
     fn post_update_timespan(&self, unix_timestamp: i64) -> Option<i64> {
@@ -74,13 +75,13 @@ impl InterestBearingConfig {
             .checked_mul(self.post_update_timespan(unix_timestamp)? as i128)?
             as f64;
         let exponent = numerator / SECONDS_PER_YEAR / ONE_IN_BASIS_POINTS;
-        Some(exponent.exp())
+        Some(Float::exp(exponent))
     }
 
     fn total_scale(&self, decimals: u8, unix_timestamp: i64) -> Option<f64> {
         Some(
             self.pre_update_exp()? * self.post_update_exp(unix_timestamp)?
-                / 10_f64.powi(decimals as i32),
+                / pow(10_f64, decimals as usize),
         )
     }
 
@@ -118,7 +119,7 @@ impl InterestBearingConfig {
         } else {
             // this is important, if you round earlier, you'll get wrong "inf"
             // answers
-            Ok(amount.round() as u64)
+            Ok(Float::round(amount) as u64)
         }
     }
 

--- a/interface/src/extension/scaled_ui_amount/mod.rs
+++ b/interface/src/extension/scaled_ui_amount/mod.rs
@@ -5,6 +5,7 @@ use {
     },
     alloc::{format, string::String},
     bytemuck::{Pod, Zeroable},
+    num_traits::{pow, Float},
     solana_address::Address,
     solana_nullable::MaybeNull,
     solana_program_error::ProgramError,
@@ -70,7 +71,7 @@ impl ScaledUiAmountConfig {
     }
 
     fn total_multiplier(&self, decimals: u8, unix_timestamp: i64) -> f64 {
-        self.current_multiplier(unix_timestamp) / 10_f64.powi(decimals as i32)
+        self.current_multiplier(unix_timestamp) / pow(10_f64, decimals as usize)
     }
 
     /// Convert a raw amount to its UI representation using the given decimals
@@ -85,7 +86,7 @@ impl ScaledUiAmountConfig {
         unix_timestamp: i64,
     ) -> Option<String> {
         let scaled_amount = (amount as f64) * self.current_multiplier(unix_timestamp);
-        let truncated_amount = scaled_amount.trunc() / 10_f64.powi(decimals as i32);
+        let truncated_amount = Float::trunc(scaled_amount) / pow(10_f64, decimals as usize);
         let ui_amount = format!("{truncated_amount:.*}", decimals as usize);
         Some(trim_ui_amount_string(ui_amount, decimals))
     }
@@ -110,7 +111,7 @@ impl ScaledUiAmountConfig {
         } else {
             // this is important, if you truncate earlier, you'll get wrong "inf"
             // answers
-            Ok(amount.trunc() as u64)
+            Ok(Float::trunc(amount) as u64)
         }
     }
 }

--- a/interface/tests/float_equivalence.rs
+++ b/interface/tests/float_equivalence.rs
@@ -1,0 +1,47 @@
+use num_traits::{pow, Float};
+
+// The interface crate uses `num_traits` float helpers instead of inherent `f64` methods
+// so the same code compiles for no-std targets. These tests validate the new helpers
+// match the inherent `f64` methods.
+
+const FLOAT_CASES: [f64; 19] = [
+    f64::NEG_INFINITY,
+    -f64::MAX,
+    -123_456_789.987_654_33,
+    -10.5,
+    -2.0,
+    -1.5,
+    -1.0,
+    -0.5,
+    -0.0,
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    10.5,
+    123_456_789.987_654_33,
+    f64::MIN_POSITIVE,
+    f64::MAX,
+    f64::INFINITY,
+];
+
+#[test]
+fn num_traits_pow_matches_f64_powi_for_all_u8_decimals() {
+    for decimals in 0..=u8::MAX {
+        assert_eq!(
+            pow(10_f64, decimals as usize).to_bits(),
+            10_f64.powi(decimals as i32).to_bits(),
+            "decimals={decimals}"
+        );
+    }
+}
+
+#[test]
+fn num_traits_float_methods_match_f64_methods() {
+    for x in FLOAT_CASES {
+        assert_eq!(Float::exp(x).to_bits(), x.exp().to_bits(), "exp({x})");
+        assert_eq!(Float::round(x).to_bits(), x.round().to_bits(), "round({x})");
+        assert_eq!(Float::trunc(x).to_bits(), x.trunc().to_bits(), "trunc({x})");
+    }
+}


### PR DESCRIPTION
Continues the march toward making `spl-token-2022-interface` no-std friendly via the new ci/cd checks: https://github.com/solana-program/actions/pull/33.

This PR moves the floats to use `num-traits` instead of the inherent float methods that don't compile in `bpfel-unknown-none`.

Added tests to ensure the swap is equivalent to what we have now.