### PR TITLE
Add no-std alloc checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   SBPF_PROGRAM_PACKAGES: "['confidential-elgamal-registry', 'program']"
   RUST_PACKAGES: "['clients-cli', 'clients-rust-legacy', 'interface', 'program', 'confidential-ciphertext-arithmetic', 'confidential-elgamal-registry', 'confidential-elgamal-registry-interface', 'confidential-proof-extraction', 'confidential-proof-generation', 'confidential-proof-tests']"
   WASM_PACKAGES: "['confidential-elgamal-registry-interface', 'interface', 'program']"
-  NO_STD_ALLOC_PACKAGES: "['confidential-proof-extraction', 'interface']"
+  NO_STD_ALLOC_PACKAGES: "['confidential-ciphertext-arithmetic', 'confidential-elgamal-registry-interface', 'confidential-proof-extraction', 'interface']"
 
 jobs:
   set_env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ env:
   SBPF_PROGRAM_PACKAGES: "['confidential-elgamal-registry', 'program']"
   RUST_PACKAGES: "['clients-cli', 'clients-rust-legacy', 'interface', 'program', 'confidential-ciphertext-arithmetic', 'confidential-elgamal-registry', 'confidential-elgamal-registry-interface', 'confidential-proof-extraction', 'confidential-proof-generation', 'confidential-proof-tests']"
   WASM_PACKAGES: "['confidential-elgamal-registry-interface', 'interface', 'program']"
+  NO_STD_ALLOC_PACKAGES: "['confidential-proof-extraction', 'interface']"
 
 jobs:
   set_env:
@@ -21,6 +22,7 @@ jobs:
       SBPF_PROGRAM_PACKAGES: ${{ steps.compute.outputs.SBPF_PROGRAM_PACKAGES }}
       RUST_PACKAGES: ${{ steps.compute.outputs.RUST_PACKAGES }}
       WASM_PACKAGES: ${{ steps.compute.outputs.WASM_PACKAGES }}
