### PR TITLE
Add toml cli to runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Install toml-cli
+        uses: taiki-e/install-action@v2
+        with:
+          tool: toml-cli
+
       - name: Compute variables
         id: compute
         shell: bash


### PR DESCRIPTION
Addresses build failures. Context: https://github.com/solana-program/token-2022/pull/1162#discussion_r3243260340.