### PR TITLE
Return InvalidInstructionData for malformed token metadata instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10568,6 +10568,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error",
  "solana-zk-sdk",
+ "spl-discriminator",
  "spl-elgamal-registry-interface",
  "spl-memo-interface",
  "spl-pod",

--- a/clients/rust-legacy/tests/token_metadata_initialize.rs
+++ b/clients/rust-legacy/tests/token_metadata_initialize.rs
@@ -10,9 +10,7 @@ use {
     spl_token_2022_interface::{error::TokenError, extension::BaseStateWithExtensions},
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     spl_token_metadata_interface::{
-        error::TokenMetadataError,
-        instruction::Initialize,
-        state::TokenMetadata,
+        error::TokenMetadataError, instruction::Initialize, state::TokenMetadata,
     },
     std::{convert::TryInto, sync::Arc},
 };

--- a/clients/rust-legacy/tests/token_metadata_initialize.rs
+++ b/clients/rust-legacy/tests/token_metadata_initialize.rs
@@ -9,7 +9,11 @@ use {
     },
     spl_token_2022_interface::{error::TokenError, extension::BaseStateWithExtensions},
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
-    spl_token_metadata_interface::{error::TokenMetadataError, state::TokenMetadata},
+    spl_token_metadata_interface::{
+        error::TokenMetadataError,
+        instruction::Initialize,
+        state::TokenMetadata,
+    },
     std::{convert::TryInto, sync::Arc},
 };
 
@@ -279,6 +283,56 @@ async fn fail_without_signature() {
         error,
         TokenClientError::Client(Box::new(TransportError::TransactionError(
             TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_initialize_with_forged_name_length_returns_invalid_instruction_data() {
+    let authority = Pubkey::new_unique();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority).await;
+
+    let token_context = test_context.token_context.take().unwrap();
+
+    let name = "Name".to_string();
+    let symbol = "SYM".to_string();
+    let uri = "uri".to_string();
+    let payload = borsh::to_vec(&Initialize {
+        name: name.clone(),
+        symbol: symbol.clone(),
+        uri: uri.clone(),
+    })
+    .unwrap();
+    let mut instruction = spl_token_metadata_interface::instruction::initialize(
+        &spl_token_2022_interface::id(),
+        token_context.token.get_address(),
+        &Pubkey::new_unique(),
+        token_context.token.get_address(),
+        &token_context.mint_authority.pubkey(),
+        name,
+        symbol,
+        uri,
+    );
+
+    let payload_offset = instruction.data.len().checked_sub(payload.len()).unwrap();
+    let length_prefix_len = std::mem::size_of::<u32>();
+    instruction.data[payload_offset..payload_offset + length_prefix_len]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+
+    let error = token_context
+        .token
+        .process_ixs(&[instruction], &[&token_context.mint_authority])
+        .await
+        .unwrap_err();
+
+    // Once the metadata decoder is hardened, malformed recognized payloads
+    // should reject as InvalidInstructionData instead of aborting or falling
+    // through to another error shape.
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
         )))
     );
 }

