### PR TITLE
Setup toml cli env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+
       - name: Compute variables
         id: compute
         shell: bash

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+
       - name: Compute variables
         id: compute
         shell: bash

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Environment
+        uses: solana-program/actions/setup-ubuntu@main
+
       - name: Compute variables
         id: compute
         shell: bash


### PR DESCRIPTION
Now that https://github.com/solana-program/actions/pull/34 is available, we can fix the build errors by using the new environment that has toml-cli installed by default. Context: https://github.com/solana-program/token-2022/pull/1162#discussion_r3243260340.