+      NO_STD_ALLOC_PACKAGES: ${{ steps.compute.outputs.NO_STD_ALLOC_PACKAGES }}
       RUST_TOOLCHAIN_NIGHTLY: ${{ steps.compute.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       SOLANA_CLI_VERSION: ${{ steps.compute.outputs.SOLANA_CLI_VERSION }}
     steps:
@@ -38,6 +40,7 @@ jobs:
           echo "SBPF_PROGRAM_PACKAGES=${{ env.SBPF_PROGRAM_PACKAGES }}" >> $GITHUB_OUTPUT
           echo "RUST_PACKAGES=${{ env.RUST_PACKAGES }}" >> $GITHUB_OUTPUT
           echo "WASM_PACKAGES=${{ env.WASM_PACKAGES }}" >> $GITHUB_OUTPUT
+          echo "NO_STD_ALLOC_PACKAGES=${{ env.NO_STD_ALLOC_PACKAGES }}" >> $GITHUB_OUTPUT
           echo "RUST_TOOLCHAIN_NIGHTLY=$(make rust-toolchain-nightly)" >> "$GITHUB_OUTPUT"
           echo "SOLANA_CLI_VERSION=$(make solana-cli-version)" >> "$GITHUB_OUTPUT"
 
@@ -52,3 +55,5 @@ jobs:
       rustfmt-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       clippy-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}
+      no-std-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
+      no-std-alloc-packages: ${{ needs.set_env.outputs.NO_STD_ALLOC_PACKAGES }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6417,7 +6417,7 @@ dependencies = [
  "spl-generic-token",
  "spl-token-2022-interface 2.1.0",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "spl-token-metadata-interface 0.8.0",
  "thiserror 2.0.18",
  "zstd",
@@ -8949,7 +8949,7 @@ dependencies = [
  "solana-vote-program",
  "spl-generic-token",
  "spl-token-2022-interface 2.1.0",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "stream-cancel",
  "thiserror 2.0.18",
  "tokio",
@@ -10257,7 +10257,7 @@ dependencies = [
  "spl-memo-interface",
  "spl-token-2022-interface 2.1.0",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 2.0.0",
  "spl-token-metadata-interface 0.8.0",
  "thiserror 2.0.18",
 ]
@@ -11001,7 +11001,7 @@ dependencies = [
  "spl-token-2022-interface 3.0.0",
  "spl-token-confidential-transfer-proof-extraction 0.6.0",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 3.0.0",
  "spl-token-metadata-interface 1.0.0",
  "spl-type-length-value",
  "strum 0.28.0",
@@ -11043,7 +11043,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 3.0.0",
  "spl-token-metadata-interface 1.0.0",
  "strum 0.28.0",
  "strum_macros 0.28.0",
@@ -11098,7 +11098,7 @@ dependencies = [
  "spl-token-confidential-transfer-proof-extraction 0.6.0",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
  "spl-token-group-interface",
- "spl-token-interface",
+ "spl-token-interface 3.0.0",
  "spl-token-metadata-interface 1.0.0",
  "spl-transfer-hook-interface",
  "test-case",
@@ -11214,6 +11214,26 @@ name = "spl-token-interface"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7143c4e676984047a400e2fbd7ac29a1659f2b1b52b897cfde19316b562e4589"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
  "solana-bn254",
  "solana-clock",
  "solana-cpi",
- "solana-curve25519 4.0.0",
+ "solana-curve25519 4.0.1",
  "solana-hash 4.2.0",
  "solana-instruction",
  "solana-keccak-hasher",
@@ -6417,7 +6417,7 @@ dependencies = [
  "spl-generic-token",
  "spl-token-2022-interface 2.1.0",
  "spl-token-group-interface",
- "spl-token-interface 2.0.0",
+ "spl-token-interface",
  "spl-token-metadata-interface 0.8.0",
  "thiserror 2.0.18",
  "zstd",
@@ -6536,7 +6536,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
@@ -6734,7 +6734,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -7388,14 +7388,14 @@ dependencies = [
 
 [[package]]
 name = "solana-curve25519"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ee66a3e25ed8d20ed6fcd1ac71735415ff1edaf33ff1ec2118826eba927bcc"
+checksum = "14b4d2a4bf0d0b0a86c22111917e86e8bd39a7b31420fb2c7d73eb83761fc7af"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "subtle",
  "thiserror 2.0.18",
 ]
@@ -7414,9 +7414,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aacdd7a61e2109887a7a7f046caebafce97ddf1150f33722eeac04f9039c73"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
 
 [[package]]
 name = "solana-derivation-path"
@@ -7857,7 +7857,7 @@ dependencies = [
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
 ]
@@ -8203,7 +8203,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]
@@ -8949,7 +8949,7 @@ dependencies = [
  "solana-vote-program",
  "spl-generic-token",
  "spl-token-2022-interface 2.1.0",
- "spl-token-interface 2.0.0",
+ "spl-token-interface",
  "stream-cancel",
  "thiserror 2.0.18",
  "tokio",
@@ -9344,7 +9344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5f18893d62e6c73117dcba48f8f5e3266d90e5ec3d0a0a90f9785adac36c1"
 dependencies = [
  "k256",
- "solana-define-syscall 5.0.0",
+ "solana-define-syscall 5.1.0",
  "thiserror 2.0.18",
 ]
 
@@ -10257,7 +10257,7 @@ dependencies = [
  "spl-memo-interface",
  "spl-token-2022-interface 2.1.0",
  "spl-token-group-interface",
- "spl-token-interface 2.0.0",
+ "spl-token-interface",
  "spl-token-metadata-interface 0.8.0",
  "thiserror 2.0.18",
 ]
@@ -10524,9 +10524,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-elgamal-proof-interface"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b7f848e2b626a7bce1987e16d38c639dd9d1352676ceb09f967ca91f52639d"
+checksum = "d8da7f01db2148a1dc16261ff1dc6f3930a1e255a33cece4f1b56658694f27f7"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -11001,7 +11001,7 @@ dependencies = [
  "spl-token-2022-interface 3.0.0",
  "spl-token-confidential-transfer-proof-extraction 0.6.0",
  "spl-token-group-interface",
- "spl-token-interface 3.0.0",
+ "spl-token-interface",
  "spl-token-metadata-interface 1.0.0",
  "spl-type-length-value",
  "strum 0.28.0",
@@ -11043,7 +11043,7 @@ dependencies = [
  "spl-token-client",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
  "spl-token-group-interface",
- "spl-token-interface 3.0.0",
+ "spl-token-interface",
  "spl-token-metadata-interface 1.0.0",
  "strum 0.28.0",
  "strum_macros 0.28.0",
@@ -11098,7 +11098,7 @@ dependencies = [
  "spl-token-confidential-transfer-proof-extraction 0.6.0",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
  "spl-token-group-interface",
- "spl-token-interface 3.0.0",
+ "spl-token-interface",
  "spl-token-metadata-interface 1.0.0",
  "spl-transfer-hook-interface",
  "test-case",
@@ -11110,10 +11110,9 @@ dependencies = [
 name = "spl-token-confidential-transfer-ciphertext-arithmetic"
 version = "0.5.0"
 dependencies = [
- "base64 0.22.1",
  "bytemuck",
  "curve25519-dalek 4.1.3",
- "solana-curve25519 3.1.4",
+ "solana-curve25519 4.0.1",
  "solana-zk-sdk 6.0.1",
  "solana-zk-sdk-pod",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
@@ -11146,7 +11145,7 @@ dependencies = [
  "bytemuck",
  "solana-account-info",
  "solana-address 2.6.0",
- "solana-curve25519 3.1.4",
+ "solana-curve25519 4.0.1",
  "solana-instruction",
  "solana-instructions-sysvar",
  "solana-msg",
@@ -11215,26 +11214,6 @@ name = "spl-token-interface"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c564ac05a7c8d8b12e988a37d82695b5ba4db376d07ea98bc4882c81f96c7f3"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive",
- "num-traits",
- "num_enum",
- "solana-instruction",
- "solana-program-error",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "spl-token-interface"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7143c4e676984047a400e2fbd7ac29a1659f2b1b52b897cfde19316b562e4589"
 dependencies = [
  "arrayref",
  "bytemuck",

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,11 @@ publish-rust-%:
 
 publish-rust-dry-run-%:
 	cd "$(call make-path,$*)" && cargo release $(LEVEL) --tag-name "$(call tag-name,$*)@v{{version}}"
+
+check-no-std-alloc-%:
+	cargo $(nightly) hack check \
+		--target bpfel-unknown-none \
+		--each-feature \
+		--manifest-path $(call make-path,$*)/Cargo.toml \
+		-Zbuild-std=alloc,core \
+		$(ARGS)

--- a/confidential/ciphertext-arithmetic/Cargo.toml
+++ b/confidential/ciphertext-arithmetic/Cargo.toml
@@ -9,9 +9,8 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-base64 = "0.22.1"
 bytemuck = "1.25.0"
-solana-curve25519 = { version = "3.0.7", features = ["agave-unstable-api"] }
+solana-curve25519 = "4.0.1"
 solana-zk-sdk-pod = "0.1.2"
 
 [dev-dependencies]

--- a/confidential/ciphertext-arithmetic/src/lib.rs
+++ b/confidential/ciphertext-arithmetic/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use {
     bytemuck::bytes_of,
     solana_curve25519::{

--- a/confidential/elgamal-registry-interface/Cargo.toml
+++ b/confidential/elgamal-registry-interface/Cargo.toml
@@ -15,7 +15,7 @@ solana-instruction = "3.0.0"
 solana-program-error = "3.0.1"
 solana-sdk-ids = "3.1.0"
 solana-zk-sdk-pod = "0.1.2"
-solana-zk-elgamal-proof-interface = "0.1.2"
+solana-zk-elgamal-proof-interface = "0.1.3"
 spl-token-confidential-transfer-proof-extraction = { version = "0.6.0", path = "../proof-extraction" }
 
 [lib]

--- a/confidential/elgamal-registry-interface/src/instruction.rs
+++ b/confidential/elgamal-registry-interface/src/instruction.rs
@@ -1,5 +1,6 @@
 use {
     crate::{get_elgamal_registry_address, id},
+    alloc::{vec, vec::Vec},
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,

--- a/confidential/elgamal-registry-interface/src/lib.rs
+++ b/confidential/elgamal-registry-interface/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod instruction;
 pub mod state;
 

--- a/confidential/proof-extraction/Cargo.toml
+++ b/confidential/proof-extraction/Cargo.toml
@@ -12,12 +12,12 @@ edition = { workspace = true }
 bytemuck = "1.25.0"
 solana-account-info = "3.1.1"
 solana-address = "2.6.0"
-solana-curve25519 = { version = "3.0.7", features = ["agave-unstable-api"] }
+solana-curve25519 = "4.0.1"
 solana-instruction = "3.0.0"
 solana-instructions-sysvar = "3.0.1"
-solana-msg = "3.1.0"
+solana-msg = { version = "3.1.0", default-features = false, features = ["alloc"] }
 solana-program-error = "3.0.1"
 solana-sdk-ids = "3.1.0"
-solana-zk-elgamal-proof-interface = "0.1.2"
+solana-zk-elgamal-proof-interface = "0.1.3"
 solana-zk-sdk-pod = "0.1.2"
-thiserror = "2.0.18"
+thiserror = { version = "2.0.18", default-features = false }

--- a/confidential/proof-extraction/src/instruction.rs
+++ b/confidential/proof-extraction/src/instruction.rs
@@ -2,7 +2,9 @@
 //! instruction data in SPL crates
 
 use {
+    alloc::vec::Vec,
     bytemuck::Pod,
+    core::{num::NonZeroI8, slice::Iter},
     solana_account_info::{next_account_info, AccountInfo},
     solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
@@ -15,7 +17,6 @@ use {
         proof_data::{ProofType, ZkProofData},
         state::ProofContextState,
     },
-    std::{num::NonZeroI8, slice::Iter},
 };
 
 /// Checks that the supplied program ID is correct for the ZK ElGamal proof

--- a/confidential/proof-extraction/src/lib.rs
+++ b/confidential/proof-extraction/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 pub mod burn;
 pub mod encryption;
 pub mod errors;

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -29,7 +29,7 @@ solana-program-pack = "3.1.0"
 solana-sdk-ids = "3.1.0"
 solana-zero-copy = { version = "1.0.1", features = ["bytemuck"] }
 solana-zk-sdk-pod = "0.1.2"
-solana-zk-elgamal-proof-interface = "0.1.2"
+solana-zk-elgamal-proof-interface = "0.1.3"
 spl-token-confidential-transfer-proof-extraction = { version = "0.6.0", path = "../confidential/proof-extraction" }
 spl-token-group-interface = "0.7.2"
 spl-token-metadata-interface = "1.0.0"


### PR DESCRIPTION
Long journey of whack-a-mole with deps has finally led us to enabling no-std checks on this repo.

This PR bumps deps required for no-std and adds ci/cd checks.

Note: `confidential-transfer-proof-generation` wasn't added as it depends on `solana-zk-sdk` which still uses the standard library.