--- a/clients/rust-legacy/tests/token_metadata_remove_key.rs
+++ b/clients/rust-legacy/tests/token_metadata_remove_key.rs
@@ -14,7 +14,7 @@ use {
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     spl_token_metadata_interface::{
         error::TokenMetadataError,
-        instruction::remove_key,
+        instruction::{remove_key, RemoveKey},
         state::{Field, TokenMetadata},
     },
     std::{convert::TryInto, sync::Arc},
@@ -248,5 +248,67 @@ async fn fail_authority_checks() {
     assert_eq!(
         error,
         TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature,)
+    );
+}
+
+#[tokio::test]
+async fn fail_remove_key_with_forged_key_length_returns_invalid_instruction_data() {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    token_context
+        .token
+        .token_metadata_initialize_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority.pubkey(),
+            &token_context.mint_authority.pubkey(),
+            "MySuperCoolToken".to_string(),
+            "MINE".to_string(),
+            "my.super.cool.token".to_string(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let key = "new_name".to_string();
+    let idempotent = true;
+    let idempotent_prefix = borsh::to_vec(&idempotent).unwrap();
+    let payload = borsh::to_vec(&RemoveKey {
+        key: key.clone(),
+        idempotent,
+    })
+    .unwrap();
+    let mut instruction = remove_key(
+        &spl_token_2022_interface::id(),
+        token_context.token.get_address(),
+        &update_authority.pubkey(),
+        key,
+        idempotent,
+    );
+
+    let payload_offset = instruction.data.len().checked_sub(payload.len()).unwrap();
+    let key_length_offset = payload_offset + idempotent_prefix.len();
+    let length_prefix_len = std::mem::size_of::<u32>();
+    instruction.data[key_length_offset..key_length_offset + length_prefix_len]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+
+    let error = token_context
+        .token
+        .process_ixs(&[instruction], &[&update_authority])
+        .await
+        .unwrap_err();
+
+    // Once the metadata decoder is hardened, malformed recognized payloads
+    // should reject as InvalidInstructionData instead of aborting or falling
+    // through to another error shape.
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
+        )))
     );
 }

--- a/clients/rust-legacy/tests/token_metadata_update_field.rs
+++ b/clients/rust-legacy/tests/token_metadata_update_field.rs
@@ -11,7 +11,7 @@ use {
     spl_token_client::token::{ExtensionInitializationParams, TokenError as TokenClientError},
     spl_token_metadata_interface::{
         error::TokenMetadataError,
-        instruction::update_field,
+        instruction::{update_field, UpdateField},
         state::{Field, TokenMetadata},
     },
     std::{convert::TryInto, sync::Arc},
@@ -195,6 +195,68 @@ async fn fail_authority_checks() {
                 0,
                 InstructionError::Custom(TokenMetadataError::IncorrectUpdateAuthority as u32)
             )
+        )))
+    );
+}
+
+#[tokio::test]
+async fn fail_update_field_with_forged_value_length_returns_invalid_instruction_data() {
+    let authority = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let mut test_context = setup(mint_keypair, &authority.pubkey()).await;
+    let payer_pubkey = test_context.context.lock().await.payer.pubkey();
+    let token_context = test_context.token_context.take().unwrap();
+
+    let update_authority = Keypair::new();
+    token_context
+        .token
+        .token_metadata_initialize_with_rent_transfer(
+            &payer_pubkey,
+            &update_authority.pubkey(),
+            &token_context.mint_authority.pubkey(),
+            "MySuperCoolToken".to_string(),
+            "MINE".to_string(),
+            "my.super.cool.token".to_string(),
+            &[&token_context.mint_authority],
+        )
+        .await
+        .unwrap();
+
+    let field = Field::Name;
+    let value = "new_name".to_string();
+    let field_prefix = borsh::to_vec(&field).unwrap();
+    let payload = borsh::to_vec(&UpdateField {
+        field: field.clone(),
+        value: value.clone(),
+    })
+    .unwrap();
+    let mut instruction = update_field(
+        &spl_token_2022_interface::id(),
+        token_context.token.get_address(),
+        &update_authority.pubkey(),
+        field,
+        value,
+    );
+
+    let payload_offset = instruction.data.len().checked_sub(payload.len()).unwrap();
+    let value_length_offset = payload_offset + field_prefix.len();
+    let length_prefix_len = std::mem::size_of::<u32>();
+    instruction.data[value_length_offset..value_length_offset + length_prefix_len]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+
+    let error = token_context
+        .token
+        .process_ixs(&[instruction], &[&update_authority])
+        .await
+        .unwrap_err();
+
+    // Once the metadata decoder is hardened, malformed recognized payloads
+    // should reject as InvalidInstructionData instead of aborting or falling
+    // through to another error shape.
+    assert_eq!(
+        error,
+        TokenClientError::Client(Box::new(TransportError::TransactionError(
+            TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
         )))
     );
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -41,6 +41,7 @@ solana-security-txt = "1.1.2"
 solana-sysvar = { version = "3.0.0", features = ["bincode"] }
 solana-system-interface = { version = "3.0.0", features = ["bincode"] }
 solana-zk-sdk = "4.0.0"
+spl-discriminator = { version = "0.5.1" }
 spl-elgamal-registry-interface = { version = "0.1.0", path = "../confidential/elgamal-registry-interface" }
 spl-memo-interface = { version = "2.0" }
 spl-token-2022-interface = { version = "2.1.0", path = "../interface" }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -159,7 +159,7 @@ impl Processor {
     fn validate_token_metadata_update_field_payload(input: &[u8]) -> ProgramResult {
         let mut cursor = 0;
         match Self::read_u8(input, &mut cursor)? {
-            0 | 1 | 2 => {}
+            0..=2 => {}
             3 => Self::skip_borsh_string(input, &mut cursor)?,
             _ => return Err(ProgramError::InvalidInstructionData),
         }
@@ -2215,8 +2215,8 @@ impl Processor {
                 }
             }
         } else if Self::validate_affected_token_metadata_instruction(input)? {
-            let instruction =
-                TokenMetadataInstruction::unpack(input).map_err(|_| ProgramError::InvalidInstructionData)?;
+            let instruction = TokenMetadataInstruction::unpack(input)
+                .map_err(|_| ProgramError::InvalidInstructionData)?;
             token_metadata::processor::process_instruction(program_id, accounts, instruction)
         } else if let Ok(instruction) = TokenMetadataInstruction::unpack(input) {
             token_metadata::processor::process_instruction(program_id, accounts, instruction)

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -27,6 +27,7 @@ use {
     solana_sdk_ids::system_program,
     solana_system_interface::instruction as system_instruction,
     solana_sysvar::{Sysvar, SysvarSerialize},
+    spl_discriminator::SplDiscriminate,
     spl_pod::{
         bytemuck::{pod_from_bytes, pod_from_bytes_mut},
         primitives::{PodBool, PodU64},
@@ -69,18 +70,14 @@ use {
         state::{Account, AccountState, Mint, PackedSizeOf},
     },
     spl_token_group_interface::instruction::TokenGroupInstruction,
-    spl_token_metadata_interface::instruction::TokenMetadataInstruction,
+    spl_token_metadata_interface::instruction::{
+        Initialize, RemoveKey, TokenMetadataInstruction, UpdateField,
+    },
     std::convert::{TryFrom, TryInto},
 };
 
 const TOKEN_METADATA_DISCRIMINATOR_LENGTH: usize = 8;
 const U32_BYTES: usize = 4;
-const TOKEN_METADATA_INITIALIZE_DISCRIMINATOR: [u8; TOKEN_METADATA_DISCRIMINATOR_LENGTH] =
-    [0xd2, 0xe1, 0x1e, 0xa2, 0x58, 0xb8, 0x4d, 0x8d];
-const TOKEN_METADATA_UPDATE_FIELD_DISCRIMINATOR: [u8; TOKEN_METADATA_DISCRIMINATOR_LENGTH] =
-    [0xdd, 0xe9, 0x31, 0x2d, 0xb5, 0xca, 0xdc, 0xc8];
-const TOKEN_METADATA_REMOVE_KEY_DISCRIMINATOR: [u8; TOKEN_METADATA_DISCRIMINATOR_LENGTH] =
-    [0xea, 0x12, 0x20, 0x38, 0x59, 0x8d, 0x25, 0xb5];
 
 pub(crate) enum TransferInstruction {
     Unchecked,
@@ -183,13 +180,13 @@ impl Processor {
         }
 
         let (discriminator, rest) = input.split_at(TOKEN_METADATA_DISCRIMINATOR_LENGTH);
-        if discriminator == TOKEN_METADATA_INITIALIZE_DISCRIMINATOR.as_slice() {
+        if discriminator == Initialize::SPL_DISCRIMINATOR_SLICE {
             Self::validate_token_metadata_initialize_payload(rest)?;
             Ok(true)
-        } else if discriminator == TOKEN_METADATA_UPDATE_FIELD_DISCRIMINATOR.as_slice() {
+        } else if discriminator == UpdateField::SPL_DISCRIMINATOR_SLICE {
             Self::validate_token_metadata_update_field_payload(rest)?;
             Ok(true)
-        } else if discriminator == TOKEN_METADATA_REMOVE_KEY_DISCRIMINATOR.as_slice() {
+        } else if discriminator == RemoveKey::SPL_DISCRIMINATOR_SLICE {
             Self::validate_token_metadata_remove_key_payload(rest)?;
             Ok(true)
         } else {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -73,6 +73,15 @@ use {
     std::convert::{TryFrom, TryInto},
 };
 
+const TOKEN_METADATA_DISCRIMINATOR_LENGTH: usize = 8;
+const U32_BYTES: usize = 4;
+const TOKEN_METADATA_INITIALIZE_DISCRIMINATOR: [u8; TOKEN_METADATA_DISCRIMINATOR_LENGTH] =
+    [0xd2, 0xe1, 0x1e, 0xa2, 0x58, 0xb8, 0x4d, 0x8d];
+const TOKEN_METADATA_UPDATE_FIELD_DISCRIMINATOR: [u8; TOKEN_METADATA_DISCRIMINATOR_LENGTH] =
+    [0xdd, 0xe9, 0x31, 0x2d, 0xb5, 0xca, 0xdc, 0xc8];
+const TOKEN_METADATA_REMOVE_KEY_DISCRIMINATOR: [u8; TOKEN_METADATA_DISCRIMINATOR_LENGTH] =
+    [0xea, 0x12, 0x20, 0x38, 0x59, 0x8d, 0x25, 0xb5];
+
 pub(crate) enum TransferInstruction {
     Unchecked,
     Checked { decimals: u8 },
@@ -96,6 +105,98 @@ pub(crate) enum BurnInstructionVariant {
 /// Program state handler.
 pub struct Processor {}
 impl Processor {
+    fn read_u8(input: &[u8], cursor: &mut usize) -> Result<u8, ProgramError> {
+        let value = *input
+            .get(*cursor)
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        *cursor = cursor
+            .checked_add(1)
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        Ok(value)
+    }
+
+    fn read_u32(input: &[u8], cursor: &mut usize) -> Result<u32, ProgramError> {
+        let end = cursor
+            .checked_add(U32_BYTES)
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        let bytes = input
+            .get(*cursor..end)
+            .and_then(|slice| slice.try_into().ok())
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        *cursor = end;
+        Ok(u32::from_le_bytes(bytes))
+    }
+
+    fn skip_borsh_string(input: &[u8], cursor: &mut usize) -> ProgramResult {
+        let length = usize::try_from(Self::read_u32(input, cursor)?)
+            .map_err(|_| ProgramError::InvalidInstructionData)?;
+        let end = cursor
+            .checked_add(length)
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        input
+            .get(*cursor..end)
+            .ok_or(ProgramError::InvalidInstructionData)?;
+        *cursor = end;
+        Ok(())
+    }
+
+    fn validate_no_remaining_bytes(input: &[u8], cursor: usize) -> ProgramResult {
+        if cursor == input.len() {
+            Ok(())
+        } else {
+            Err(ProgramError::InvalidInstructionData)
+        }
+    }
+
+    fn validate_token_metadata_initialize_payload(input: &[u8]) -> ProgramResult {
+        let mut cursor = 0;
+        Self::skip_borsh_string(input, &mut cursor)?;
+        Self::skip_borsh_string(input, &mut cursor)?;
+        Self::skip_borsh_string(input, &mut cursor)?;
+        Self::validate_no_remaining_bytes(input, cursor)
+    }
+
+    fn validate_token_metadata_update_field_payload(input: &[u8]) -> ProgramResult {
+        let mut cursor = 0;
+        match Self::read_u8(input, &mut cursor)? {
+            0 | 1 | 2 => {}
+            3 => Self::skip_borsh_string(input, &mut cursor)?,
+            _ => return Err(ProgramError::InvalidInstructionData),
+        }
+        Self::skip_borsh_string(input, &mut cursor)?;
+        Self::validate_no_remaining_bytes(input, cursor)
+    }
+
+    fn validate_token_metadata_remove_key_payload(input: &[u8]) -> ProgramResult {
+        let mut cursor = 0;
+        match Self::read_u8(input, &mut cursor)? {
+            0 | 1 => {}
+            _ => return Err(ProgramError::InvalidInstructionData),
+        }
+        Self::skip_borsh_string(input, &mut cursor)?;
+        Self::validate_no_remaining_bytes(input, cursor)
+    }
+
+    fn validate_affected_token_metadata_instruction(input: &[u8]) -> Result<bool, ProgramError> {
+        if input.len() < TOKEN_METADATA_DISCRIMINATOR_LENGTH {
+            return Ok(false);
+        }
+
+        let (discriminator, rest) = input.split_at(TOKEN_METADATA_DISCRIMINATOR_LENGTH);
+        if discriminator == TOKEN_METADATA_INITIALIZE_DISCRIMINATOR.as_slice() {
+            Self::validate_token_metadata_initialize_payload(rest)?;
+            Ok(true)
+        } else if discriminator == TOKEN_METADATA_UPDATE_FIELD_DISCRIMINATOR.as_slice() {
+            Self::validate_token_metadata_update_field_payload(rest)?;
+            Ok(true)
+        } else if discriminator == TOKEN_METADATA_REMOVE_KEY_DISCRIMINATOR.as_slice() {
+            Self::validate_token_metadata_remove_key_payload(rest)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     fn _process_initialize_mint(
         accounts: &[AccountInfo],
         decimals: u8,
@@ -2113,6 +2214,10 @@ impl Processor {
                     Self::process_unwrap_lamports(program_id, accounts, amount)
                 }
             }
+        } else if Self::validate_affected_token_metadata_instruction(input)? {
+            let instruction =
+                TokenMetadataInstruction::unpack(input).map_err(|_| ProgramError::InvalidInstructionData)?;
+            token_metadata::processor::process_instruction(program_id, accounts, instruction)
         } else if let Ok(instruction) = TokenMetadataInstruction::unpack(input) {
             token_metadata::processor::process_instruction(program_id, accounts, instruction)
         } else if let Ok(instruction) = TokenGroupInstruction::unpack(input) {

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -28,7 +28,7 @@ use {
     solana_system_interface::instruction as system_instruction,
     solana_sysvar::{Sysvar, SysvarSerialize},
     solana_zero_copy::unaligned::U64,
-    spl_discriminator::SplDiscriminate,
+    spl_discriminator::{discriminator::ArrayDiscriminator, SplDiscriminate},
     spl_token_2022_interface::{
         check_program_account,
         error::TokenError,
@@ -73,9 +73,6 @@ use {
     std::convert::{TryFrom, TryInto},
 };
 
-const TOKEN_METADATA_DISCRIMINATOR_LENGTH: usize = 8;
-const U32_BYTES: usize = 4;
-
 pub(crate) enum TransferInstruction {
     Unchecked,
     Checked { decimals: u8 },
@@ -111,7 +108,7 @@ impl Processor {
 
     fn read_u32(input: &[u8], cursor: &mut usize) -> Result<u32, ProgramError> {
         let end = cursor
-            .checked_add(U32_BYTES)
+            .checked_add(core::mem::size_of::<u32>())
             .ok_or(ProgramError::InvalidInstructionData)?;
         let bytes = input
             .get(*cursor..end)
@@ -171,12 +168,23 @@ impl Processor {
         Self::validate_no_remaining_bytes(input, cursor)
     }
 
+    /// Defense-in-depth guard for the token-metadata instructions that carry
+    /// Borsh length-prefixed strings (`Initialize`, `UpdateField`, `RemoveKey`).
+    /// A forged length prefix makes `TokenMetadataInstruction::unpack` ask Borsh
+    /// to allocate before it can return an error, which aborts on the SBF heap.
+    /// Validating the declared lengths against the buffer here rejects such
+    /// payloads as `InvalidInstructionData` before that allocation happens.
+    ///
+    /// `UpdateAuthority` and `Emit` carry only fixed-size fields, so they are
+    /// not affected and fall through to the regular `unpack` path. The root-cause
+    /// fix belongs in `spl-token-metadata-interface::unpack` (see #1152); this
+    /// guard can be removed once that lands.
     fn validate_affected_token_metadata_instruction(input: &[u8]) -> Result<bool, ProgramError> {
-        if input.len() < TOKEN_METADATA_DISCRIMINATOR_LENGTH {
+        if input.len() < ArrayDiscriminator::LENGTH {
             return Ok(false);
         }
 
-        let (discriminator, rest) = input.split_at(TOKEN_METADATA_DISCRIMINATOR_LENGTH);
+        let (discriminator, rest) = input.split_at(ArrayDiscriminator::LENGTH);
         if discriminator == Initialize::SPL_DISCRIMINATOR_SLICE {
             Self::validate_token_metadata_initialize_payload(rest)?;
             Ok(true)

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -70,3 +70,5 @@ cryptographically
 prover
 encryptions
 permissioned
+borsh
+SBF


### PR DESCRIPTION
Closes #1152

## Summary
Malformed token metadata payloads for `Initialize`, `UpdateField`, and `RemoveKey` could reach `TokenMetadataInstruction::unpack(input)`, trigger Borsh allocation on forged string lengths, and abort the program as `ProgramFailedToComplete`. This adds a narrow pre-validation guard in `program/src/processor.rs` so recognized malformed payloads fail with `InvalidInstructionData` instead.

## What changed
- Added a local token-metadata pre-validation guard in `program/src/processor.rs` before `TokenMetadataInstruction::unpack(input)`.
- Matched only the affected metadata discriminators: `Initialize`, `UpdateField`, and `RemoveKey`.
- Validated the affected payload layouts with slice/cursor walking and fixed-size reads.
- Returned `ProgramError::InvalidInstructionData` for malformed recognized payloads instead of falling through or panicking.
- Added regression tests for forged string-length prefixes in initialize, update-field, and remove-key flows.

## Why
Before this change, malformed token metadata payloads for the affected variants could reach generic Borsh deserialization, attempt oversized allocation, and panic on SBF. In program-test this surfaced as `ProgramFailedToComplete`.

After this change, recognized malformed payloads are rejected locally and return `InstructionError(0, InvalidInstructionData)`.

## Scope
This change is intentionally narrow.
- Only `Initialize`, `UpdateField`, and `RemoveKey` are pre-validated.
- `UpdateAuthority`, `Emit`, and other metadata variants continue through the existing `TokenMetadataInstruction::unpack(input)` path unchanged.
- The production change is local to `program/src/processor.rs`, with targeted regression coverage in the three Rust legacy metadata test files.

## Tests
- Added `fail_initialize_with_forged_name_length_returns_invalid_instruction_data`.
- Added `fail_update_field_with_forged_value_length_returns_invalid_instruction_data`.
- Added `fail_remove_key_with_forged_key_length_returns_invalid_instruction_data`.
- Ran nearby success coverage:
  - `success_initialize`
  - `success_update`
  - `success_remove`

## Notes
The Rust legacy integration tests load `target/deploy/spl_token_2022.so` via program-test, so rebuild the SBF artifact with `make build-sbf-program` before running `make test-clients-rust-legacy`