### PR TITLE
Add confidential mint/burn helper plans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ tag-message = "Publish {{crate_name}} v{{version}}"
 consolidate-commits = false
 
 [workspace.metadata.cli]
-solana = "3.1.8"
+solana = "4.0.1"

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -44,13 +44,19 @@
     "homepage": "https://github.com/solana-program/token-2022#readme",
     "peerDependencies": {
         "@solana/kit": "^6.0.0",
-        "@solana/sysvars": "^5.0"
+        "@solana/sysvars": "^5.0",
+        "@solana/zk-sdk": "^0.4.2"
+    },
+    "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "@solana-program/zk-elgamal-proof": "^0.1.0"
     },
     "devDependencies": {
         "@ava/typescript": "^7.0.0",
         "@solana-program/system": "^0.12.0",
         "@solana/eslint-config-solana": "^3.0.3",
         "@solana/kit": "^6.0.0",
+        "@solana/zk-sdk": "^0.4.2",
         "@types/node": "^25",
         "@typescript-eslint/eslint-plugin": "^7.16.1",
         "@typescript-eslint/parser": "^7.16.1",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -47,6 +47,11 @@
         "@solana/sysvars": "^5.0",
         "@solana/zk-sdk": "^0.4.2"
     },
+    "peerDependenciesMeta": {
+        "@solana/zk-sdk": {
+            "optional": true
+        }
+    },
     "dependencies": {
         "@noble/curves": "^1.9.7",
         "@solana-program/zk-elgamal-proof": "^0.1.0"

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@noble/curves':
+        specifier: ^1.9.7
+        version: 1.9.7
+      '@solana-program/zk-elgamal-proof':
+        specifier: ^0.1.0
+        version: 0.1.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/sysvars':
         specifier: ^5.0
         version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -24,6 +30,9 @@ importers:
       '@solana/kit':
         specifier: ^6.0.0
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/zk-sdk':
+        specifier: ^0.4.2
+        version: 0.4.2
       '@types/node':
         specifier: ^25
         version: 25.9.2
@@ -287,6 +296,14 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -448,6 +465,11 @@ packages:
     resolution: {integrity: sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==}
     peerDependencies:
       '@solana/kit': ^6.4.0
+
+  '@solana-program/zk-elgamal-proof@0.1.0':
+    resolution: {integrity: sha512-MKyeapz8P7SqkkC7h53ARFLoanb59ylVzokSMyINDH7hxY3JyiZs92/VfPa/qedhLAEHLd8jcc8sQ3pr3GyXtw==}
+    peerDependencies:
+      '@solana/kit': ^5.0
 
   '@solana/accounts@5.0.0':
     resolution: {integrity: sha512-0JzBdEobgp8NBdhhu+GgwNDh7e8KkHDsSTVZAnNQgvT3taOz0Mwv5E48MuEeDhW6DLFwWVAx/FO3pvibG/NGwA==}
@@ -935,6 +957,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/zk-sdk@0.4.2':
+    resolution: {integrity: sha512-lTc3lvg2b14oP7XURa6jmI2m7CLyJR5otf6TVdzw+xo/A9aYvXEQxCqaK7qpfu2JYuzNxRGqP3RnjAvdOSOEUQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2515,6 +2540,12 @@ snapshots:
       - encoding
       - supports-color
 
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2630,6 +2661,11 @@ snapshots:
 
   '@solana-program/system@0.12.2(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
     dependencies:
+      '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
+  '@solana-program/zk-elgamal-proof@0.1.0(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/system': 0.12.2(@solana/kit@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
       '@solana/kit': 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
 
   '@solana/accounts@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
@@ -3231,6 +3267,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/zk-sdk@0.4.2': {}
 
   '@types/estree@1.0.8': {}
 

--- a/clients/js/src/confidentialMintBurnHelpers.ts
+++ b/clients/js/src/confidentialMintBurnHelpers.ts
@@ -1,0 +1,640 @@
+import {
+    closeContextStateProof,
+    verifyBatchedGroupedCiphertext3HandlesValidity,
+    verifyBatchedRangeProofU128,
+    verifyCiphertextCommitmentEquality,
+} from '@solana-program/zk-elgamal-proof';
+import {
+    Address,
+    Instruction,
+    TransactionSigner,
+    generateKeyPairSigner,
+    getAddressEncoder,
+    isSome,
+    parallelInstructionPlan,
+    sequentialInstructionPlan,
+    type GetMinimumBalanceForRentExemptionApi,
+    type InstructionPlan,
+    type ReadonlyUint8Array,
+    type Rpc,
+} from '@solana/kit';
+import {
+    Extension,
+    Mint,
+    TOKEN_2022_PROGRAM_ADDRESS,
+    Token,
+    getApplyConfidentialPendingBurnInstruction,
+    getConfidentialBurnInstruction,
+    getConfidentialMintInstruction,
+    getPermissionedConfidentialBurnInstruction,
+    getUpdateConfidentialMintBurnDecryptableSupplyInstruction,
+} from './generated';
+import {
+    AeCiphertext,
+    AeKey,
+    BatchedGroupedCiphertext3HandlesValidityProofData,
+    BatchedRangeProofU128Data,
+    CiphertextCommitmentEqualityProofData,
+    ElGamalCiphertext,
+    ElGamalKeypair,
+    ElGamalPubkey,
+    ElGamalSecretKey,
+    GroupedElGamalCiphertext3Handles,
+    PedersenCommitment,
+    PedersenOpening,
+} from '@solana/zk-sdk/bundler';
+import {
+    addWithLoHiCiphertexts,
+    extractCiphertextFromGroupedBytes,
+    subtractWithLoHiCiphertexts,
+} from './confidentialTransferArithmetic';
+
+const AMOUNT_LO_BIT_LENGTH = 16n;
+const AMOUNT_HI_BIT_LENGTH = 32n;
+const CONFIDENTIAL_MINT_BURN_AMOUNT_BIT_LENGTH = 48n;
+const BALANCE_BIT_LENGTH = 64;
+const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
+
+type ConfidentialMintBurnExtension = Extract<Extension, { __kind: 'ConfidentialMintBurn' }>;
+type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
+type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
+
+type ContextStateProofMode = {
+    /**
+     * The strategy used to provide zero-knowledge proofs to the program.
+     *
+     * Currently, only `context-state` is supported, where each proof is verified
+     * into a dedicated context-state account before the instruction is executed.
+     * Additional modes such as `instruction-data` may be supported in the future.
+     */
+    proofMode?: 'context-state';
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+};
+
+type GetConfidentialMintInstructionPlanBaseInput = {
+    token: Address;
+    mint: Address;
+    mintAccount: Mint;
+    destinationTokenAccount: Token;
+    authority: Address | TransactionSigner;
+    amount: number | bigint;
+    supplyElgamalKeypair: ElGamalKeypair;
+    supplyAesKey: AeKey;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+export type GetConfidentialMintInstructionPlanInput = GetConfidentialMintInstructionPlanBaseInput &
+    ContextStateProofMode;
+
+type GetConfidentialBurnInstructionPlanBaseInput = {
+    token: Address;
+    mint: Address;
+    mintAccount: Mint;
+    tokenAccount: Token;
+    authority: Address | TransactionSigner;
+    amount: number | bigint;
+    sourceElgamalKeypair: ElGamalKeypair;
+    sourceAesKey: AeKey;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+export type GetConfidentialBurnInstructionPlanInput = GetConfidentialBurnInstructionPlanBaseInput &
+    ContextStateProofMode;
+
+export type GetPermissionedConfidentialBurnInstructionPlanInput = GetConfidentialBurnInstructionPlanInput & {
+    permissionedBurnAuthority: TransactionSigner;
+};
+
+export type GetApplyConfidentialPendingBurnInstructionPlanInput = {
+    mint: Address;
+    mintAccount: Mint;
+    authority: Address | TransactionSigner;
+    supplyElgamalSecretKey: ElGamalSecretKey;
+    supplyAesKey: AeKey;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+function getTokenProgramAddress(programAddress?: Address) {
+    return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
+}
+
+function getRequiredConfidentialMintBurnExtension(mintAccount: Mint): ConfidentialMintBurnExtension {
+    if (!isSome(mintAccount.extensions)) {
+        throw new Error('Mint account is missing extensions.');
+    }
+
+    const extension = mintAccount.extensions.value.find(candidate => candidate.__kind === 'ConfidentialMintBurn') as
+        | ConfidentialMintBurnExtension
+        | undefined;
+    if (!extension) {
+        throw new Error('Mint account is missing the ConfidentialMintBurn extension.');
+    }
+
+    return extension;
+}
+
+function getRequiredConfidentialTransferMintExtension(mintAccount: Mint): ConfidentialTransferMintExtension {
+    if (!isSome(mintAccount.extensions)) {
+        throw new Error('Mint account is missing extensions.');
+    }
+
+    const extension = mintAccount.extensions.value.find(
+        candidate => candidate.__kind === 'ConfidentialTransferMint',
+    ) as ConfidentialTransferMintExtension | undefined;
+    if (!extension) {
+        throw new Error('Mint account is missing the ConfidentialTransferMint extension.');
+    }
+
+    return extension;
+}
+
+function getRequiredConfidentialTransferAccountExtension(tokenAccount: Token): ConfidentialTransferAccountExtension {
+    if (!isSome(tokenAccount.extensions)) {
+        throw new Error('Token account is missing extensions.');
+    }
+
+    const extension = tokenAccount.extensions.value.find(
+        candidate => candidate.__kind === 'ConfidentialTransferAccount',
+    ) as ConfidentialTransferAccountExtension | undefined;
+    if (!extension) {
+        throw new Error('Token account is missing the ConfidentialTransferAccount extension.');
+    }
+
+    return extension;
+}
+
+function parseAeCiphertext(bytes: ReadonlyUint8Array) {
+    const ciphertext = AeCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to deserialize an authenticated-encryption ciphertext.');
+    }
+    return ciphertext;
+}
+
+function parseElGamalCiphertext(bytes: ReadonlyUint8Array) {
+    const ciphertext = ElGamalCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to deserialize an ElGamal ciphertext.');
+    }
+    return ciphertext;
+}
+
+function getElGamalPubkeyFromAddress(value: Address) {
+    return ElGamalPubkey.fromBytes(getAddressEncoder().encode(value) as Uint8Array);
+}
+
+function getAuditorElGamalPubkey(mintAccount: Mint) {
+    const auditorElGamalPubkey = getRequiredConfidentialTransferMintExtension(mintAccount).auditorElgamalPubkey;
+    return isSome(auditorElGamalPubkey)
+        ? getElGamalPubkeyFromAddress(auditorElGamalPubkey.value)
+        : ElGamalPubkey.fromBytes(new Uint8Array(32));
+}
+
+function splitAmount(amount: bigint, bitLength: bigint): [bigint, bigint] {
+    const mask = (1n << bitLength) - 1n;
+    return [amount & mask, amount >> bitLength];
+}
+
+function assertAmountFitsBitLength(amount: bigint, bitLength: bigint): void {
+    if (amount < 0n) {
+        throw new Error('Amount must be non-negative.');
+    }
+    if (amount >= 1n << bitLength) {
+        throw new Error(`Amount must fit within ${bitLength} bits.`);
+    }
+}
+
+function computeNewAmount(currentAmount: bigint, amount: bigint): bigint {
+    if (amount > currentAmount) {
+        throw new Error('Insufficient funds.');
+    }
+    return currentAmount - amount;
+}
+
+function bytesEqual(left: ReadonlyUint8Array, right: ReadonlyUint8Array): boolean {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function assertSupplyElGamalKeypairMatchesMint(
+    supplyElgamalKeypair: ElGamalKeypair,
+    mintBurnExtension: ConfidentialMintBurnExtension,
+): void {
+    if (
+        !bytesEqual(
+            supplyElgamalKeypair.pubkey().toBytes(),
+            getAddressEncoder().encode(mintBurnExtension.supplyElgamalPubkey),
+        )
+    ) {
+        throw new Error('Supply ElGamal keypair does not match mint.');
+    }
+}
+
+function assertSourceElGamalKeypairMatchesToken(
+    sourceElgamalKeypair: ElGamalKeypair,
+    account: ConfidentialTransferAccountExtension,
+): void {
+    if (!bytesEqual(sourceElgamalKeypair.pubkey().toBytes(), getAddressEncoder().encode(account.elgamalPubkey))) {
+        throw new Error('Source ElGamal keypair does not match token account.');
+    }
+}
+
+async function buildContextStateProofPlan(
+    proofData: ReadonlyUint8Array,
+    verifyAction: (args: {
+        rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+        payer: TransactionSigner;
+        proofData: Uint8Array;
+        contextState: { contextAccount: Awaited<ReturnType<typeof generateKeyPairSigner>>; authority: Address };
+    }) => Promise<Instruction[]>,
+    payer: TransactionSigner,
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>,
+    contextStateAuthority: TransactionSigner = payer,
+): Promise<{ address: Address; setup: InstructionPlan; cleanup: Instruction }> {
+    const contextAccount = await generateKeyPairSigner();
+    const setupInstructions = await verifyAction({
+        rpc,
+        payer,
+        proofData: new Uint8Array(proofData),
+        contextState: { contextAccount, authority: contextStateAuthority.address },
+    });
+    return {
+        address: contextAccount.address,
+        // Divisible: the create-account and verify-proof instructions can fit
+        // in one transaction for small proofs but exceed the size limit for
+        // larger proofs. A transaction planner decides how to pack them; the
+        // verify only needs the account to exist, which is true once
+        // create-account is confirmed.
+        setup: sequentialInstructionPlan(setupInstructions),
+        cleanup: closeContextStateProof({
+            contextState: contextAccount.address,
+            authority: contextStateAuthority,
+            destination: payer.address,
+        }),
+    };
+}
+
+function buildRangeProofData(
+    remainingOrSupplyCommitment: PedersenCommitment,
+    remainingOrSupplyAmount: bigint,
+    remainingOrSupplyOpening: PedersenOpening,
+    groupedCiphertextLoBytes: ReadonlyUint8Array,
+    groupedCiphertextHiBytes: ReadonlyUint8Array,
+    amountLo: bigint,
+    amountHi: bigint,
+    openingLo: PedersenOpening,
+    openingHi: PedersenOpening,
+) {
+    const commitmentLo = PedersenCommitment.fromBytes(groupedCiphertextLoBytes.slice(0, 32));
+    const commitmentHi = PedersenCommitment.fromBytes(groupedCiphertextHiBytes.slice(0, 32));
+    const paddingOpening = new PedersenOpening();
+    const paddingCommitment = PedersenCommitment.from(0n, paddingOpening);
+    return new BatchedRangeProofU128Data(
+        [remainingOrSupplyCommitment, commitmentLo, commitmentHi, paddingCommitment],
+        new BigUint64Array([remainingOrSupplyAmount, amountLo, amountHi, 0n]),
+        Uint8Array.from([
+            BALANCE_BIT_LENGTH,
+            Number(AMOUNT_LO_BIT_LENGTH),
+            Number(AMOUNT_HI_BIT_LENGTH),
+            RANGE_PROOF_PADDING_BIT_LENGTH,
+        ]),
+        [remainingOrSupplyOpening, openingLo, openingHi, paddingOpening],
+    );
+}
+
+async function buildMintBurnProofPlans(
+    input: ContextStateProofMode,
+    equalityProofData: CiphertextCommitmentEqualityProofData,
+    ciphertextValidityProofData: BatchedGroupedCiphertext3HandlesValidityProofData,
+    rangeProofData: BatchedRangeProofU128Data,
+) {
+    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            ciphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU128, input.payer, input.rpc),
+    ]);
+
+    return { equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan };
+}
+
+/**
+ * Returns an instruction plan that confidentially mints tokens into a token
+ * account's pending confidential balance and updates the mint's confidential
+ * supply. Generates and verifies the equality, grouped-ciphertext validity,
+ * and batched range proofs via context-state accounts.
+ */
+export async function getConfidentialMintInstructionPlan(
+    input: GetConfidentialMintInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const amount = BigInt(input.amount);
+    assertAmountFitsBitLength(amount, CONFIDENTIAL_MINT_BURN_AMOUNT_BIT_LENGTH);
+
+    const mintBurnExtension = getRequiredConfidentialMintBurnExtension(input.mintAccount);
+    assertSupplyElGamalKeypairMatchesMint(input.supplyElgamalKeypair, mintBurnExtension);
+    const destinationAccount = getRequiredConfidentialTransferAccountExtension(input.destinationTokenAccount);
+    const [amountLo, amountHi] = splitAmount(amount, AMOUNT_LO_BIT_LENGTH);
+
+    const supplyPubkey = input.supplyElgamalKeypair.pubkey();
+    const destinationPubkey = getElGamalPubkeyFromAddress(destinationAccount.elgamalPubkey);
+    const auditorPubkey = getAuditorElGamalPubkey(input.mintAccount);
+
+    const openingLo = new PedersenOpening();
+    const openingHi = new PedersenOpening();
+    const groupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptWith(
+        destinationPubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountLo,
+        openingLo,
+    );
+    const groupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptWith(
+        destinationPubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountHi,
+        openingHi,
+    );
+
+    const groupedCiphertextLoBytes = groupedCiphertextLo.toBytes();
+    const groupedCiphertextHiBytes = groupedCiphertextHi.toBytes();
+    const mintAmountSupplyCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 1);
+    const mintAmountSupplyCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 1);
+    const mintAmountAuditorCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 2);
+    const mintAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 2);
+
+    const currentSupply = input.supplyAesKey.decrypt(parseAeCiphertext(mintBurnExtension.decryptableSupply));
+    const newSupply = currentSupply + amount;
+    assertAmountFitsBitLength(newSupply, BigInt(BALANCE_BIT_LENGTH));
+
+    const newSupplyOpening = new PedersenOpening();
+    const newSupplyCommitment = PedersenCommitment.from(newSupply, newSupplyOpening);
+    const newSupplyCiphertext = parseElGamalCiphertext(
+        addWithLoHiCiphertexts(
+            mintBurnExtension.confidentialSupply,
+            mintAmountSupplyCiphertextLo,
+            mintAmountSupplyCiphertextHi,
+            AMOUNT_LO_BIT_LENGTH,
+        ),
+    );
+
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
+        input.supplyElgamalKeypair,
+        newSupplyCiphertext,
+        newSupplyCommitment,
+        newSupplyOpening,
+        newSupply,
+    );
+    const ciphertextValidityProofData = new BatchedGroupedCiphertext3HandlesValidityProofData(
+        destinationPubkey,
+        supplyPubkey,
+        auditorPubkey,
+        groupedCiphertextLo,
+        groupedCiphertextHi,
+        amountLo,
+        amountHi,
+        openingLo,
+        openingHi,
+    );
+    const rangeProofData = buildRangeProofData(
+        newSupplyCommitment,
+        newSupply,
+        newSupplyOpening,
+        groupedCiphertextLoBytes,
+        groupedCiphertextHiBytes,
+        amountLo,
+        amountHi,
+        openingLo,
+        openingHi,
+    );
+
+    const { equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan } = await buildMintBurnProofPlans(
+        input,
+        equalityProofData,
+        ciphertextValidityProofData,
+        rangeProofData,
+    );
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([equalityProofPlan.setup, ciphertextValidityProofPlan.setup, rangeProofPlan.setup]),
+        getConfidentialMintInstruction(
+            {
+                token: input.token,
+                mint: input.mint,
+                equalityRecord: equalityProofPlan.address,
+                ciphertextValidityRecord: ciphertextValidityProofPlan.address,
+                rangeRecord: rangeProofPlan.address,
+                authority: input.authority,
+                newDecryptableSupply: input.supplyAesKey.encrypt(newSupply).toBytes(),
+                mintAmountAuditorCiphertextLo,
+                mintAmountAuditorCiphertextHi,
+                equalityProofInstructionOffset: 0,
+                ciphertextValidityProofInstructionOffset: 0,
+                rangeProofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: getTokenProgramAddress(input.programAddress) },
+        ),
+        parallelInstructionPlan([
+            equalityProofPlan.cleanup,
+            ciphertextValidityProofPlan.cleanup,
+            rangeProofPlan.cleanup,
+        ]),
+    ]);
+}
+
+async function getConfidentialBurnInstructionPlanInternal(
+    input: GetConfidentialBurnInstructionPlanInput,
+    permissionedBurnAuthority?: TransactionSigner,
+): Promise<InstructionPlan> {
+    const amount = BigInt(input.amount);
+    assertAmountFitsBitLength(amount, CONFIDENTIAL_MINT_BURN_AMOUNT_BIT_LENGTH);
+
+    const mintBurnExtension = getRequiredConfidentialMintBurnExtension(input.mintAccount);
+    const sourceAccount = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
+    assertSourceElGamalKeypairMatchesToken(input.sourceElgamalKeypair, sourceAccount);
+    const [amountLo, amountHi] = splitAmount(amount, AMOUNT_LO_BIT_LENGTH);
+
+    const sourcePubkey = input.sourceElgamalKeypair.pubkey();
+    const supplyPubkey = getElGamalPubkeyFromAddress(mintBurnExtension.supplyElgamalPubkey);
+    const auditorPubkey = getAuditorElGamalPubkey(input.mintAccount);
+
+    const openingLo = new PedersenOpening();
+    const openingHi = new PedersenOpening();
+    const groupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountLo,
+        openingLo,
+    );
+    const groupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountHi,
+        openingHi,
+    );
+
+    const groupedCiphertextLoBytes = groupedCiphertextLo.toBytes();
+    const groupedCiphertextHiBytes = groupedCiphertextHi.toBytes();
+    const burnAmountSourceCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 0);
+    const burnAmountSourceCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 0);
+    const burnAmountAuditorCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 2);
+    const burnAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 2);
+
+    const currentAvailableBalance = input.sourceAesKey.decrypt(
+        parseAeCiphertext(sourceAccount.decryptableAvailableBalance),
+    );
+    const newAvailableBalance = computeNewAmount(currentAvailableBalance, amount);
+    const newAvailableBalanceOpening = new PedersenOpening();
+    const newAvailableBalanceCommitment = PedersenCommitment.from(newAvailableBalance, newAvailableBalanceOpening);
+    const newAvailableBalanceCiphertext = parseElGamalCiphertext(
+        subtractWithLoHiCiphertexts(
+            sourceAccount.availableBalance,
+            burnAmountSourceCiphertextLo,
+            burnAmountSourceCiphertextHi,
+            AMOUNT_LO_BIT_LENGTH,
+        ),
+    );
+
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
+        input.sourceElgamalKeypair,
+        newAvailableBalanceCiphertext,
+        newAvailableBalanceCommitment,
+        newAvailableBalanceOpening,
+        newAvailableBalance,
+    );
+    const ciphertextValidityProofData = new BatchedGroupedCiphertext3HandlesValidityProofData(
+        sourcePubkey,
+        supplyPubkey,
+        auditorPubkey,
+        groupedCiphertextLo,
+        groupedCiphertextHi,
+        amountLo,
+        amountHi,
+        openingLo,
+        openingHi,
+    );
+    const rangeProofData = buildRangeProofData(
+        newAvailableBalanceCommitment,
+        newAvailableBalance,
+        newAvailableBalanceOpening,
+        groupedCiphertextLoBytes,
+        groupedCiphertextHiBytes,
+        amountLo,
+        amountHi,
+        openingLo,
+        openingHi,
+    );
+
+    const { equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan } = await buildMintBurnProofPlans(
+        input,
+        equalityProofData,
+        ciphertextValidityProofData,
+        rangeProofData,
+    );
+
+    const instructionInput = {
+        token: input.token,
+        mint: input.mint,
+        equalityRecord: equalityProofPlan.address,
+        ciphertextValidityRecord: ciphertextValidityProofPlan.address,
+        rangeRecord: rangeProofPlan.address,
+        authority: input.authority,
+        newDecryptableAvailableBalance: input.sourceAesKey.encrypt(newAvailableBalance).toBytes(),
+        burnAmountAuditorCiphertextLo,
+        burnAmountAuditorCiphertextHi,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0,
+        multiSigners: input.multiSigners,
+    };
+    const burnInstruction = permissionedBurnAuthority
+        ? getPermissionedConfidentialBurnInstruction(
+              { ...instructionInput, permissionedBurnAuthority },
+              { programAddress: getTokenProgramAddress(input.programAddress) },
+          )
+        : getConfidentialBurnInstruction(instructionInput, {
+              programAddress: getTokenProgramAddress(input.programAddress),
+          });
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([equalityProofPlan.setup, ciphertextValidityProofPlan.setup, rangeProofPlan.setup]),
+        burnInstruction,
+        parallelInstructionPlan([
+            equalityProofPlan.cleanup,
+            ciphertextValidityProofPlan.cleanup,
+            rangeProofPlan.cleanup,
+        ]),
+    ]);
+}
+
+/**
+ * Returns an instruction plan that confidentially burns tokens from a token
+ * account's available confidential balance and records the encrypted burn in
+ * the mint's pending burn accumulator.
+ */
+export async function getConfidentialBurnInstructionPlan(
+    input: GetConfidentialBurnInstructionPlanInput,
+): Promise<InstructionPlan> {
+    return await getConfidentialBurnInstructionPlanInternal(input);
+}
+
+/**
+ * Returns an instruction plan for the permissioned confidential burn variant.
+ * It builds the same proofs as `getConfidentialBurnInstructionPlan` and also
+ * includes the configured permissioned burn authority signer.
+ */
+export async function getPermissionedConfidentialBurnInstructionPlan(
+    input: GetPermissionedConfidentialBurnInstructionPlanInput,
+): Promise<InstructionPlan> {
+    return await getConfidentialBurnInstructionPlanInternal(input, input.permissionedBurnAuthority);
+}
+
+/**
+ * Returns an instruction plan that applies the mint's pending confidential
+ * burn amount to confidential supply and updates the decryptable supply to
+ * match the resulting ciphertext.
+ */
+export function getApplyConfidentialPendingBurnInstructionPlan(
+    input: GetApplyConfidentialPendingBurnInstructionPlanInput,
+): InstructionPlan {
+    const mintBurnExtension = getRequiredConfidentialMintBurnExtension(input.mintAccount);
+    const currentSupply = input.supplyAesKey.decrypt(parseAeCiphertext(mintBurnExtension.decryptableSupply));
+    const pendingBurn = input.supplyElgamalSecretKey.decrypt(parseElGamalCiphertext(mintBurnExtension.pendingBurn));
+    const newSupply = computeNewAmount(currentSupply, pendingBurn);
+    const programAddress = getTokenProgramAddress(input.programAddress);
+
+    return sequentialInstructionPlan([
+        getApplyConfidentialPendingBurnInstruction(
+            {
+                mint: input.mint,
+                authority: input.authority,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress },
+        ),
+        getUpdateConfidentialMintBurnDecryptableSupplyInstruction(
+            {
+                mint: input.mint,
+                authority: input.authority,
+                newDecryptableSupply: input.supplyAesKey.encrypt(newSupply).toBytes(),
+                multiSigners: input.multiSigners,
+            },
+            { programAddress },
+        ),
+    ]);
+}

--- a/clients/js/src/confidentialTransferArithmetic.ts
+++ b/clients/js/src/confidentialTransferArithmetic.ts
@@ -1,0 +1,95 @@
+// We depend on @noble/curves because the Web Crypto API does not expose
+// Ristretto255 point arithmetic, and `@solana/zk-sdk` (the WASM SDK) does
+// not currently expose `ElGamalCiphertext` arithmetic (subtract / multiply
+// by scalar / lo-hi combination) over its public API. Once the WASM SDK
+// adds those methods, delete this file and call into the SDK directly.
+import { ristretto255 } from '@noble/curves/ed25519';
+import { type ReadonlyUint8Array } from '@solana/kit';
+
+const { Point: RistrettoPoint } = /* @__PURE__ */ ristretto255;
+
+function pointFromBytes(bytes: ReadonlyUint8Array) {
+    return RistrettoPoint.fromHex(new Uint8Array(bytes));
+}
+
+function ciphertextToPoints(ciphertext: ReadonlyUint8Array) {
+    if (ciphertext.length !== 64) {
+        throw new Error(`Expected 64 ciphertext bytes, got ${ciphertext.length}.`);
+    }
+
+    return {
+        commitment: pointFromBytes(ciphertext.slice(0, 32)),
+        handle: pointFromBytes(ciphertext.slice(32, 64)),
+    };
+}
+
+function pointsToCiphertext(commitment: ReturnType<typeof pointFromBytes>, handle: ReturnType<typeof pointFromBytes>) {
+    const ciphertext = new Uint8Array(64);
+    ciphertext.set(commitment.toRawBytes(), 0);
+    ciphertext.set(handle.toRawBytes(), 32);
+    return ciphertext;
+}
+
+/**
+ * Extracts a single ElGamal ciphertext (commitment + one handle) from a
+ * grouped ciphertext. The grouped layout is: 32-byte commitment followed
+ * by N 32-byte handles. The returned 64-byte array is [commitment, handle].
+ */
+export function extractCiphertextFromGroupedBytes(groupedCiphertext: ReadonlyUint8Array, handleIndex: number) {
+    if (!Number.isInteger(handleIndex) || handleIndex < 0) {
+        throw new Error(`handleIndex must be a non-negative integer, got ${handleIndex}.`);
+    }
+    const start = 32 + handleIndex * 32;
+    const end = start + 32;
+    if (groupedCiphertext.length < end) {
+        throw new Error(`Grouped ciphertext does not contain handle ${handleIndex}.`);
+    }
+
+    const ciphertext = new Uint8Array(64);
+    ciphertext.set(groupedCiphertext.slice(0, 32), 0);
+    ciphertext.set(groupedCiphertext.slice(start, end), 32);
+    return ciphertext;
+}
+
+function subtractCiphertexts(left: ReadonlyUint8Array, right: ReadonlyUint8Array) {
+    const leftPoints = ciphertextToPoints(left);
+    const rightPoints = ciphertextToPoints(right);
+    return pointsToCiphertext(
+        leftPoints.commitment.subtract(rightPoints.commitment),
+        leftPoints.handle.subtract(rightPoints.handle),
+    );
+}
+
+function combineLoHiCiphertexts(ciphertextLo: ReadonlyUint8Array, ciphertextHi: ReadonlyUint8Array, bitLength: bigint) {
+    const scale = 1n << bitLength;
+    const loPoints = ciphertextToPoints(ciphertextLo);
+    const hiPoints = ciphertextToPoints(ciphertextHi);
+    return pointsToCiphertext(
+        loPoints.commitment.add(hiPoints.commitment.multiply(scale)),
+        loPoints.handle.add(hiPoints.handle.multiply(scale)),
+    );
+}
+
+/**
+ * Combines lo/hi ciphertext halves (hi << bitLength + lo) and subtracts the
+ * result from `left`. Used to compute the new available-balance ciphertext
+ * after a confidential transfer.
+ */
+export function subtractWithLoHiCiphertexts(
+    left: ReadonlyUint8Array,
+    ciphertextLo: ReadonlyUint8Array,
+    ciphertextHi: ReadonlyUint8Array,
+    bitLength: bigint,
+) {
+    return subtractCiphertexts(left, combineLoHiCiphertexts(ciphertextLo, ciphertextHi, bitLength));
+}
+
+/**
+ * Subtracts a plaintext amount from an ElGamal ciphertext by removing
+ * `amount * G` from the commitment. Used to compute the expected
+ * remaining-balance ciphertext after a confidential withdraw.
+ */
+export function subtractAmountFromCiphertext(ciphertext: ReadonlyUint8Array, amount: bigint) {
+    const { commitment, handle } = ciphertextToPoints(ciphertext);
+    return pointsToCiphertext(commitment.subtract(RistrettoPoint.BASE.multiply(amount)), handle);
+}

--- a/clients/js/src/confidentialTransferArithmetic.ts
+++ b/clients/js/src/confidentialTransferArithmetic.ts
@@ -75,6 +75,20 @@ function combineLoHiCiphertexts(ciphertextLo: ReadonlyUint8Array, ciphertextHi: 
  * result from `left`. Used to compute the new available-balance ciphertext
  * after a confidential transfer.
  */
+export function addWithLoHiCiphertexts(
+    left: ReadonlyUint8Array,
+    ciphertextLo: ReadonlyUint8Array,
+    ciphertextHi: ReadonlyUint8Array,
+    bitLength: bigint,
+) {
+    const leftPoints = ciphertextToPoints(left);
+    const rightPoints = ciphertextToPoints(combineLoHiCiphertexts(ciphertextLo, ciphertextHi, bitLength));
+    return pointsToCiphertext(
+        leftPoints.commitment.add(rightPoints.commitment),
+        leftPoints.handle.add(rightPoints.handle),
+    );
+}
+
 export function subtractWithLoHiCiphertexts(
     left: ReadonlyUint8Array,
     ciphertextLo: ReadonlyUint8Array,

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -35,6 +35,22 @@ import {
     getReallocateInstruction,
 } from './generated';
 import {
+    AeCiphertext,
+    AeKey,
+    BatchedGroupedCiphertext3HandlesValidityProofData,
+    BatchedRangeProofU128Data,
+    BatchedRangeProofU64Data,
+    CiphertextCommitmentEqualityProofData,
+    ElGamalCiphertext,
+    ElGamalKeypair,
+    ElGamalPubkey,
+    ElGamalSecretKey,
+    GroupedElGamalCiphertext3Handles,
+    PedersenCommitment,
+    PedersenOpening,
+    PubkeyValidityProofData,
+} from '@solana/zk-sdk/bundler';
+import {
     extractCiphertextFromGroupedBytes,
     subtractAmountFromCiphertext,
     subtractWithLoHiCiphertexts,
@@ -46,11 +62,6 @@ const TRANSFER_AMOUNT_LO_BIT_LENGTH = 16n;
 const TRANSFER_AMOUNT_HI_BIT_LENGTH = 32n;
 const REMAINING_BALANCE_BIT_LENGTH = 64;
 const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
-
-import type * as ZkSdk from '@solana/zk-sdk/node';
-
-/** The runtime shape of `@solana/zk-sdk/node` — pass it as the `zk` parameter to every helper. */
-export type ConfidentialTransferZkClient = typeof ZkSdk;
 
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 
@@ -67,9 +78,8 @@ export type GetCreateConfidentialTransferAccountInstructionPlanInput = {
     token?: Address;
     authority?: Address | TransactionSigner;
     rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
-    zk: ConfidentialTransferZkClient;
-    elgamalKeypair: ZkSdk.ElGamalKeypair;
-    aesKey: ZkSdk.AeKey;
+    elgamalKeypair: ElGamalKeypair;
+    aesKey: AeKey;
     maximumPendingBalanceCreditCounter?: number | bigint;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
@@ -79,9 +89,8 @@ export type GetApplyConfidentialPendingBalanceInstructionFromTokenInput = {
     token: Address;
     tokenAccount: Token;
     authority: Address | TransactionSigner;
-    zk: ConfidentialTransferZkClient;
-    elgamalSecretKey: ZkSdk.ElGamalSecretKey;
-    aesKey: ZkSdk.AeKey;
+    elgamalSecretKey: ElGamalSecretKey;
+    aesKey: AeKey;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
 };
@@ -93,9 +102,8 @@ type GetConfidentialWithdrawInstructionPlanBaseInput = {
     authority: Address | TransactionSigner;
     amount: number | bigint;
     decimals: number;
-    zk: ConfidentialTransferZkClient;
-    elgamalKeypair: ZkSdk.ElGamalKeypair;
-    aesKey: ZkSdk.AeKey;
+    elgamalKeypair: ElGamalKeypair;
+    aesKey: AeKey;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
 };
@@ -111,9 +119,8 @@ type GetConfidentialTransferInstructionPlanBaseInput = {
     auditorElgamalPubkey?: Address;
     authority: Address | TransactionSigner;
     amount: number | bigint;
-    zk: ConfidentialTransferZkClient;
-    sourceElgamalKeypair: ZkSdk.ElGamalKeypair;
-    aesKey: ZkSdk.AeKey;
+    sourceElgamalKeypair: ElGamalKeypair;
+    aesKey: AeKey;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
 } & (
@@ -151,40 +158,39 @@ function getRequiredConfidentialTransferAccountExtension(tokenAccount: Token): C
     return extension;
 }
 
-function parseAeCiphertext(zk: ConfidentialTransferZkClient, bytes: ReadonlyUint8Array) {
-    const ciphertext = zk.AeCiphertext.fromBytes(new Uint8Array(bytes));
+function parseAeCiphertext(bytes: ReadonlyUint8Array) {
+    const ciphertext = AeCiphertext.fromBytes(new Uint8Array(bytes));
     if (!ciphertext) {
         throw new Error('Failed to deserialize an authenticated-encryption ciphertext.');
     }
     return ciphertext;
 }
 
-function parseElGamalCiphertext(zk: ConfidentialTransferZkClient, bytes: ReadonlyUint8Array) {
-    const ciphertext = zk.ElGamalCiphertext.fromBytes(new Uint8Array(bytes));
+function parseElGamalCiphertext(bytes: ReadonlyUint8Array) {
+    const ciphertext = ElGamalCiphertext.fromBytes(new Uint8Array(bytes));
     if (!ciphertext) {
         throw new Error('Failed to deserialize an ElGamal ciphertext.');
     }
     return ciphertext;
 }
 
-function getElGamalPubkeyFromAddress(zk: ConfidentialTransferZkClient, value: Address) {
-    return zk.ElGamalPubkey.fromBytes(getAddressEncoder().encode(value) as Uint8Array);
+function getElGamalPubkeyFromAddress(value: Address) {
+    return ElGamalPubkey.fromBytes(getAddressEncoder().encode(value) as Uint8Array);
 }
 
-function getDefaultAuditorElGamalPubkey(zk: ConfidentialTransferZkClient) {
-    return zk.ElGamalPubkey.fromBytes(new Uint8Array(32));
+function getDefaultAuditorElGamalPubkey() {
+    return ElGamalPubkey.fromBytes(new Uint8Array(32));
 }
 
 function getDestinationElGamalPubkey(input: GetConfidentialTransferInstructionPlanInput) {
     if (input.destinationElgamalPubkey) {
-        return getElGamalPubkeyFromAddress(input.zk, input.destinationElgamalPubkey);
+        return getElGamalPubkeyFromAddress(input.destinationElgamalPubkey);
     }
     if (!input.destinationTokenAccount) {
         throw new Error('Destination confidential transfer state is required.');
     }
 
     return getElGamalPubkeyFromAddress(
-        input.zk,
         getRequiredConfidentialTransferAccountExtension(input.destinationTokenAccount).elgamalPubkey,
     );
 }
@@ -198,12 +204,8 @@ function combineBalances(balanceLo: bigint, balanceHi: bigint) {
     return (balanceHi << PENDING_BALANCE_LO_BIT_LENGTH) + balanceLo;
 }
 
-function decryptAvailableBalance(
-    zk: ConfidentialTransferZkClient,
-    account: ConfidentialTransferAccountExtension,
-    aesKey: ZkSdk.AeKey,
-) {
-    return aesKey.decrypt(parseAeCiphertext(zk, account.decryptableAvailableBalance));
+function decryptAvailableBalance(account: ConfidentialTransferAccountExtension, aesKey: AeKey) {
+    return aesKey.decrypt(parseAeCiphertext(account.decryptableAvailableBalance));
 }
 
 function assertInstructionDataProofModeIsUnsupported(input: { proofMode?: string }) {
@@ -305,7 +307,7 @@ export async function getCreateConfidentialTransferAccountInstructionPlan(
             })
         )[0];
 
-    const pubkeyValidityProofData = new input.zk.PubkeyValidityProofData(input.elgamalKeypair);
+    const pubkeyValidityProofData = new PubkeyValidityProofData(input.elgamalKeypair);
     const [verifyProofInstruction] = await verifyPubkeyValidity({
         rpc: input.rpc,
         payer: input.payer,
@@ -356,17 +358,10 @@ export function getApplyConfidentialPendingBalanceInstructionFromToken(
     input: GetApplyConfidentialPendingBalanceInstructionFromTokenInput,
 ): Instruction {
     const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
-    const pendingBalanceLo = input.elgamalSecretKey.decrypt(
-        parseElGamalCiphertext(input.zk, account.pendingBalanceLow),
-    );
-    const pendingBalanceHi = input.elgamalSecretKey.decrypt(
-        parseElGamalCiphertext(input.zk, account.pendingBalanceHigh),
-    );
+    const pendingBalanceLo = input.elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceLow));
+    const pendingBalanceHi = input.elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceHigh));
     const newDecryptableAvailableBalance = input.aesKey
-        .encrypt(
-            decryptAvailableBalance(input.zk, account, input.aesKey) +
-                combineBalances(pendingBalanceLo, pendingBalanceHi),
-        )
+        .encrypt(decryptAvailableBalance(account, input.aesKey) + combineBalances(pendingBalanceLo, pendingBalanceHi))
         .toBytes();
 
     return getApplyConfidentialPendingBalanceInstruction(
@@ -393,26 +388,22 @@ export async function getConfidentialWithdrawInstructionPlan(
     const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
     const amount = BigInt(input.amount);
     assertNonNegativeAmount(amount);
-    const newAvailableBalance = computeNewAvailableBalance(
-        decryptAvailableBalance(input.zk, account, input.aesKey),
-        amount,
-    );
+    const newAvailableBalance = computeNewAvailableBalance(decryptAvailableBalance(account, input.aesKey), amount);
 
-    const remainingBalanceOpening = new input.zk.PedersenOpening();
-    const remainingBalanceCommitment = input.zk.PedersenCommitment.from(newAvailableBalance, remainingBalanceOpening);
+    const remainingBalanceOpening = new PedersenOpening();
+    const remainingBalanceCommitment = PedersenCommitment.from(newAvailableBalance, remainingBalanceOpening);
     const remainingBalanceCiphertext = parseElGamalCiphertext(
-        input.zk,
         subtractAmountFromCiphertext(account.availableBalance, amount),
     );
 
-    const equalityProofData = new input.zk.CiphertextCommitmentEqualityProofData(
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
         input.elgamalKeypair,
         remainingBalanceCiphertext,
         remainingBalanceCommitment,
         remainingBalanceOpening,
         newAvailableBalance,
     );
-    const rangeProofData = new input.zk.BatchedRangeProofU64Data(
+    const rangeProofData = new BatchedRangeProofU64Data(
         [remainingBalanceCommitment],
         new BigUint64Array([newAvailableBalance]),
         Uint8Array.from([REMAINING_BALANCE_BIT_LENGTH]),
@@ -469,19 +460,19 @@ export async function getConfidentialTransferInstructionPlan(
     const sourcePubkey = input.sourceElgamalKeypair.pubkey();
     const destinationPubkey = getDestinationElGamalPubkey(input);
     const auditorPubkey = input.auditorElgamalPubkey
-        ? getElGamalPubkeyFromAddress(input.zk, input.auditorElgamalPubkey)
-        : getDefaultAuditorElGamalPubkey(input.zk);
+        ? getElGamalPubkeyFromAddress(input.auditorElgamalPubkey)
+        : getDefaultAuditorElGamalPubkey();
 
-    const openingLo = new input.zk.PedersenOpening();
-    const openingHi = new input.zk.PedersenOpening();
-    const groupedCiphertextLo = input.zk.GroupedElGamalCiphertext3Handles.encryptWith(
+    const openingLo = new PedersenOpening();
+    const openingHi = new PedersenOpening();
+    const groupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptWith(
         sourcePubkey,
         destinationPubkey,
         auditorPubkey,
         transferAmountLo,
         openingLo,
     );
-    const groupedCiphertextHi = input.zk.GroupedElGamalCiphertext3Handles.encryptWith(
+    const groupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptWith(
         sourcePubkey,
         destinationPubkey,
         auditorPubkey,
@@ -497,16 +488,12 @@ export async function getConfidentialTransferInstructionPlan(
     const transferAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 2);
 
     const newAvailableBalance = computeNewAvailableBalance(
-        decryptAvailableBalance(input.zk, sourceAccount, input.aesKey),
+        decryptAvailableBalance(sourceAccount, input.aesKey),
         amount,
     );
-    const newAvailableBalanceOpening = new input.zk.PedersenOpening();
-    const newAvailableBalanceCommitment = input.zk.PedersenCommitment.from(
-        newAvailableBalance,
-        newAvailableBalanceOpening,
-    );
+    const newAvailableBalanceOpening = new PedersenOpening();
+    const newAvailableBalanceCommitment = PedersenCommitment.from(newAvailableBalance, newAvailableBalanceOpening);
     const newAvailableBalanceCiphertext = parseElGamalCiphertext(
-        input.zk,
         subtractWithLoHiCiphertexts(
             sourceAccount.availableBalance,
             transferAmountSourceCiphertextLo,
@@ -515,14 +502,14 @@ export async function getConfidentialTransferInstructionPlan(
         ),
     );
 
-    const equalityProofData = new input.zk.CiphertextCommitmentEqualityProofData(
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
         input.sourceElgamalKeypair,
         newAvailableBalanceCiphertext,
         newAvailableBalanceCommitment,
         newAvailableBalanceOpening,
         newAvailableBalance,
     );
-    const ciphertextValidityProofData = new input.zk.BatchedGroupedCiphertext3HandlesValidityProofData(
+    const ciphertextValidityProofData = new BatchedGroupedCiphertext3HandlesValidityProofData(
         sourcePubkey,
         destinationPubkey,
         auditorPubkey,
@@ -534,11 +521,11 @@ export async function getConfidentialTransferInstructionPlan(
         openingHi,
     );
 
-    const commitmentLo = input.zk.PedersenCommitment.fromBytes(groupedCiphertextLoBytes.slice(0, 32));
-    const commitmentHi = input.zk.PedersenCommitment.fromBytes(groupedCiphertextHiBytes.slice(0, 32));
-    const paddingOpening = new input.zk.PedersenOpening();
-    const paddingCommitment = input.zk.PedersenCommitment.from(0n, paddingOpening);
-    const rangeProofData = new input.zk.BatchedRangeProofU128Data(
+    const commitmentLo = PedersenCommitment.fromBytes(groupedCiphertextLoBytes.slice(0, 32));
+    const commitmentHi = PedersenCommitment.fromBytes(groupedCiphertextHiBytes.slice(0, 32));
+    const paddingOpening = new PedersenOpening();
+    const paddingCommitment = PedersenCommitment.from(0n, paddingOpening);
+    const rangeProofData = new BatchedRangeProofU128Data(
         [newAvailableBalanceCommitment, commitmentLo, commitmentHi, paddingCommitment],
         new BigUint64Array([newAvailableBalance, transferAmountLo, transferAmountHi, 0n]),
         Uint8Array.from([

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -208,8 +208,8 @@ function splitAmount(amount: bigint, bitLength: bigint): [bigint, bigint] {
     return [amount & mask, amount >> bitLength];
 }
 
-function combineBalances(balanceLo: bigint, balanceHi: bigint) {
-    return (balanceHi << PENDING_BALANCE_LO_BIT_LENGTH) + balanceLo;
+function combineAmounts(amountLo: bigint, amountHi: bigint, bitLength: bigint): bigint {
+    return (amountHi << bitLength) + amountLo;
 }
 
 function decryptAvailableBalance(account: ConfidentialTransferAccountExtension, aesKey: AeKey) {
@@ -361,7 +361,10 @@ export function getApplyConfidentialPendingBalanceInstructionFromToken(
     const pendingBalanceLo = input.elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceLow));
     const pendingBalanceHi = input.elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceHigh));
     const newDecryptableAvailableBalance = input.aesKey
-        .encrypt(decryptAvailableBalance(account, input.aesKey) + combineBalances(pendingBalanceLo, pendingBalanceHi))
+        .encrypt(
+            decryptAvailableBalance(account, input.aesKey) +
+                combineAmounts(pendingBalanceLo, pendingBalanceHi, PENDING_BALANCE_LO_BIT_LENGTH),
+        )
         .toBytes();
 
     return getApplyConfidentialPendingBalanceInstruction(

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -1,0 +1,596 @@
+import {
+    closeContextStateProof,
+    verifyBatchedGroupedCiphertext3HandlesValidity,
+    verifyBatchedRangeProofU128,
+    verifyBatchedRangeProofU64,
+    verifyCiphertextCommitmentEquality,
+    verifyPubkeyValidity,
+} from '@solana-program/zk-elgamal-proof';
+import {
+    Address,
+    Instruction,
+    TransactionSigner,
+    generateKeyPairSigner,
+    getAddressEncoder,
+    isSome,
+    nonDivisibleSequentialInstructionPlan,
+    parallelInstructionPlan,
+    sequentialInstructionPlan,
+    type GetMinimumBalanceForRentExemptionApi,
+    type InstructionPlan,
+    type ReadonlyUint8Array,
+    type Rpc,
+} from '@solana/kit';
+import {
+    ExtensionType,
+    Extension,
+    TOKEN_2022_PROGRAM_ADDRESS,
+    Token,
+    findAssociatedTokenPda,
+    getApplyConfidentialPendingBalanceInstruction,
+    getConfidentialTransferInstruction,
+    getConfidentialWithdrawInstruction,
+    getConfigureConfidentialTransferAccountInstruction,
+    getCreateAssociatedTokenIdempotentInstruction,
+    getReallocateInstruction,
+} from './generated';
+import {
+    extractCiphertextFromGroupedBytes,
+    subtractAmountFromCiphertext,
+    subtractWithLoHiCiphertexts,
+} from './confidentialTransferArithmetic';
+
+const DEFAULT_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER = 1n << 16n;
+const PENDING_BALANCE_LO_BIT_LENGTH = 16n;
+const TRANSFER_AMOUNT_LO_BIT_LENGTH = 16n;
+const TRANSFER_AMOUNT_HI_BIT_LENGTH = 32n;
+const REMAINING_BALANCE_BIT_LENGTH = 64;
+const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
+
+import type * as ZkSdk from '@solana/zk-sdk/node';
+
+/** The runtime shape of `@solana/zk-sdk/node` — pass it as the `zk` parameter to every helper. */
+export type ConfidentialTransferZkClient = typeof ZkSdk;
+
+type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
+
+type ContextStateProofMode = {
+    proofMode?: 'context-state';
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+};
+
+export type GetCreateConfidentialTransferAccountInstructionPlanInput = {
+    payer: TransactionSigner;
+    owner: Address | TransactionSigner;
+    mint: Address;
+    token?: Address;
+    authority?: Address | TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+    zk: ConfidentialTransferZkClient;
+    elgamalKeypair: ZkSdk.ElGamalKeypair;
+    aesKey: ZkSdk.AeKey;
+    maximumPendingBalanceCreditCounter?: number | bigint;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+export type GetApplyConfidentialPendingBalanceInstructionFromTokenInput = {
+    token: Address;
+    tokenAccount: Token;
+    authority: Address | TransactionSigner;
+    zk: ConfidentialTransferZkClient;
+    elgamalSecretKey: ZkSdk.ElGamalSecretKey;
+    aesKey: ZkSdk.AeKey;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+type GetConfidentialWithdrawInstructionPlanBaseInput = {
+    token: Address;
+    mint: Address;
+    tokenAccount: Token;
+    authority: Address | TransactionSigner;
+    amount: number | bigint;
+    decimals: number;
+    zk: ConfidentialTransferZkClient;
+    elgamalKeypair: ZkSdk.ElGamalKeypair;
+    aesKey: ZkSdk.AeKey;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+export type GetConfidentialWithdrawInstructionPlanInput = GetConfidentialWithdrawInstructionPlanBaseInput &
+    ContextStateProofMode;
+
+type GetConfidentialTransferInstructionPlanBaseInput = {
+    sourceToken: Address;
+    mint: Address;
+    destinationToken: Address;
+    sourceTokenAccount: Token;
+    auditorElgamalPubkey?: Address;
+    authority: Address | TransactionSigner;
+    amount: number | bigint;
+    zk: ConfidentialTransferZkClient;
+    sourceElgamalKeypair: ZkSdk.ElGamalKeypair;
+    aesKey: ZkSdk.AeKey;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+} & (
+    | { destinationTokenAccount: Token; destinationElgamalPubkey?: Address }
+    | { destinationElgamalPubkey: Address; destinationTokenAccount?: never }
+);
+
+export type GetConfidentialTransferInstructionPlanInput = GetConfidentialTransferInstructionPlanBaseInput &
+    ContextStateProofMode;
+
+function getTokenProgramAddress(programAddress?: Address) {
+    return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
+}
+
+function addressOf(value: Address | TransactionSigner): Address {
+    return isSigner(value) ? value.address : value;
+}
+
+function isSigner(value: Address | TransactionSigner): value is TransactionSigner {
+    return typeof value !== 'string';
+}
+
+function getRequiredConfidentialTransferAccountExtension(tokenAccount: Token): ConfidentialTransferAccountExtension {
+    if (!isSome(tokenAccount.extensions)) {
+        throw new Error('Token account is missing extensions.');
+    }
+
+    const extension = tokenAccount.extensions.value.find(
+        candidate => candidate.__kind === 'ConfidentialTransferAccount',
+    ) as ConfidentialTransferAccountExtension | undefined;
+    if (!extension) {
+        throw new Error('Token account is missing the ConfidentialTransferAccount extension.');
+    }
+
+    return extension;
+}
+
+function parseAeCiphertext(zk: ConfidentialTransferZkClient, bytes: ReadonlyUint8Array) {
+    const ciphertext = zk.AeCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to deserialize an authenticated-encryption ciphertext.');
+    }
+    return ciphertext;
+}
+
+function parseElGamalCiphertext(zk: ConfidentialTransferZkClient, bytes: ReadonlyUint8Array) {
+    const ciphertext = zk.ElGamalCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to deserialize an ElGamal ciphertext.');
+    }
+    return ciphertext;
+}
+
+function getElGamalPubkeyFromAddress(zk: ConfidentialTransferZkClient, value: Address) {
+    return zk.ElGamalPubkey.fromBytes(getAddressEncoder().encode(value) as Uint8Array);
+}
+
+function getDefaultAuditorElGamalPubkey(zk: ConfidentialTransferZkClient) {
+    return zk.ElGamalPubkey.fromBytes(new Uint8Array(32));
+}
+
+function getDestinationElGamalPubkey(input: GetConfidentialTransferInstructionPlanInput) {
+    if (input.destinationElgamalPubkey) {
+        return getElGamalPubkeyFromAddress(input.zk, input.destinationElgamalPubkey);
+    }
+    if (!input.destinationTokenAccount) {
+        throw new Error('Destination confidential transfer state is required.');
+    }
+
+    return getElGamalPubkeyFromAddress(
+        input.zk,
+        getRequiredConfidentialTransferAccountExtension(input.destinationTokenAccount).elgamalPubkey,
+    );
+}
+
+function splitAmount(amount: bigint, bitLength: bigint): [bigint, bigint] {
+    const mask = (1n << bitLength) - 1n;
+    return [amount & mask, amount >> bitLength];
+}
+
+function combineBalances(balanceLo: bigint, balanceHi: bigint) {
+    return (balanceHi << PENDING_BALANCE_LO_BIT_LENGTH) + balanceLo;
+}
+
+function decryptAvailableBalance(
+    zk: ConfidentialTransferZkClient,
+    account: ConfidentialTransferAccountExtension,
+    aesKey: ZkSdk.AeKey,
+) {
+    return aesKey.decrypt(parseAeCiphertext(zk, account.decryptableAvailableBalance));
+}
+
+function assertInstructionDataProofModeIsUnsupported(input: { proofMode?: string }) {
+    if (input.proofMode === 'instruction-data') {
+        throw new Error(
+            'instruction-data proof mode is unsupported for confidential withdraw/transfer helpers in clients/js; use the default context-state flow.',
+        );
+    }
+}
+
+function assertCreateHelperOwnerMatchesAuthority(
+    owner: Address | TransactionSigner,
+    authority: Address | TransactionSigner,
+) {
+    if (addressOf(owner) !== addressOf(authority)) {
+        throw new Error(
+            'This helper is scoped to the token-account owner. For the ATA convenience flow, authority must match owner.',
+        );
+    }
+}
+
+/**
+ * Builds the setup-and-cleanup instruction plans for a single proof's
+ * context-state account. The setup plan creates the context-state account
+ * and verifies the proof into it (these two instructions must share a
+ * transaction). The cleanup plan closes the context-state account to recover
+ * its rent.
+ */
+function assertNonNegativeAmount(amount: bigint): void {
+    if (amount < 0n) {
+        throw new Error('Amount must be non-negative.');
+    }
+}
+
+function computeNewAvailableBalance(currentBalance: bigint, amount: bigint): bigint {
+    assertNonNegativeAmount(amount);
+    const newBalance = currentBalance - amount;
+    if (newBalance < 0n) {
+        throw new Error('Insufficient funds.');
+    }
+    return newBalance;
+}
+
+async function buildContextStateProofPlan(
+    proofData: ReadonlyUint8Array,
+    verifyAction: (args: {
+        rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+        payer: TransactionSigner;
+        proofData: Uint8Array;
+        contextState: { contextAccount: Awaited<ReturnType<typeof generateKeyPairSigner>>; authority: Address };
+    }) => Promise<Instruction[]>,
+    payer: TransactionSigner,
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>,
+    contextStateAuthority: TransactionSigner = payer,
+): Promise<{ address: Address; setup: InstructionPlan; cleanup: Instruction }> {
+    const contextAccount = await generateKeyPairSigner();
+    const setupInstructions = await verifyAction({
+        rpc,
+        payer,
+        proofData: new Uint8Array(proofData),
+        contextState: { contextAccount, authority: contextStateAuthority.address },
+    });
+    return {
+        address: contextAccount.address,
+        // Divisible: the create-account and verify-proof instructions can fit
+        // in one transaction for small proofs (e.g. PubkeyValidity) but exceed
+        // the size limit for larger proofs (e.g. BatchedRangeProofU128). A
+        // transaction planner decides how to pack them; the verify only needs
+        // the account to exist, which is true once create-account is confirmed.
+        setup: sequentialInstructionPlan(setupInstructions),
+        cleanup: closeContextStateProof({
+            contextState: contextAccount.address,
+            authority: contextStateAuthority,
+            destination: payer.address,
+        }),
+    };
+}
+
+/**
+ * Returns a single-transaction plan that creates the ATA, reallocates it
+ * for the confidential-transfer extension, configures the account, and
+ * verifies the ZK pubkey-validity proof.
+ */
+export async function getCreateConfidentialTransferAccountInstructionPlan(
+    input: GetCreateConfidentialTransferAccountInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const programAddress = getTokenProgramAddress(input.programAddress);
+    const authority = input.authority ?? input.owner;
+    assertCreateHelperOwnerMatchesAuthority(input.owner, authority);
+
+    const ownerAddress = addressOf(input.owner);
+    const token =
+        input.token ??
+        (
+            await findAssociatedTokenPda({
+                owner: ownerAddress,
+                tokenProgram: programAddress,
+                mint: input.mint,
+            })
+        )[0];
+
+    const pubkeyValidityProofData = new input.zk.PubkeyValidityProofData(input.elgamalKeypair);
+    const [verifyProofInstruction] = await verifyPubkeyValidity({
+        rpc: input.rpc,
+        payer: input.payer,
+        proofData: new Uint8Array(pubkeyValidityProofData.toBytes()),
+    });
+
+    return nonDivisibleSequentialInstructionPlan([
+        getCreateAssociatedTokenIdempotentInstruction({
+            ata: token,
+            mint: input.mint,
+            owner: ownerAddress,
+            payer: input.payer,
+            tokenProgram: programAddress,
+        }),
+        getReallocateInstruction(
+            {
+                token,
+                payer: input.payer,
+                owner: authority,
+                newExtensionTypes: [ExtensionType.ConfidentialTransferAccount],
+                multiSigners: input.multiSigners,
+            },
+            { programAddress },
+        ),
+        getConfigureConfidentialTransferAccountInstruction(
+            {
+                token,
+                mint: input.mint,
+                authority,
+                decryptableZeroBalance: input.aesKey.encrypt(0n).toBytes(),
+                maximumPendingBalanceCreditCounter:
+                    input.maximumPendingBalanceCreditCounter ?? DEFAULT_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER,
+                proofInstructionOffset: 1,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress },
+        ),
+        verifyProofInstruction,
+    ]);
+}
+
+/**
+ * Builds an `ApplyPendingBalance` instruction plan from a decoded token
+ * account, decrypting the pending balance and re-encrypting the new
+ * available balance locally.
+ */
+export function getApplyConfidentialPendingBalanceInstructionFromToken(
+    input: GetApplyConfidentialPendingBalanceInstructionFromTokenInput,
+): Instruction {
+    const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
+    const pendingBalanceLo = input.elgamalSecretKey.decrypt(
+        parseElGamalCiphertext(input.zk, account.pendingBalanceLow),
+    );
+    const pendingBalanceHi = input.elgamalSecretKey.decrypt(
+        parseElGamalCiphertext(input.zk, account.pendingBalanceHigh),
+    );
+    const newDecryptableAvailableBalance = input.aesKey
+        .encrypt(
+            decryptAvailableBalance(input.zk, account, input.aesKey) +
+                combineBalances(pendingBalanceLo, pendingBalanceHi),
+        )
+        .toBytes();
+
+    return getApplyConfidentialPendingBalanceInstruction(
+        {
+            token: input.token,
+            authority: input.authority,
+            expectedPendingBalanceCreditCounter: account.pendingBalanceCreditCounter,
+            newDecryptableAvailableBalance,
+            multiSigners: input.multiSigners,
+        },
+        { programAddress: getTokenProgramAddress(input.programAddress) },
+    );
+}
+
+/**
+ * Returns an instruction plan that moves tokens from the encrypted
+ * available balance back to the plaintext balance. Generates and verifies
+ * the equality and batched range proofs via context-state accounts.
+ */
+export async function getConfidentialWithdrawInstructionPlan(
+    input: GetConfidentialWithdrawInstructionPlanInput,
+): Promise<InstructionPlan> {
+    assertInstructionDataProofModeIsUnsupported(input as { proofMode?: string });
+    const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
+    const amount = BigInt(input.amount);
+    assertNonNegativeAmount(amount);
+    const newAvailableBalance = computeNewAvailableBalance(
+        decryptAvailableBalance(input.zk, account, input.aesKey),
+        amount,
+    );
+
+    const remainingBalanceOpening = new input.zk.PedersenOpening();
+    const remainingBalanceCommitment = input.zk.PedersenCommitment.from(newAvailableBalance, remainingBalanceOpening);
+    const remainingBalanceCiphertext = parseElGamalCiphertext(
+        input.zk,
+        subtractAmountFromCiphertext(account.availableBalance, amount),
+    );
+
+    const equalityProofData = new input.zk.CiphertextCommitmentEqualityProofData(
+        input.elgamalKeypair,
+        remainingBalanceCiphertext,
+        remainingBalanceCommitment,
+        remainingBalanceOpening,
+        newAvailableBalance,
+    );
+    const rangeProofData = new input.zk.BatchedRangeProofU64Data(
+        [remainingBalanceCommitment],
+        new BigUint64Array([newAvailableBalance]),
+        Uint8Array.from([REMAINING_BALANCE_BIT_LENGTH]),
+        [remainingBalanceOpening],
+    );
+
+    const [equalityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU64, input.payer, input.rpc),
+    ]);
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([equalityProofPlan.setup, rangeProofPlan.setup]),
+        getConfidentialWithdrawInstruction(
+            {
+                token: input.token,
+                mint: input.mint,
+                equalityRecord: equalityProofPlan.address,
+                rangeRecord: rangeProofPlan.address,
+                authority: input.authority,
+                amount,
+                decimals: input.decimals,
+                newDecryptableAvailableBalance: input.aesKey.encrypt(newAvailableBalance).toBytes(),
+                equalityProofInstructionOffset: 0,
+                rangeProofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: input.programAddress ?? TOKEN_2022_PROGRAM_ADDRESS },
+        ),
+        parallelInstructionPlan([equalityProofPlan.cleanup, rangeProofPlan.cleanup]),
+    ]);
+}
+
+/**
+ * Returns an instruction plan that confidentially transfers tokens between
+ * two accounts. Splits the amount into lo/hi halves and verifies the three
+ * required proofs (equality, grouped-ciphertext validity, batched range)
+ * via context-state accounts.
+ */
+export async function getConfidentialTransferInstructionPlan(
+    input: GetConfidentialTransferInstructionPlanInput,
+): Promise<InstructionPlan> {
+    assertInstructionDataProofModeIsUnsupported(input as { proofMode?: string });
+    const sourceAccount = getRequiredConfidentialTransferAccountExtension(input.sourceTokenAccount);
+    const amount = BigInt(input.amount);
+    assertNonNegativeAmount(amount);
+    const [transferAmountLo, transferAmountHi] = splitAmount(amount, TRANSFER_AMOUNT_LO_BIT_LENGTH);
+
+    const sourcePubkey = input.sourceElgamalKeypair.pubkey();
+    const destinationPubkey = getDestinationElGamalPubkey(input);
+    const auditorPubkey = input.auditorElgamalPubkey
+        ? getElGamalPubkeyFromAddress(input.zk, input.auditorElgamalPubkey)
+        : getDefaultAuditorElGamalPubkey(input.zk);
+
+    const openingLo = new input.zk.PedersenOpening();
+    const openingHi = new input.zk.PedersenOpening();
+    const groupedCiphertextLo = input.zk.GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        destinationPubkey,
+        auditorPubkey,
+        transferAmountLo,
+        openingLo,
+    );
+    const groupedCiphertextHi = input.zk.GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        destinationPubkey,
+        auditorPubkey,
+        transferAmountHi,
+        openingHi,
+    );
+
+    const groupedCiphertextLoBytes = groupedCiphertextLo.toBytes();
+    const groupedCiphertextHiBytes = groupedCiphertextHi.toBytes();
+    const transferAmountSourceCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 0);
+    const transferAmountSourceCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 0);
+    const transferAmountAuditorCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 2);
+    const transferAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 2);
+
+    const newAvailableBalance = computeNewAvailableBalance(
+        decryptAvailableBalance(input.zk, sourceAccount, input.aesKey),
+        amount,
+    );
+    const newAvailableBalanceOpening = new input.zk.PedersenOpening();
+    const newAvailableBalanceCommitment = input.zk.PedersenCommitment.from(
+        newAvailableBalance,
+        newAvailableBalanceOpening,
+    );
+    const newAvailableBalanceCiphertext = parseElGamalCiphertext(
+        input.zk,
+        subtractWithLoHiCiphertexts(
+            sourceAccount.availableBalance,
+            transferAmountSourceCiphertextLo,
+            transferAmountSourceCiphertextHi,
+            TRANSFER_AMOUNT_LO_BIT_LENGTH,
+        ),
+    );
+
+    const equalityProofData = new input.zk.CiphertextCommitmentEqualityProofData(
+        input.sourceElgamalKeypair,
+        newAvailableBalanceCiphertext,
+        newAvailableBalanceCommitment,
+        newAvailableBalanceOpening,
+        newAvailableBalance,
+    );
+    const ciphertextValidityProofData = new input.zk.BatchedGroupedCiphertext3HandlesValidityProofData(
+        sourcePubkey,
+        destinationPubkey,
+        auditorPubkey,
+        groupedCiphertextLo,
+        groupedCiphertextHi,
+        transferAmountLo,
+        transferAmountHi,
+        openingLo,
+        openingHi,
+    );
+
+    const commitmentLo = input.zk.PedersenCommitment.fromBytes(groupedCiphertextLoBytes.slice(0, 32));
+    const commitmentHi = input.zk.PedersenCommitment.fromBytes(groupedCiphertextHiBytes.slice(0, 32));
+    const paddingOpening = new input.zk.PedersenOpening();
+    const paddingCommitment = input.zk.PedersenCommitment.from(0n, paddingOpening);
+    const rangeProofData = new input.zk.BatchedRangeProofU128Data(
+        [newAvailableBalanceCommitment, commitmentLo, commitmentHi, paddingCommitment],
+        new BigUint64Array([newAvailableBalance, transferAmountLo, transferAmountHi, 0n]),
+        Uint8Array.from([
+            REMAINING_BALANCE_BIT_LENGTH,
+            Number(TRANSFER_AMOUNT_LO_BIT_LENGTH),
+            Number(TRANSFER_AMOUNT_HI_BIT_LENGTH),
+            RANGE_PROOF_PADDING_BIT_LENGTH,
+        ]),
+        [newAvailableBalanceOpening, openingLo, openingHi, paddingOpening],
+    );
+
+    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            ciphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU128, input.payer, input.rpc),
+    ]);
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([equalityProofPlan.setup, ciphertextValidityProofPlan.setup, rangeProofPlan.setup]),
+        getConfidentialTransferInstruction(
+            {
+                sourceToken: input.sourceToken,
+                mint: input.mint,
+                destinationToken: input.destinationToken,
+                equalityRecord: equalityProofPlan.address,
+                ciphertextValidityRecord: ciphertextValidityProofPlan.address,
+                rangeRecord: rangeProofPlan.address,
+                authority: input.authority,
+                newSourceDecryptableAvailableBalance: input.aesKey.encrypt(newAvailableBalance).toBytes(),
+                transferAmountAuditorCiphertextLo,
+                transferAmountAuditorCiphertextHi,
+                equalityProofInstructionOffset: 0,
+                ciphertextValidityProofInstructionOffset: 0,
+                rangeProofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: input.programAddress ?? TOKEN_2022_PROGRAM_ADDRESS },
+        ),
+        parallelInstructionPlan([
+            equalityProofPlan.cleanup,
+            ciphertextValidityProofPlan.cleanup,
+            rangeProofPlan.cleanup,
+        ]),
+    ]);
+}

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -66,6 +66,14 @@ const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 
 type ContextStateProofMode = {
+    /**
+     * The strategy used to provide zero-knowledge proofs to the program.
+     *
+     * Currently, only `context-state` is supported, where each proof is verified
+     * into a dedicated context-state account before the instruction is executed.
+     * Additional modes — such as `instruction-data`, where proofs are provided
+     * inline within the same transaction — may be supported in the future.
+     */
     proofMode?: 'context-state';
     payer: TransactionSigner;
     rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
@@ -206,14 +214,6 @@ function combineBalances(balanceLo: bigint, balanceHi: bigint) {
 
 function decryptAvailableBalance(account: ConfidentialTransferAccountExtension, aesKey: AeKey) {
     return aesKey.decrypt(parseAeCiphertext(account.decryptableAvailableBalance));
-}
-
-function assertInstructionDataProofModeIsUnsupported(input: { proofMode?: string }) {
-    if (input.proofMode === 'instruction-data') {
-        throw new Error(
-            'instruction-data proof mode is unsupported for confidential withdraw/transfer helpers in clients/js; use the default context-state flow.',
-        );
-    }
 }
 
 function assertCreateHelperOwnerMatchesAuthority(
@@ -384,7 +384,6 @@ export function getApplyConfidentialPendingBalanceInstructionFromToken(
 export async function getConfidentialWithdrawInstructionPlan(
     input: GetConfidentialWithdrawInstructionPlanInput,
 ): Promise<InstructionPlan> {
-    assertInstructionDataProofModeIsUnsupported(input as { proofMode?: string });
     const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
     const amount = BigInt(input.amount);
     assertNonNegativeAmount(amount);
@@ -451,7 +450,6 @@ export async function getConfidentialWithdrawInstructionPlan(
 export async function getConfidentialTransferInstructionPlan(
     input: GetConfidentialTransferInstructionPlanInput,
 ): Promise<InstructionPlan> {
-    assertInstructionDataProofModeIsUnsupported(input as { proofMode?: string });
     const sourceAccount = getRequiredConfidentialTransferAccountExtension(input.sourceTokenAccount);
     const amount = BigInt(input.amount);
     assertNonNegativeAmount(amount);

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -1,0 +1,108 @@
+import {
+    createSignableMessage,
+    getAddressDecoder,
+    getAddressEncoder,
+    getTupleEncoder,
+    type Address,
+    type MessagePartialSigner,
+    type ReadonlyUint8Array,
+} from '@solana/kit';
+import type { ConfidentialTransferZkClient } from './confidentialTransferHelpers';
+
+export type DerivedElGamalKeypair = Readonly<{
+    elgamalPubkey: Address;
+    secretKey: Uint8Array;
+}>;
+
+async function signDerivationMessage(signer: MessagePartialSigner, message: Uint8Array): Promise<Uint8Array> {
+    const [signatures] = await signer.signMessages([createSignableMessage(message)]);
+    const signature = signatures?.[signer.address];
+    if (signature == null) {
+        throw new Error(`Signer ${signer.address} did not return a signature`);
+    }
+    return new Uint8Array(signature);
+}
+
+function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
+    return getTupleEncoder([getAddressEncoder(), getAddressEncoder()]).encode([owner, mint]);
+}
+
+/**
+ * Derives an ElGamal keypair by having the signer sign a domain-separated
+ * message and feeding the resulting Ed25519 signature into the WASM ZK SDK.
+ */
+export async function deriveElGamalKeypair({
+    signer,
+    zk,
+    publicSeed = new Uint8Array(0),
+}: {
+    signer: MessagePartialSigner;
+    zk: ConfidentialTransferZkClient;
+    publicSeed?: ReadonlyUint8Array;
+}): Promise<DerivedElGamalKeypair> {
+    const message = zk.ElGamalKeypair.signerMessage(new Uint8Array(publicSeed));
+    const signature = await signDerivationMessage(signer, message);
+    const keypair = zk.ElGamalKeypair.fromSignature(signature);
+    const secretKey = new Uint8Array(keypair.secret().toBytes());
+    const elgamalPubkey = getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
+    return { elgamalPubkey, secretKey };
+}
+
+/**
+ * Derives an ElGamal keypair bound to an `(owner, mint)` pair. The seed
+ * is `concat(ownerBytes, mintBytes)`, which is stable across token-account
+ * close-and-reopen and prevents key reuse across mints.
+ */
+export async function deriveElGamalKeypairForOwnerMint({
+    signer,
+    zk,
+    owner,
+    mint,
+}: {
+    signer: MessagePartialSigner;
+    zk: ConfidentialTransferZkClient;
+    owner: Address;
+    mint: Address;
+}): Promise<DerivedElGamalKeypair> {
+    return await deriveElGamalKeypair({ signer, zk, publicSeed: ownerMintSeed(owner, mint) });
+}
+
+/**
+ * Derives an AES-128 authenticated-encryption key by having the signer
+ * sign a domain-separated message and feeding the signature into the
+ * WASM ZK SDK.
+ */
+export async function deriveAeKey({
+    signer,
+    zk,
+    publicSeed = new Uint8Array(0),
+}: {
+    signer: MessagePartialSigner;
+    zk: ConfidentialTransferZkClient;
+    publicSeed?: ReadonlyUint8Array;
+}): Promise<Uint8Array> {
+    const message = zk.AeKey.signerMessage(new Uint8Array(publicSeed));
+    const signature = await signDerivationMessage(signer, message);
+    const aeKey = zk.AeKey.fromSignature(signature);
+    return new Uint8Array(aeKey.toBytes());
+}
+
+/**
+ * Derives an AES key scoped to an `(owner, mint)` pair.
+ *
+ * See `deriveElGamalKeypairForOwnerMint` for why this is the right binding
+ * for confidential token accounts.
+ */
+export async function deriveAeKeyForOwnerMint({
+    signer,
+    zk,
+    owner,
+    mint,
+}: {
+    signer: MessagePartialSigner;
+    zk: ConfidentialTransferZkClient;
+    owner: Address;
+    mint: Address;
+}): Promise<Uint8Array> {
+    return await deriveAeKey({ signer, zk, publicSeed: ownerMintSeed(owner, mint) });
+}

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -7,7 +7,7 @@ import {
     type MessagePartialSigner,
     type ReadonlyUint8Array,
 } from '@solana/kit';
-import type { ConfidentialTransferZkClient } from './confidentialTransferHelpers';
+import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
 
 export type DerivedElGamalKeypair = Readonly<{
     elgamalPubkey: Address;
@@ -33,16 +33,14 @@ function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
  */
 export async function deriveElGamalKeypair({
     signer,
-    zk,
     publicSeed = new Uint8Array(0),
 }: {
     signer: MessagePartialSigner;
-    zk: ConfidentialTransferZkClient;
     publicSeed?: ReadonlyUint8Array;
 }): Promise<DerivedElGamalKeypair> {
-    const message = zk.ElGamalKeypair.signerMessage(new Uint8Array(publicSeed));
+    const message = ElGamalKeypair.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
-    const keypair = zk.ElGamalKeypair.fromSignature(signature);
+    const keypair = ElGamalKeypair.fromSignature(signature);
     const secretKey = new Uint8Array(keypair.secret().toBytes());
     const elgamalPubkey = getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
     return { elgamalPubkey, secretKey };
@@ -55,16 +53,14 @@ export async function deriveElGamalKeypair({
  */
 export async function deriveElGamalKeypairForOwnerMint({
     signer,
-    zk,
     owner,
     mint,
 }: {
     signer: MessagePartialSigner;
-    zk: ConfidentialTransferZkClient;
     owner: Address;
     mint: Address;
 }): Promise<DerivedElGamalKeypair> {
-    return await deriveElGamalKeypair({ signer, zk, publicSeed: ownerMintSeed(owner, mint) });
+    return await deriveElGamalKeypair({ signer, publicSeed: ownerMintSeed(owner, mint) });
 }
 
 /**
@@ -74,16 +70,14 @@ export async function deriveElGamalKeypairForOwnerMint({
  */
 export async function deriveAeKey({
     signer,
-    zk,
     publicSeed = new Uint8Array(0),
 }: {
     signer: MessagePartialSigner;
-    zk: ConfidentialTransferZkClient;
     publicSeed?: ReadonlyUint8Array;
 }): Promise<Uint8Array> {
-    const message = zk.AeKey.signerMessage(new Uint8Array(publicSeed));
+    const message = AeKey.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
-    const aeKey = zk.AeKey.fromSignature(signature);
+    const aeKey = AeKey.fromSignature(signature);
     return new Uint8Array(aeKey.toBytes());
 }
 
@@ -95,14 +89,12 @@ export async function deriveAeKey({
  */
 export async function deriveAeKeyForOwnerMint({
     signer,
-    zk,
     owner,
     mint,
 }: {
     signer: MessagePartialSigner;
-    zk: ConfidentialTransferZkClient;
     owner: Address;
     mint: Address;
 }): Promise<Uint8Array> {
-    return await deriveAeKey({ signer, zk, publicSeed: ownerMintSeed(owner, mint) });
+    return await deriveAeKey({ signer, publicSeed: ownerMintSeed(owner, mint) });
 }

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -4,6 +4,7 @@ export * from './generated';
 export { type BatchInstruction, getBatchInstruction, parseBatchInstruction } from './batch';
 
 export * from './amountToUiAmount';
+export * from './confidentialMintBurnHelpers';
 export * from './confidentialTransferHelpers';
 export * from './confidentialTransferKeys';
 export * from './getInitializeInstructionsForExtensions';

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -4,6 +4,8 @@ export * from './generated';
 export { type BatchInstruction, getBatchInstruction, parseBatchInstruction } from './batch';
 
 export * from './amountToUiAmount';
+export * from './confidentialTransferHelpers';
+export * from './confidentialTransferKeys';
 export * from './getInitializeInstructionsForExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -4,6 +4,7 @@ import {
     TransactionMessage,
     Commitment,
     Instruction,
+    InstructionPlan,
     Rpc,
     RpcSubscriptions,
     SolanaRpcApi,
@@ -18,19 +19,32 @@ import {
     createSolanaRpc,
     createSolanaRpcSubscriptions,
     createTransactionMessage,
+    createTransactionPlanExecutor,
+    createTransactionPlanner,
     generateKeyPairSigner,
     getSignatureFromTransaction,
+    isSome,
     lamports,
+    none,
     pipe,
     sendAndConfirmTransactionFactory,
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
     signTransactionMessageWithSigners,
+    some,
 } from '@solana/kit';
+import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import {
     Extension,
     ExtensionArgs,
     TOKEN_2022_PROGRAM_ADDRESS,
+    Token,
+    extension,
+    fetchToken,
+    findAssociatedTokenPda,
+    getApplyConfidentialPendingBalanceInstructionFromToken,
+    getConfidentialDepositInstruction,
+    getCreateConfidentialTransferAccountInstructionPlan,
     getInitializeAccountInstruction,
     getInitializeMintInstruction,
     getMintSize,
@@ -41,7 +55,7 @@ import {
     getTokenSize,
 } from '../src';
 
-type Client = {
+export type Client = {
     rpc: Rpc<SolanaRpcApi>;
     rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 };
@@ -95,6 +109,32 @@ export const sendAndConfirmInstructions = async (
         tx => signAndSendTransaction(client, tx),
     );
     return signature;
+};
+
+export const sendAndConfirmInstructionPlan = async (
+    client: Client,
+    payer: TransactionSigner,
+    instructionPlan: InstructionPlan,
+) => {
+    const planner = createTransactionPlanner({
+        createTransactionMessage: () =>
+            pipe(createTransactionMessage({ version: 0 }), tx => setTransactionMessageFeePayerSigner(payer, tx)),
+    });
+    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory(client);
+    const executor = createTransactionPlanExecutor({
+        executeTransactionMessage: async (_context, message) => {
+            const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
+            const transaction = await pipe(setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, message), tx =>
+                signTransactionMessageWithSigners(tx),
+            );
+            assertIsSendableTransaction(transaction);
+            assertIsTransactionWithBlockhashLifetime(transaction);
+            await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
+            return transaction;
+        },
+    });
+    const transactionPlan = await planner(instructionPlan);
+    return await executor(transactionPlan);
 };
 
 export const getCreateMintInstructions = async (input: {
@@ -220,4 +260,129 @@ export const createTokenWithAmount = async (
         }),
     ]);
     return token.address;
+};
+
+export const getTokenExtension = <TKind extends Extension['__kind']>(
+    token: Token,
+    kind: TKind,
+): Extract<Extension, { __kind: TKind }> => {
+    if (!isSome(token.extensions)) {
+        throw new Error('Token account has no extensions.');
+    }
+    const found = token.extensions.value.find(e => e.__kind === kind);
+    if (!found) {
+        throw new Error(`Token account is missing the ${kind} extension.`);
+    }
+    return found as Extract<Extension, { __kind: TKind }>;
+};
+
+export const fetchAssociatedToken = async (client: Client, owner: Address, mint: Address): Promise<Token> => {
+    const [token] = await findAssociatedTokenPda({ owner, tokenProgram: TOKEN_2022_PROGRAM_ADDRESS, mint });
+    const { data } = await fetchToken(client.rpc, token);
+    return data;
+};
+
+// Creates a mint configured for confidential transfers with auto-approval, so
+// that newly configured accounts are immediately usable without a separate
+// approval from the confidential transfer mint authority.
+export const createConfidentialMint = async (input: {
+    client: Client;
+    payer: TransactionSigner;
+    decimals?: number;
+}): Promise<{ mint: Address; mintAuthority: TransactionSigner }> => {
+    const mintAuthority = await generateKeyPairSigner();
+    const mint = await createMint({
+        client: input.client,
+        payer: input.payer,
+        authority: mintAuthority,
+        decimals: input.decimals ?? 2,
+        extensions: [
+            extension('ConfidentialTransferMint', {
+                authority: some(mintAuthority.address),
+                autoApproveNewAccounts: true,
+                auditorElgamalPubkey: none(),
+            }),
+        ],
+    });
+    return { mint, mintAuthority };
+};
+
+export type ConfidentialTokenAccount = {
+    token: Address;
+    elgamalKeypair: ElGamalKeypair;
+    aesKey: AeKey;
+};
+
+// Creates and configures an associated token account for confidential transfers.
+export const createConfidentialTokenAccount = async (input: {
+    client: Client;
+    payer: TransactionSigner;
+    owner: TransactionSigner;
+    mint: Address;
+}): Promise<ConfidentialTokenAccount> => {
+    const elgamalKeypair = new ElGamalKeypair();
+    const aesKey = new AeKey();
+    const [token] = await findAssociatedTokenPda({
+        owner: input.owner.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        mint: input.mint,
+    });
+    await sendAndConfirmInstructionPlan(
+        input.client,
+        input.payer,
+        await getCreateConfidentialTransferAccountInstructionPlan({
+            payer: input.payer,
+            owner: input.owner,
+            mint: input.mint,
+            rpc: input.client.rpc,
+            elgamalKeypair,
+            aesKey,
+        }),
+    );
+    return { token, elgamalKeypair, aesKey };
+};
+
+// Creates a confidential token account with `amount` tokens deposited and
+// applied to its available confidential balance (ready to withdraw or transfer).
+export const createConfidentialTokenAccountWithBalance = async (input: {
+    client: Client;
+    payer: TransactionSigner;
+    owner: TransactionSigner;
+    mint: Address;
+    mintAuthority: TransactionSigner;
+    decimals: number;
+    amount: bigint;
+}): Promise<ConfidentialTokenAccount> => {
+    const account = await createConfidentialTokenAccount(input);
+
+    // Mint public tokens, then deposit them into the confidential pending balance.
+    await sendAndConfirmInstructions(input.client, input.payer, [
+        getMintToInstruction({
+            mint: input.mint,
+            token: account.token,
+            mintAuthority: input.mintAuthority,
+            amount: input.amount,
+        }),
+        getConfidentialDepositInstruction({
+            token: account.token,
+            mint: input.mint,
+            authority: input.owner,
+            amount: input.amount,
+            decimals: input.decimals,
+        }),
+    ]);
+
+    // Apply the pending balance so the deposited amount becomes available.
+    const { data: tokenAccount } = await fetchToken(input.client.rpc, account.token);
+    await sendAndConfirmInstructions(input.client, input.payer, [
+        getApplyConfidentialPendingBalanceInstructionFromToken({
+            token: account.token,
+            tokenAccount,
+            authority: input.owner,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }),
+    ]);
+
+    return account;
 };

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -1,0 +1,262 @@
+import {
+    createKeyPairSignerFromPrivateKeyBytes,
+    generateKeyPairSigner,
+    getAddressDecoder,
+    getAddressEncoder,
+    some,
+    type MessagePartialSigner,
+} from '@solana/kit';
+import * as zk from '@solana/zk-sdk/node';
+import test from 'ava';
+import {
+    deriveAeKey,
+    deriveAeKeyForOwnerMint,
+    deriveElGamalKeypair,
+    deriveElGamalKeypairForOwnerMint,
+    getInitializeConfidentialTransferMintInstruction,
+    parseInitializeConfidentialTransferMintInstruction,
+} from '../src';
+
+const ADDRESS_DECODER = getAddressDecoder();
+const ADDRESS_ENCODER = getAddressEncoder();
+
+const RUST_VECTOR_PRIVATE_KEY = new Uint8Array([
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    32,
+]);
+const RUST_VECTOR_PUBLIC_SEED = new Uint8Array([
+    32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2,
+    1,
+]);
+const RUST_VECTOR_ELGAMAL_SECRET_KEY = new Uint8Array([
+    241, 57, 101, 25, 81, 46, 182, 190, 48, 67, 70, 212, 112, 100, 196, 151, 81, 38, 121, 14, 125, 101, 91, 57, 182,
+    241, 127, 250, 6, 41, 183, 15,
+]);
+const RUST_VECTOR_ELGAMAL_PUBKEY = new Uint8Array([
+    214, 11, 48, 194, 204, 45, 151, 60, 254, 187, 74, 62, 160, 235, 15, 191, 75, 101, 68, 140, 231, 60, 57, 244, 153,
+    44, 163, 98, 166, 34, 173, 16,
+]);
+const RUST_VECTOR_AE_KEY = new Uint8Array([227, 20, 117, 208, 41, 69, 224, 51, 180, 203, 193, 101, 242, 164, 192, 190]);
+
+test('it derives a 32-byte ElGamal secret key and a public key Address', async t => {
+    const signer = await generateKeyPairSigner();
+
+    const { elgamalPubkey, secretKey } = await deriveElGamalKeypair({ signer, zk });
+
+    t.truthy(elgamalPubkey);
+    t.is(secretKey.length, 32);
+    t.is(ADDRESS_ENCODER.encode(elgamalPubkey).length, 32);
+});
+
+test('it derives a 16-byte AES key', async t => {
+    const signer = await generateKeyPairSigner();
+
+    const aeKey = await deriveAeKey({ signer, zk });
+
+    t.is(aeKey.length, 16);
+});
+
+test('it derives deterministic ElGamal keys from the same signer and seed', async t => {
+    const signer = await generateKeyPairSigner();
+    const publicSeed = new Uint8Array([1, 2, 3, 4]);
+
+    const first = await deriveElGamalKeypair({ signer, zk, publicSeed });
+    const second = await deriveElGamalKeypair({ signer, zk, publicSeed });
+
+    t.deepEqual(first.secretKey, second.secretKey);
+    t.is(first.elgamalPubkey, second.elgamalPubkey);
+});
+
+test('it derives deterministic AES keys from the same signer and seed', async t => {
+    const signer = await generateKeyPairSigner();
+    const publicSeed = new Uint8Array([5, 6, 7, 8]);
+
+    const first = await deriveAeKey({ signer, zk, publicSeed });
+    const second = await deriveAeKey({ signer, zk, publicSeed });
+
+    t.deepEqual(first, second);
+});
+
+test('it derives different ElGamal keys for different seeds', async t => {
+    const signer = await generateKeyPairSigner();
+
+    const noSeed = await deriveElGamalKeypair({ signer, zk });
+    const withSeed = await deriveElGamalKeypair({ signer, zk, publicSeed: new Uint8Array([1]) });
+
+    t.notDeepEqual(noSeed.secretKey, withSeed.secretKey);
+    t.not(noSeed.elgamalPubkey, withSeed.elgamalPubkey);
+});
+
+test('it derives different AES keys for different seeds', async t => {
+    const signer = await generateKeyPairSigner();
+
+    const noSeed = await deriveAeKey({ signer, zk });
+    const withSeed = await deriveAeKey({ signer, zk, publicSeed: new Uint8Array([1]) });
+
+    t.notDeepEqual(noSeed, withSeed);
+});
+
+test('it derives different keys for different signers', async t => {
+    const [signerA, signerB] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+
+    const [elgamalA, elgamalB] = await Promise.all([
+        deriveElGamalKeypair({ signer: signerA, zk }),
+        deriveElGamalKeypair({ signer: signerB, zk }),
+    ]);
+    const [aeA, aeB] = await Promise.all([deriveAeKey({ signer: signerA, zk }), deriveAeKey({ signer: signerB, zk })]);
+
+    t.notDeepEqual(elgamalA.secretKey, elgamalB.secretKey);
+    t.notDeepEqual(aeA, aeB);
+});
+
+test('it matches the Rust solana-zk-sdk derivation vector', async t => {
+    const signer = await createKeyPairSignerFromPrivateKeyBytes(RUST_VECTOR_PRIVATE_KEY);
+
+    const [derivedElGamal, derivedAeKey] = await Promise.all([
+        deriveElGamalKeypair({ signer, zk, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
+        deriveAeKey({ signer, zk, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
+    ]);
+
+    t.deepEqual(derivedElGamal.secretKey, RUST_VECTOR_ELGAMAL_SECRET_KEY);
+    t.is(derivedElGamal.elgamalPubkey, ADDRESS_DECODER.decode(RUST_VECTOR_ELGAMAL_PUBKEY));
+    t.deepEqual(derivedAeKey, RUST_VECTOR_AE_KEY);
+});
+
+test('deriveElGamalKeypairForOwnerMint composes the seed as concat(owner, mint)', async t => {
+    const [signer, ownerSigner, mintSigner] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const owner = ownerSigner.address;
+    const mint = mintSigner.address;
+
+    const expectedSeed = new Uint8Array(64);
+    expectedSeed.set(ADDRESS_ENCODER.encode(owner), 0);
+    expectedSeed.set(ADDRESS_ENCODER.encode(mint), 32);
+
+    const [convenience, manual] = await Promise.all([
+        deriveElGamalKeypairForOwnerMint({ signer, zk, owner, mint }),
+        deriveElGamalKeypair({ signer, zk, publicSeed: expectedSeed }),
+    ]);
+
+    t.deepEqual(convenience.secretKey, manual.secretKey);
+    t.is(convenience.elgamalPubkey, manual.elgamalPubkey);
+});
+
+test('deriveAeKeyForOwnerMint composes the seed as concat(owner, mint)', async t => {
+    const [signer, ownerSigner, mintSigner] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const owner = ownerSigner.address;
+    const mint = mintSigner.address;
+
+    const expectedSeed = new Uint8Array(64);
+    expectedSeed.set(ADDRESS_ENCODER.encode(owner), 0);
+    expectedSeed.set(ADDRESS_ENCODER.encode(mint), 32);
+
+    const [convenience, manual] = await Promise.all([
+        deriveAeKeyForOwnerMint({ signer, zk, owner, mint }),
+        deriveAeKey({ signer, zk, publicSeed: expectedSeed }),
+    ]);
+
+    t.deepEqual(convenience, manual);
+});
+
+test('deriveElGamalKeypairForOwnerMint binds keys to (owner, mint), not just owner', async t => {
+    const [signer, mintA, mintB] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const owner = signer.address;
+
+    const [keysForMintA, keysForMintB] = await Promise.all([
+        deriveElGamalKeypairForOwnerMint({ signer, zk, owner, mint: mintA.address }),
+        deriveElGamalKeypairForOwnerMint({ signer, zk, owner, mint: mintB.address }),
+    ]);
+
+    // Different mints with the same owner must yield different keys.
+    t.notDeepEqual(keysForMintA.secretKey, keysForMintB.secretKey);
+    t.not(keysForMintA.elgamalPubkey, keysForMintB.elgamalPubkey);
+});
+
+test('deriveElGamalKeypairForOwnerMint binds keys to (owner, mint), not just mint', async t => {
+    const [signerA, signerB, mintSigner] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const mint = mintSigner.address;
+
+    const [keysForOwnerA, keysForOwnerB] = await Promise.all([
+        deriveElGamalKeypairForOwnerMint({ signer: signerA, zk, owner: signerA.address, mint }),
+        deriveElGamalKeypairForOwnerMint({ signer: signerB, zk, owner: signerB.address, mint }),
+    ]);
+
+    // Different owners with the same mint must yield different keys.
+    t.notDeepEqual(keysForOwnerA.secretKey, keysForOwnerB.secretKey);
+    t.not(keysForOwnerA.elgamalPubkey, keysForOwnerB.elgamalPubkey);
+});
+
+test('it derives keys from a generic message signer', async t => {
+    const signer = await generateKeyPairSigner();
+    const genericSigner: MessagePartialSigner = {
+        address: signer.address,
+        signMessages: signer.signMessages,
+    };
+    const publicSeed = new Uint8Array([9, 8, 7, 6]);
+
+    const [derivedElGamal, expectedElGamal] = await Promise.all([
+        deriveElGamalKeypair({ signer: genericSigner, zk, publicSeed }),
+        deriveElGamalKeypair({ signer, zk, publicSeed }),
+    ]);
+    const [derivedAeKey, expectedAeKey] = await Promise.all([
+        deriveAeKey({ signer: genericSigner, zk, publicSeed }),
+        deriveAeKey({ signer, zk, publicSeed }),
+    ]);
+
+    t.deepEqual(derivedElGamal.secretKey, expectedElGamal.secretKey);
+    t.is(derivedElGamal.elgamalPubkey, expectedElGamal.elgamalPubkey);
+    t.deepEqual(derivedAeKey, expectedAeKey);
+});
+
+test('it plugs derived ElGamal pubkeys directly into confidential transfer instruction builders', async t => {
+    const [authority, mintSigner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
+        signer: authority,
+        zk,
+        owner: authority.address,
+        mint: mintSigner.address,
+    });
+
+    const instruction = getInitializeConfidentialTransferMintInstruction({
+        mint: mintSigner.address,
+        authority: some(authority.address),
+        autoApproveNewAccounts: true,
+        auditorElgamalPubkey: some(derivedElGamal.elgamalPubkey),
+    });
+    const parsed = parseInitializeConfidentialTransferMintInstruction(instruction);
+
+    t.deepEqual(parsed.data.authority, some(authority.address));
+    t.true(parsed.data.autoApproveNewAccounts);
+    t.deepEqual(parsed.data.auditorElgamalPubkey, some(derivedElGamal.elgamalPubkey));
+});
+
+test('it produces a non-zero ElGamal secret key', async t => {
+    const signer = await generateKeyPairSigner();
+
+    const { secretKey } = await deriveElGamalKeypair({ signer, zk });
+
+    t.false(secretKey.every(b => b === 0));
+});
+
+test('it produces a non-zero AES key', async t => {
+    const signer = await generateKeyPairSigner();
+
+    const aeKey = await deriveAeKey({ signer, zk });
+
+    t.false(aeKey.every(b => b === 0));
+});

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -6,7 +6,6 @@ import {
     some,
     type MessagePartialSigner,
 } from '@solana/kit';
-import * as zk from '@solana/zk-sdk/node';
 import test from 'ava';
 import {
     deriveAeKey,
@@ -41,7 +40,7 @@ const RUST_VECTOR_AE_KEY = new Uint8Array([227, 20, 117, 208, 41, 69, 224, 51, 1
 test('it derives a 32-byte ElGamal secret key and a public key Address', async t => {
     const signer = await generateKeyPairSigner();
 
-    const { elgamalPubkey, secretKey } = await deriveElGamalKeypair({ signer, zk });
+    const { elgamalPubkey, secretKey } = await deriveElGamalKeypair({ signer });
 
     t.truthy(elgamalPubkey);
     t.is(secretKey.length, 32);
@@ -51,7 +50,7 @@ test('it derives a 32-byte ElGamal secret key and a public key Address', async t
 test('it derives a 16-byte AES key', async t => {
     const signer = await generateKeyPairSigner();
 
-    const aeKey = await deriveAeKey({ signer, zk });
+    const aeKey = await deriveAeKey({ signer });
 
     t.is(aeKey.length, 16);
 });
@@ -60,8 +59,8 @@ test('it derives deterministic ElGamal keys from the same signer and seed', asyn
     const signer = await generateKeyPairSigner();
     const publicSeed = new Uint8Array([1, 2, 3, 4]);
 
-    const first = await deriveElGamalKeypair({ signer, zk, publicSeed });
-    const second = await deriveElGamalKeypair({ signer, zk, publicSeed });
+    const first = await deriveElGamalKeypair({ signer, publicSeed });
+    const second = await deriveElGamalKeypair({ signer, publicSeed });
 
     t.deepEqual(first.secretKey, second.secretKey);
     t.is(first.elgamalPubkey, second.elgamalPubkey);
@@ -71,8 +70,8 @@ test('it derives deterministic AES keys from the same signer and seed', async t 
     const signer = await generateKeyPairSigner();
     const publicSeed = new Uint8Array([5, 6, 7, 8]);
 
-    const first = await deriveAeKey({ signer, zk, publicSeed });
-    const second = await deriveAeKey({ signer, zk, publicSeed });
+    const first = await deriveAeKey({ signer, publicSeed });
+    const second = await deriveAeKey({ signer, publicSeed });
 
     t.deepEqual(first, second);
 });
@@ -80,8 +79,8 @@ test('it derives deterministic AES keys from the same signer and seed', async t 
 test('it derives different ElGamal keys for different seeds', async t => {
     const signer = await generateKeyPairSigner();
 
-    const noSeed = await deriveElGamalKeypair({ signer, zk });
-    const withSeed = await deriveElGamalKeypair({ signer, zk, publicSeed: new Uint8Array([1]) });
+    const noSeed = await deriveElGamalKeypair({ signer });
+    const withSeed = await deriveElGamalKeypair({ signer, publicSeed: new Uint8Array([1]) });
 
     t.notDeepEqual(noSeed.secretKey, withSeed.secretKey);
     t.not(noSeed.elgamalPubkey, withSeed.elgamalPubkey);
@@ -90,8 +89,8 @@ test('it derives different ElGamal keys for different seeds', async t => {
 test('it derives different AES keys for different seeds', async t => {
     const signer = await generateKeyPairSigner();
 
-    const noSeed = await deriveAeKey({ signer, zk });
-    const withSeed = await deriveAeKey({ signer, zk, publicSeed: new Uint8Array([1]) });
+    const noSeed = await deriveAeKey({ signer });
+    const withSeed = await deriveAeKey({ signer, publicSeed: new Uint8Array([1]) });
 
     t.notDeepEqual(noSeed, withSeed);
 });
@@ -100,10 +99,10 @@ test('it derives different keys for different signers', async t => {
     const [signerA, signerB] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     const [elgamalA, elgamalB] = await Promise.all([
-        deriveElGamalKeypair({ signer: signerA, zk }),
-        deriveElGamalKeypair({ signer: signerB, zk }),
+        deriveElGamalKeypair({ signer: signerA }),
+        deriveElGamalKeypair({ signer: signerB }),
     ]);
-    const [aeA, aeB] = await Promise.all([deriveAeKey({ signer: signerA, zk }), deriveAeKey({ signer: signerB, zk })]);
+    const [aeA, aeB] = await Promise.all([deriveAeKey({ signer: signerA }), deriveAeKey({ signer: signerB })]);
 
     t.notDeepEqual(elgamalA.secretKey, elgamalB.secretKey);
     t.notDeepEqual(aeA, aeB);
@@ -113,8 +112,8 @@ test('it matches the Rust solana-zk-sdk derivation vector', async t => {
     const signer = await createKeyPairSignerFromPrivateKeyBytes(RUST_VECTOR_PRIVATE_KEY);
 
     const [derivedElGamal, derivedAeKey] = await Promise.all([
-        deriveElGamalKeypair({ signer, zk, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
-        deriveAeKey({ signer, zk, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
+        deriveElGamalKeypair({ signer, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
+        deriveAeKey({ signer, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
     ]);
 
     t.deepEqual(derivedElGamal.secretKey, RUST_VECTOR_ELGAMAL_SECRET_KEY);
@@ -136,8 +135,8 @@ test('deriveElGamalKeypairForOwnerMint composes the seed as concat(owner, mint)'
     expectedSeed.set(ADDRESS_ENCODER.encode(mint), 32);
 
     const [convenience, manual] = await Promise.all([
-        deriveElGamalKeypairForOwnerMint({ signer, zk, owner, mint }),
-        deriveElGamalKeypair({ signer, zk, publicSeed: expectedSeed }),
+        deriveElGamalKeypairForOwnerMint({ signer, owner, mint }),
+        deriveElGamalKeypair({ signer, publicSeed: expectedSeed }),
     ]);
 
     t.deepEqual(convenience.secretKey, manual.secretKey);
@@ -158,8 +157,8 @@ test('deriveAeKeyForOwnerMint composes the seed as concat(owner, mint)', async t
     expectedSeed.set(ADDRESS_ENCODER.encode(mint), 32);
 
     const [convenience, manual] = await Promise.all([
-        deriveAeKeyForOwnerMint({ signer, zk, owner, mint }),
-        deriveAeKey({ signer, zk, publicSeed: expectedSeed }),
+        deriveAeKeyForOwnerMint({ signer, owner, mint }),
+        deriveAeKey({ signer, publicSeed: expectedSeed }),
     ]);
 
     t.deepEqual(convenience, manual);
@@ -174,8 +173,8 @@ test('deriveElGamalKeypairForOwnerMint binds keys to (owner, mint), not just own
     const owner = signer.address;
 
     const [keysForMintA, keysForMintB] = await Promise.all([
-        deriveElGamalKeypairForOwnerMint({ signer, zk, owner, mint: mintA.address }),
-        deriveElGamalKeypairForOwnerMint({ signer, zk, owner, mint: mintB.address }),
+        deriveElGamalKeypairForOwnerMint({ signer, owner, mint: mintA.address }),
+        deriveElGamalKeypairForOwnerMint({ signer, owner, mint: mintB.address }),
     ]);
 
     // Different mints with the same owner must yield different keys.
@@ -192,8 +191,8 @@ test('deriveElGamalKeypairForOwnerMint binds keys to (owner, mint), not just min
     const mint = mintSigner.address;
 
     const [keysForOwnerA, keysForOwnerB] = await Promise.all([
-        deriveElGamalKeypairForOwnerMint({ signer: signerA, zk, owner: signerA.address, mint }),
-        deriveElGamalKeypairForOwnerMint({ signer: signerB, zk, owner: signerB.address, mint }),
+        deriveElGamalKeypairForOwnerMint({ signer: signerA, owner: signerA.address, mint }),
+        deriveElGamalKeypairForOwnerMint({ signer: signerB, owner: signerB.address, mint }),
     ]);
 
     // Different owners with the same mint must yield different keys.
@@ -210,12 +209,12 @@ test('it derives keys from a generic message signer', async t => {
     const publicSeed = new Uint8Array([9, 8, 7, 6]);
 
     const [derivedElGamal, expectedElGamal] = await Promise.all([
-        deriveElGamalKeypair({ signer: genericSigner, zk, publicSeed }),
-        deriveElGamalKeypair({ signer, zk, publicSeed }),
+        deriveElGamalKeypair({ signer: genericSigner, publicSeed }),
+        deriveElGamalKeypair({ signer, publicSeed }),
     ]);
     const [derivedAeKey, expectedAeKey] = await Promise.all([
-        deriveAeKey({ signer: genericSigner, zk, publicSeed }),
-        deriveAeKey({ signer, zk, publicSeed }),
+        deriveAeKey({ signer: genericSigner, publicSeed }),
+        deriveAeKey({ signer, publicSeed }),
     ]);
 
     t.deepEqual(derivedElGamal.secretKey, expectedElGamal.secretKey);
@@ -227,7 +226,6 @@ test('it plugs derived ElGamal pubkeys directly into confidential transfer instr
     const [authority, mintSigner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
     const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
         signer: authority,
-        zk,
         owner: authority.address,
         mint: mintSigner.address,
     });
@@ -248,7 +246,7 @@ test('it plugs derived ElGamal pubkeys directly into confidential transfer instr
 test('it produces a non-zero ElGamal secret key', async t => {
     const signer = await generateKeyPairSigner();
 
-    const { secretKey } = await deriveElGamalKeypair({ signer, zk });
+    const { secretKey } = await deriveElGamalKeypair({ signer });
 
     t.false(secretKey.every(b => b === 0));
 });
@@ -256,7 +254,7 @@ test('it produces a non-zero ElGamal secret key', async t => {
 test('it produces a non-zero AES key', async t => {
     const signer = await generateKeyPairSigner();
 
-    const aeKey = await deriveAeKey({ signer, zk });
+    const aeKey = await deriveAeKey({ signer });
 
     t.false(aeKey.every(b => b === 0));
 });

--- a/clients/js/test/extensions/confidentialMintBurn/confidentialMintBurnHelpers.test.ts
+++ b/clients/js/test/extensions/confidentialMintBurn/confidentialMintBurnHelpers.test.ts
@@ -1,0 +1,451 @@
+import { generateKeyPairSigner, getAddressDecoder, isSome, none, some, type ReadonlyUint8Array } from '@solana/kit';
+import { AeCiphertext, ElGamalCiphertext, ElGamalKeypair, AeKey } from '@solana/zk-sdk/bundler';
+import test from 'ava';
+import {
+    AccountState,
+    Extension,
+    Mint,
+    Token,
+    extension,
+    fetchMint,
+    fetchToken,
+    getApplyConfidentialPendingBalanceInstructionFromToken,
+    getApplyConfidentialPendingBurnInstructionPlan,
+    getConfidentialBurnInstructionPlan,
+    getConfidentialMintInstructionPlan,
+    getPermissionedConfidentialBurnInstructionPlan,
+} from '../../../src';
+import {
+    Client,
+    createConfidentialTokenAccount,
+    createDefaultSolanaClient,
+    createMint,
+    generateKeyPairSignerWithSol,
+    sendAndConfirmInstructionPlan,
+    sendAndConfirmInstructions,
+} from '../../_setup';
+
+const addressDecoder = getAddressDecoder();
+
+type ConfidentialMintBurnMint = {
+    mint: Awaited<ReturnType<typeof createMint>>;
+    mintAuthority: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+    supplyElgamalKeypair: ElGamalKeypair;
+    supplyAesKey: AeKey;
+};
+
+function getElGamalPubkeyAddress(keypair: ElGamalKeypair) {
+    return addressDecoder.decode(new Uint8Array(keypair.pubkey().toBytes()));
+}
+
+function getRequiredExtension<TKind extends Extension['__kind']>(
+    account: Mint | Token,
+    kind: TKind,
+): Extract<Extension, { __kind: TKind }> {
+    if (!isSome(account.extensions)) {
+        throw new Error('Account has no extensions.');
+    }
+    const found = account.extensions.value.find(e => e.__kind === kind);
+    if (!found) {
+        throw new Error(`Account is missing the ${kind} extension.`);
+    }
+    return found as Extract<Extension, { __kind: TKind }>;
+}
+
+function decryptAeBalance(aesKey: AeKey, bytes: ReadonlyUint8Array) {
+    const ciphertext = AeCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to parse decryptable balance.');
+    }
+    return aesKey.decrypt(ciphertext);
+}
+
+function decryptElGamalBalance(keypair: ElGamalKeypair, bytes: ReadonlyUint8Array) {
+    const ciphertext = ElGamalCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to parse encrypted balance.');
+    }
+    return keypair.secret().decrypt(ciphertext);
+}
+
+function createLocalMintAccount(input: { supplyElgamalKeypair: ElGamalKeypair; supplyAesKey: AeKey }): Mint {
+    return {
+        mintAuthority: none(),
+        supply: 0n,
+        decimals: 0,
+        isInitialized: true,
+        freezeAuthority: none(),
+        extensions: some([
+            {
+                __kind: 'ConfidentialTransferMint',
+                authority: none(),
+                autoApproveNewAccounts: true,
+                auditorElgamalPubkey: none(),
+            },
+            {
+                __kind: 'ConfidentialMintBurn',
+                confidentialSupply: new Uint8Array(64),
+                decryptableSupply: input.supplyAesKey.encrypt(0n).toBytes(),
+                supplyElgamalPubkey: getElGamalPubkeyAddress(input.supplyElgamalKeypair),
+                pendingBurn: new Uint8Array(64),
+            },
+        ]),
+    };
+}
+
+function createLocalTokenAccount(input: {
+    mint: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+    owner: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+    elgamalKeypair: ElGamalKeypair;
+    aesKey: AeKey;
+    availableBalance?: bigint;
+}): Token {
+    const availableBalance = input.availableBalance ?? 0n;
+    return {
+        mint: input.mint.address,
+        owner: input.owner.address,
+        amount: 0n,
+        delegate: none(),
+        state: AccountState.Initialized,
+        isNative: none(),
+        delegatedAmount: 0n,
+        closeAuthority: none(),
+        extensions: some([
+            {
+                __kind: 'ConfidentialTransferAccount',
+                approved: true,
+                elgamalPubkey: getElGamalPubkeyAddress(input.elgamalKeypair),
+                pendingBalanceLow: new Uint8Array(64),
+                pendingBalanceHigh: new Uint8Array(64),
+                availableBalance: input.elgamalKeypair.pubkey().encryptU64(availableBalance).toBytes(),
+                decryptableAvailableBalance: input.aesKey.encrypt(availableBalance).toBytes(),
+                allowConfidentialCredits: true,
+                allowNonConfidentialCredits: true,
+                pendingBalanceCreditCounter: 0n,
+                maximumPendingBalanceCreditCounter: 0n,
+                expectedPendingBalanceCreditCounter: 0n,
+                actualPendingBalanceCreditCounter: 0n,
+            },
+        ]),
+    };
+}
+
+async function createConfidentialMintBurnMint(input: {
+    client: Client;
+    payer: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+    permissionedBurnAuthority?: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+}): Promise<ConfidentialMintBurnMint> {
+    const mintAuthority = await generateKeyPairSignerWithSol(input.client);
+    const supplyElgamalKeypair = new ElGamalKeypair();
+    const supplyAesKey = new AeKey();
+    const confidentialTransferMintExtension = extension('ConfidentialTransferMint', {
+        authority: some(mintAuthority.address),
+        autoApproveNewAccounts: true,
+        auditorElgamalPubkey: none(),
+    });
+    const confidentialMintBurnExtension = extension('ConfidentialMintBurn', {
+        confidentialSupply: new Uint8Array(64),
+        decryptableSupply: supplyAesKey.encrypt(0n).toBytes(),
+        supplyElgamalPubkey: getElGamalPubkeyAddress(supplyElgamalKeypair),
+        pendingBurn: new Uint8Array(64),
+    });
+    const permissionedBurnExtension = input.permissionedBurnAuthority
+        ? [
+              extension('PermissionedBurn', {
+                  authority: some(input.permissionedBurnAuthority.address),
+              }),
+          ]
+        : [];
+
+    const mint = await createMint({
+        client: input.client,
+        payer: input.payer,
+        authority: mintAuthority,
+        extensions: [confidentialTransferMintExtension, confidentialMintBurnExtension, ...permissionedBurnExtension],
+    });
+
+    return { mint, mintAuthority, supplyElgamalKeypair, supplyAesKey };
+}
+
+async function mintConfidentialTokens(input: {
+    client: Client;
+    payer: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+    mint: ConfidentialMintBurnMint;
+    token: Awaited<ReturnType<typeof createConfidentialTokenAccount>>;
+    amount: bigint;
+}) {
+    const [{ data: mintAccount }, { data: tokenAccount }] = await Promise.all([
+        fetchMint(input.client.rpc, input.mint.mint),
+        fetchToken(input.client.rpc, input.token.token),
+    ]);
+    await sendAndConfirmInstructionPlan(
+        input.client,
+        input.payer,
+        await getConfidentialMintInstructionPlan({
+            payer: input.payer,
+            rpc: input.client.rpc,
+            token: input.token.token,
+            mint: input.mint.mint,
+            mintAccount,
+            destinationTokenAccount: tokenAccount,
+            authority: input.mint.mintAuthority,
+            amount: input.amount,
+            supplyElgamalKeypair: input.mint.supplyElgamalKeypair,
+            supplyAesKey: input.mint.supplyAesKey,
+        }),
+    );
+}
+
+async function applyPendingBalance(input: {
+    client: Client;
+    payer: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+    owner: Awaited<ReturnType<typeof generateKeyPairSignerWithSol>>;
+    token: Awaited<ReturnType<typeof createConfidentialTokenAccount>>;
+}) {
+    const { data: tokenAccount } = await fetchToken(input.client.rpc, input.token.token);
+    await sendAndConfirmInstructions(input.client, input.payer, [
+        getApplyConfidentialPendingBalanceInstructionFromToken({
+            token: input.token.token,
+            tokenAccount,
+            authority: input.owner,
+            elgamalSecretKey: input.token.elgamalKeypair.secret(),
+            aesKey: input.token.aesKey,
+        }),
+    ]);
+}
+
+test('it rejects a negative confidential mint amount', async t => {
+    const [payer, mintAddress, tokenAddress, owner, mintAuthority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const supplyElgamalKeypair = new ElGamalKeypair();
+    const supplyAesKey = new AeKey();
+    const destinationElgamalKeypair = new ElGamalKeypair();
+    const destinationAesKey = new AeKey();
+
+    await t.throwsAsync(
+        () =>
+            getConfidentialMintInstructionPlan({
+                payer,
+                rpc: createDefaultSolanaClient().rpc,
+                token: tokenAddress.address,
+                mint: mintAddress.address,
+                mintAccount: createLocalMintAccount({ supplyElgamalKeypair, supplyAesKey }),
+                destinationTokenAccount: createLocalTokenAccount({
+                    mint: mintAddress,
+                    owner,
+                    elgamalKeypair: destinationElgamalKeypair,
+                    aesKey: destinationAesKey,
+                }),
+                authority: mintAuthority,
+                amount: -1n,
+                supplyElgamalKeypair,
+                supplyAesKey,
+            }),
+        { message: 'Amount must be non-negative.' },
+    );
+});
+
+test('it rejects a confidential mint with the wrong supply ElGamal keypair', async t => {
+    const [payer, mintAddress, tokenAddress, owner, mintAuthority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const configuredSupplyElgamalKeypair = new ElGamalKeypair();
+    const inputSupplyElgamalKeypair = new ElGamalKeypair();
+    const supplyAesKey = new AeKey();
+    const destinationElgamalKeypair = new ElGamalKeypair();
+    const destinationAesKey = new AeKey();
+
+    await t.throwsAsync(
+        () =>
+            getConfidentialMintInstructionPlan({
+                payer,
+                rpc: createDefaultSolanaClient().rpc,
+                token: tokenAddress.address,
+                mint: mintAddress.address,
+                mintAccount: createLocalMintAccount({
+                    supplyElgamalKeypair: configuredSupplyElgamalKeypair,
+                    supplyAesKey,
+                }),
+                destinationTokenAccount: createLocalTokenAccount({
+                    mint: mintAddress,
+                    owner,
+                    elgamalKeypair: destinationElgamalKeypair,
+                    aesKey: destinationAesKey,
+                }),
+                authority: mintAuthority,
+                amount: 1n,
+                supplyElgamalKeypair: inputSupplyElgamalKeypair,
+                supplyAesKey,
+            }),
+        { message: 'Supply ElGamal keypair does not match mint.' },
+    );
+});
+
+test('it rejects a confidential burn larger than the decryptable available balance', async t => {
+    const [payer, mintAddress, tokenAddress, owner] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const supplyElgamalKeypair = new ElGamalKeypair();
+    const supplyAesKey = new AeKey();
+    const sourceElgamalKeypair = new ElGamalKeypair();
+    const sourceAesKey = new AeKey();
+
+    await t.throwsAsync(
+        () =>
+            getConfidentialBurnInstructionPlan({
+                payer,
+                rpc: createDefaultSolanaClient().rpc,
+                token: tokenAddress.address,
+                mint: mintAddress.address,
+                mintAccount: createLocalMintAccount({ supplyElgamalKeypair, supplyAesKey }),
+                tokenAccount: createLocalTokenAccount({
+                    mint: mintAddress,
+                    owner,
+                    elgamalKeypair: sourceElgamalKeypair,
+                    aesKey: sourceAesKey,
+                    availableBalance: 5n,
+                }),
+                authority: owner,
+                amount: 6n,
+                sourceElgamalKeypair,
+                sourceAesKey,
+            }),
+        { message: 'Insufficient funds.' },
+    );
+});
+
+test('it confidentially mints tokens into a pending balance', async t => {
+    // Given a mint with confidential mint/burn enabled and a configured token account.
+    const client = createDefaultSolanaClient();
+    const payer = await generateKeyPairSignerWithSol(client);
+    const mint = await createConfidentialMintBurnMint({ client, payer });
+    const owner = await generateKeyPairSignerWithSol(client);
+    const token = await createConfidentialTokenAccount({ client, payer, owner, mint: mint.mint });
+
+    // When the mint authority confidentially mints tokens to the account.
+    await mintConfidentialTokens({ client, payer, mint, token, amount: 1000n });
+
+    // Then the mint supply is updated and the token account receives one pending credit.
+    const [{ data: mintAccount }, { data: tokenAccount }] = await Promise.all([
+        fetchMint(client.rpc, mint.mint),
+        fetchToken(client.rpc, token.token),
+    ]);
+    const mintBurnExtension = getRequiredExtension(mintAccount, 'ConfidentialMintBurn');
+    const confidentialAccount = getRequiredExtension(tokenAccount, 'ConfidentialTransferAccount');
+
+    t.is(decryptAeBalance(mint.supplyAesKey, mintBurnExtension.decryptableSupply), 1000n);
+    t.is(confidentialAccount.pendingBalanceCreditCounter, 1n);
+});
+
+test('it confidentially burns tokens and applies the pending burn to supply', async t => {
+    // Given a confidential balance supplied by confidential minting.
+    const client = createDefaultSolanaClient();
+    const payer = await generateKeyPairSignerWithSol(client);
+    const mint = await createConfidentialMintBurnMint({ client, payer });
+    const owner = await generateKeyPairSignerWithSol(client);
+    const token = await createConfidentialTokenAccount({ client, payer, owner, mint: mint.mint });
+    await mintConfidentialTokens({ client, payer, mint, token, amount: 1000n });
+    await applyPendingBalance({ client, payer, owner, token });
+
+    // When the owner confidentially burns part of the available balance.
+    const [{ data: mintAccount }, { data: tokenAccount }] = await Promise.all([
+        fetchMint(client.rpc, mint.mint),
+        fetchToken(client.rpc, token.token),
+    ]);
+    await sendAndConfirmInstructionPlan(
+        client,
+        payer,
+        await getConfidentialBurnInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: token.token,
+            mint: mint.mint,
+            mintAccount,
+            tokenAccount,
+            authority: owner,
+            amount: 400n,
+            sourceElgamalKeypair: token.elgamalKeypair,
+            sourceAesKey: token.aesKey,
+        }),
+    );
+
+    // Then the source balance decreases and the mint records a pending burn.
+    const [{ data: mintAfterBurn }, { data: tokenAfterBurn }] = await Promise.all([
+        fetchMint(client.rpc, mint.mint),
+        fetchToken(client.rpc, token.token),
+    ]);
+    const tokenExtensionAfterBurn = getRequiredExtension(tokenAfterBurn, 'ConfidentialTransferAccount');
+    const mintBurnExtensionAfterBurn = getRequiredExtension(mintAfterBurn, 'ConfidentialMintBurn');
+
+    t.is(decryptAeBalance(token.aesKey, tokenExtensionAfterBurn.decryptableAvailableBalance), 600n);
+    t.is(decryptElGamalBalance(mint.supplyElgamalKeypair, mintBurnExtensionAfterBurn.pendingBurn), 400n);
+
+    // And applying the pending burn updates decryptable supply.
+    await sendAndConfirmInstructionPlan(
+        client,
+        payer,
+        getApplyConfidentialPendingBurnInstructionPlan({
+            mint: mint.mint,
+            mintAccount: mintAfterBurn,
+            authority: mint.mintAuthority,
+            supplyElgamalSecretKey: mint.supplyElgamalKeypair.secret(),
+            supplyAesKey: mint.supplyAesKey,
+        }),
+    );
+    const { data: mintAfterApply } = await fetchMint(client.rpc, mint.mint);
+    const mintBurnExtensionAfterApply = getRequiredExtension(mintAfterApply, 'ConfidentialMintBurn');
+    t.is(decryptAeBalance(mint.supplyAesKey, mintBurnExtensionAfterApply.decryptableSupply), 600n);
+    t.deepEqual(mintBurnExtensionAfterApply.pendingBurn, new Uint8Array(64));
+});
+
+test('it confidentially burns with a permissioned burn authority', async t => {
+    // Given a mint with confidential mint/burn and permissioned burn enabled.
+    const client = createDefaultSolanaClient();
+    const payer = await generateKeyPairSignerWithSol(client);
+    const permissionedBurnAuthority = await generateKeyPairSignerWithSol(client);
+    const mint = await createConfidentialMintBurnMint({ client, payer, permissionedBurnAuthority });
+    const owner = await generateKeyPairSignerWithSol(client);
+    const token = await createConfidentialTokenAccount({ client, payer, owner, mint: mint.mint });
+    await mintConfidentialTokens({ client, payer, mint, token, amount: 1000n });
+    await applyPendingBalance({ client, payer, owner, token });
+
+    // When the burn includes the configured permissioned burn authority.
+    const [{ data: mintAccount }, { data: tokenAccount }] = await Promise.all([
+        fetchMint(client.rpc, mint.mint),
+        fetchToken(client.rpc, token.token),
+    ]);
+    await sendAndConfirmInstructionPlan(
+        client,
+        payer,
+        await getPermissionedConfidentialBurnInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: token.token,
+            mint: mint.mint,
+            mintAccount,
+            tokenAccount,
+            permissionedBurnAuthority,
+            authority: owner,
+            amount: 250n,
+            sourceElgamalKeypair: token.elgamalKeypair,
+            sourceAesKey: token.aesKey,
+        }),
+    );
+
+    // Then the source balance decreases.
+    const { data: tokenAfterBurn } = await fetchToken(client.rpc, token.token);
+    const tokenExtensionAfterBurn = getRequiredExtension(tokenAfterBurn, 'ConfidentialTransferAccount');
+    t.is(decryptAeBalance(token.aesKey, tokenExtensionAfterBurn.decryptableAvailableBalance), 750n);
+});

--- a/clients/js/test/extensions/confidentialTransfer/confidentialTransfer.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/confidentialTransfer.test.ts
@@ -1,0 +1,178 @@
+import { address, generateKeyPairSigner, type AccountMeta } from '@solana/kit';
+import test from 'ava';
+import { getConfidentialTransferInstruction, parseConfidentialTransferInstruction } from '../../../src';
+
+const SYSVAR_INSTRUCTIONS_ADDRESS = address('Sysvar1nstructions1111111111111111111111111');
+const SOURCE_AUDITOR_CIPHERTEXT_LO = new Uint8Array(64).fill(0xab);
+const SOURCE_AUDITOR_CIPHERTEXT_HI = new Uint8Array(64).fill(0xcd);
+const NEW_SOURCE_DECRYPTABLE_BALANCE = new Uint8Array(36).fill(0xef);
+
+test('it encodes the auditor ciphertext fields into the Transfer instruction data', async t => {
+    const [sourceToken, mint, destinationToken, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfidentialTransferInstruction({
+        sourceToken: sourceToken.address,
+        mint: mint.address,
+        destinationToken: destinationToken.address,
+        instructionsSysvar: SYSVAR_INSTRUCTIONS_ADDRESS,
+        authority,
+        newSourceDecryptableAvailableBalance: NEW_SOURCE_DECRYPTABLE_BALANCE,
+        transferAmountAuditorCiphertextLo: SOURCE_AUDITOR_CIPHERTEXT_LO,
+        transferAmountAuditorCiphertextHi: SOURCE_AUDITOR_CIPHERTEXT_HI,
+        equalityProofInstructionOffset: 1,
+        ciphertextValidityProofInstructionOffset: 2,
+        rangeProofInstructionOffset: 3,
+    });
+
+    const parsed = parseConfidentialTransferInstruction(instruction);
+
+    t.deepEqual(parsed.data.transferAmountAuditorCiphertextLo, SOURCE_AUDITOR_CIPHERTEXT_LO);
+    t.deepEqual(parsed.data.transferAmountAuditorCiphertextHi, SOURCE_AUDITOR_CIPHERTEXT_HI);
+    t.deepEqual(parsed.data.newSourceDecryptableAvailableBalance, NEW_SOURCE_DECRYPTABLE_BALANCE);
+    t.is(parsed.data.equalityProofInstructionOffset, 1);
+    t.is(parsed.data.ciphertextValidityProofInstructionOffset, 2);
+    t.is(parsed.data.rangeProofInstructionOffset, 3);
+});
+
+test('it encodes the auditor ciphertexts at the documented byte offsets', async t => {
+    const [sourceToken, mint, destinationToken, equalityRecord, ciphertextValidityRecord, rangeRecord, authority] =
+        await Promise.all([
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+        ]);
+
+    const instruction = getConfidentialTransferInstruction({
+        sourceToken: sourceToken.address,
+        mint: mint.address,
+        destinationToken: destinationToken.address,
+        equalityRecord: equalityRecord.address,
+        ciphertextValidityRecord: ciphertextValidityRecord.address,
+        rangeRecord: rangeRecord.address,
+        authority,
+        newSourceDecryptableAvailableBalance: NEW_SOURCE_DECRYPTABLE_BALANCE,
+        transferAmountAuditorCiphertextLo: SOURCE_AUDITOR_CIPHERTEXT_LO,
+        transferAmountAuditorCiphertextHi: SOURCE_AUDITOR_CIPHERTEXT_HI,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0,
+    });
+
+    // Data layout: 1 byte outer disc + 1 byte inner disc + 36 bytes AE balance
+    // = 38 bytes before the lo ciphertext, 102 bytes before the hi ciphertext.
+    t.deepEqual(instruction.data.slice(38, 102), SOURCE_AUDITOR_CIPHERTEXT_LO);
+    t.deepEqual(instruction.data.slice(102, 166), SOURCE_AUDITOR_CIPHERTEXT_HI);
+});
+
+test('it skips all optional accounts when every proof is in context-state mode', async t => {
+    const [sourceToken, mint, destinationToken, equalityRecord, ciphertextValidityRecord, rangeRecord, authority] =
+        await Promise.all([
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+        ]);
+
+    const instruction = getConfidentialTransferInstruction({
+        sourceToken: sourceToken.address,
+        mint: mint.address,
+        destinationToken: destinationToken.address,
+        equalityRecord: equalityRecord.address,
+        ciphertextValidityRecord: ciphertextValidityRecord.address,
+        rangeRecord: rangeRecord.address,
+        authority,
+        newSourceDecryptableAvailableBalance: NEW_SOURCE_DECRYPTABLE_BALANCE,
+        transferAmountAuditorCiphertextLo: SOURCE_AUDITOR_CIPHERTEXT_LO,
+        transferAmountAuditorCiphertextHi: SOURCE_AUDITOR_CIPHERTEXT_HI,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 7);
+    t.is(accounts[0].address, sourceToken.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, destinationToken.address);
+    t.is(accounts[3].address, equalityRecord.address);
+    t.is(accounts[4].address, ciphertextValidityRecord.address);
+    t.is(accounts[5].address, rangeRecord.address);
+    t.is(accounts[6].address, authority.address);
+});
+
+test('it emits only the sysvar when every proof is inline', async t => {
+    const [sourceToken, mint, destinationToken, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfidentialTransferInstruction({
+        sourceToken: sourceToken.address,
+        mint: mint.address,
+        destinationToken: destinationToken.address,
+        instructionsSysvar: SYSVAR_INSTRUCTIONS_ADDRESS,
+        authority,
+        newSourceDecryptableAvailableBalance: NEW_SOURCE_DECRYPTABLE_BALANCE,
+        transferAmountAuditorCiphertextLo: SOURCE_AUDITOR_CIPHERTEXT_LO,
+        transferAmountAuditorCiphertextHi: SOURCE_AUDITOR_CIPHERTEXT_HI,
+        equalityProofInstructionOffset: 1,
+        ciphertextValidityProofInstructionOffset: 2,
+        rangeProofInstructionOffset: 3,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 5);
+    t.is(accounts[0].address, sourceToken.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, destinationToken.address);
+    t.is(accounts[3].address, SYSVAR_INSTRUCTIONS_ADDRESS);
+    t.is(accounts[4].address, authority.address);
+});
+
+test('it emits sysvar plus only the context-state records that are provided in mixed mode', async t => {
+    const [sourceToken, mint, destinationToken, equalityRecord, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfidentialTransferInstruction({
+        sourceToken: sourceToken.address,
+        mint: mint.address,
+        destinationToken: destinationToken.address,
+        instructionsSysvar: SYSVAR_INSTRUCTIONS_ADDRESS,
+        equalityRecord: equalityRecord.address,
+        authority,
+        newSourceDecryptableAvailableBalance: NEW_SOURCE_DECRYPTABLE_BALANCE,
+        transferAmountAuditorCiphertextLo: SOURCE_AUDITOR_CIPHERTEXT_LO,
+        transferAmountAuditorCiphertextHi: SOURCE_AUDITOR_CIPHERTEXT_HI,
+        equalityProofInstructionOffset: 0,
+        ciphertextValidityProofInstructionOffset: 1,
+        rangeProofInstructionOffset: 2,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 6);
+    t.is(accounts[0].address, sourceToken.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, destinationToken.address);
+    t.is(accounts[3].address, SYSVAR_INSTRUCTIONS_ADDRESS);
+    t.is(accounts[4].address, equalityRecord.address);
+    t.is(accounts[5].address, authority.address);
+});

--- a/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
@@ -1,12 +1,7 @@
 import { generateKeyPairSigner } from '@solana/kit';
 import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import test from 'ava';
-import {
-    getConfidentialTransferInstructionPlan,
-    getConfidentialWithdrawInstructionPlan,
-    getCreateConfidentialTransferAccountInstructionPlan,
-    type Token,
-} from '../../../src';
+import { getCreateConfidentialTransferAccountInstructionPlan } from '../../../src';
 import { createDefaultSolanaClient } from '../../_setup';
 
 test('it rejects create helper authority that does not match the owner ATA flow', async t => {
@@ -31,58 +26,6 @@ test('it rejects create helper authority that does not match the owner ATA flow'
             }),
         {
             message: /authority must match owner/i,
-        },
-    );
-});
-
-test('it rejects instruction-data proof mode for confidential withdraw', async t => {
-    const [payer, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const elgamalKeypair = new ElGamalKeypair();
-    const aesKey = new AeKey();
-
-    await t.throwsAsync(
-        () =>
-            getConfidentialWithdrawInstructionPlan({
-                payer,
-                rpc: createDefaultSolanaClient().rpc,
-                token: payer.address,
-                mint: owner.address,
-                tokenAccount: {} as Token,
-                authority: owner,
-                amount: 1n,
-                decimals: 0,
-                elgamalKeypair,
-                aesKey,
-                proofMode: 'instruction-data',
-            } as unknown as Parameters<typeof getConfidentialWithdrawInstructionPlan>[0]),
-        {
-            message: /instruction-data proof mode is unsupported/i,
-        },
-    );
-});
-
-test('it rejects instruction-data proof mode for confidential transfer', async t => {
-    const [payer, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const sourceElgamalKeypair = new ElGamalKeypair();
-    const aesKey = new AeKey();
-
-    await t.throwsAsync(
-        () =>
-            getConfidentialTransferInstructionPlan({
-                payer,
-                rpc: createDefaultSolanaClient().rpc,
-                sourceToken: payer.address,
-                mint: owner.address,
-                destinationToken: payer.address,
-                sourceTokenAccount: {} as Token,
-                authority: owner,
-                amount: 1n,
-                sourceElgamalKeypair,
-                aesKey,
-                proofMode: 'instruction-data',
-            } as unknown as Parameters<typeof getConfidentialTransferInstructionPlan>[0]),
-        {
-            message: /instruction-data proof mode is unsupported/i,
         },
     );
 });

--- a/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
@@ -1,0 +1,91 @@
+import { generateKeyPairSigner } from '@solana/kit';
+import * as zk from '@solana/zk-sdk/node';
+import test from 'ava';
+import {
+    getConfidentialTransferInstructionPlan,
+    getConfidentialWithdrawInstructionPlan,
+    getCreateConfidentialTransferAccountInstructionPlan,
+    type Token,
+} from '../../../src';
+import { createDefaultSolanaClient } from '../../_setup';
+
+test('it rejects create helper authority that does not match the owner ATA flow', async t => {
+    const [payer, owner, delegatedAuthority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const elgamalKeypair = new zk.ElGamalKeypair();
+    const aesKey = new zk.AeKey();
+
+    await t.throwsAsync(
+        () =>
+            getCreateConfidentialTransferAccountInstructionPlan({
+                payer,
+                owner,
+                authority: delegatedAuthority,
+                mint: payer.address,
+                rpc: createDefaultSolanaClient().rpc,
+                zk,
+                elgamalKeypair,
+                aesKey,
+            }),
+        {
+            message: /authority must match owner/i,
+        },
+    );
+});
+
+test('it rejects instruction-data proof mode for confidential withdraw', async t => {
+    const [payer, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    const elgamalKeypair = new zk.ElGamalKeypair();
+    const aesKey = new zk.AeKey();
+
+    await t.throwsAsync(
+        () =>
+            getConfidentialWithdrawInstructionPlan({
+                payer,
+                rpc: createDefaultSolanaClient().rpc,
+                token: payer.address,
+                mint: owner.address,
+                tokenAccount: {} as Token,
+                authority: owner,
+                amount: 1n,
+                decimals: 0,
+                zk,
+                elgamalKeypair,
+                aesKey,
+                proofMode: 'instruction-data',
+            } as unknown as Parameters<typeof getConfidentialWithdrawInstructionPlan>[0]),
+        {
+            message: /instruction-data proof mode is unsupported/i,
+        },
+    );
+});
+
+test('it rejects instruction-data proof mode for confidential transfer', async t => {
+    const [payer, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    const sourceElgamalKeypair = new zk.ElGamalKeypair();
+    const aesKey = new zk.AeKey();
+
+    await t.throwsAsync(
+        () =>
+            getConfidentialTransferInstructionPlan({
+                payer,
+                rpc: createDefaultSolanaClient().rpc,
+                sourceToken: payer.address,
+                mint: owner.address,
+                destinationToken: payer.address,
+                sourceTokenAccount: {} as Token,
+                authority: owner,
+                amount: 1n,
+                zk,
+                sourceElgamalKeypair,
+                aesKey,
+                proofMode: 'instruction-data',
+            } as unknown as Parameters<typeof getConfidentialTransferInstructionPlan>[0]),
+        {
+            message: /instruction-data proof mode is unsupported/i,
+        },
+    );
+});

--- a/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
@@ -1,5 +1,5 @@
 import { generateKeyPairSigner } from '@solana/kit';
-import * as zk from '@solana/zk-sdk/node';
+import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import test from 'ava';
 import {
     getConfidentialTransferInstructionPlan,
@@ -15,8 +15,8 @@ test('it rejects create helper authority that does not match the owner ATA flow'
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
-    const elgamalKeypair = new zk.ElGamalKeypair();
-    const aesKey = new zk.AeKey();
+    const elgamalKeypair = new ElGamalKeypair();
+    const aesKey = new AeKey();
 
     await t.throwsAsync(
         () =>
@@ -26,7 +26,6 @@ test('it rejects create helper authority that does not match the owner ATA flow'
                 authority: delegatedAuthority,
                 mint: payer.address,
                 rpc: createDefaultSolanaClient().rpc,
-                zk,
                 elgamalKeypair,
                 aesKey,
             }),
@@ -38,8 +37,8 @@ test('it rejects create helper authority that does not match the owner ATA flow'
 
 test('it rejects instruction-data proof mode for confidential withdraw', async t => {
     const [payer, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const elgamalKeypair = new zk.ElGamalKeypair();
-    const aesKey = new zk.AeKey();
+    const elgamalKeypair = new ElGamalKeypair();
+    const aesKey = new AeKey();
 
     await t.throwsAsync(
         () =>
@@ -52,7 +51,6 @@ test('it rejects instruction-data proof mode for confidential withdraw', async t
                 authority: owner,
                 amount: 1n,
                 decimals: 0,
-                zk,
                 elgamalKeypair,
                 aesKey,
                 proofMode: 'instruction-data',
@@ -65,8 +63,8 @@ test('it rejects instruction-data proof mode for confidential withdraw', async t
 
 test('it rejects instruction-data proof mode for confidential transfer', async t => {
     const [payer, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const sourceElgamalKeypair = new zk.ElGamalKeypair();
-    const aesKey = new zk.AeKey();
+    const sourceElgamalKeypair = new ElGamalKeypair();
+    const aesKey = new AeKey();
 
     await t.throwsAsync(
         () =>
@@ -79,7 +77,6 @@ test('it rejects instruction-data proof mode for confidential transfer', async t
                 sourceTokenAccount: {} as Token,
                 authority: owner,
                 amount: 1n,
-                zk,
                 sourceElgamalKeypair,
                 aesKey,
                 proofMode: 'instruction-data',

--- a/clients/js/test/extensions/confidentialTransfer/confidentialWithdraw.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/confidentialWithdraw.test.ts
@@ -1,0 +1,96 @@
+import { address, generateKeyPairSigner, type AccountMeta } from '@solana/kit';
+import test from 'ava';
+import { getConfidentialWithdrawInstruction } from '../../../src';
+
+const SYSVAR_INSTRUCTIONS_ADDRESS = address('Sysvar1nstructions1111111111111111111111111');
+const NEW_DECRYPTABLE_BALANCE = new Uint8Array(36);
+
+test('it skips all optional accounts when both proofs are in context-state mode', async t => {
+    const [token, mint, equalityRecord, rangeRecord, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfidentialWithdrawInstruction({
+        token: token.address,
+        mint: mint.address,
+        equalityRecord: equalityRecord.address,
+        rangeRecord: rangeRecord.address,
+        authority,
+        amount: 1n,
+        decimals: 0,
+        newDecryptableAvailableBalance: NEW_DECRYPTABLE_BALANCE,
+        equalityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 0,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    // Layout when both proofs are pre-verified into context state: token, mint,
+    // equalityRecord, rangeRecord, authority. No sysvar in the accounts list.
+    t.is(accounts.length, 5);
+    t.is(accounts[0].address, token.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, equalityRecord.address);
+    t.is(accounts[3].address, rangeRecord.address);
+    t.is(accounts[4].address, authority.address);
+});
+
+test('it emits only the sysvar when both proofs are inline', async t => {
+    const [token, mint, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfidentialWithdrawInstruction({
+        token: token.address,
+        mint: mint.address,
+        instructionsSysvar: SYSVAR_INSTRUCTIONS_ADDRESS,
+        authority,
+        amount: 1n,
+        decimals: 0,
+        newDecryptableAvailableBalance: NEW_DECRYPTABLE_BALANCE,
+        equalityProofInstructionOffset: 1,
+        rangeProofInstructionOffset: 2,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 4);
+    t.is(accounts[0].address, token.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, SYSVAR_INSTRUCTIONS_ADDRESS);
+    t.is(accounts[3].address, authority.address);
+});
+
+test('it emits sysvar plus a single context-state account in mixed mode', async t => {
+    const [token, mint, equalityRecord, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfidentialWithdrawInstruction({
+        token: token.address,
+        mint: mint.address,
+        instructionsSysvar: SYSVAR_INSTRUCTIONS_ADDRESS,
+        equalityRecord: equalityRecord.address,
+        authority,
+        amount: 1n,
+        decimals: 0,
+        newDecryptableAvailableBalance: NEW_DECRYPTABLE_BALANCE,
+        equalityProofInstructionOffset: 0,
+        rangeProofInstructionOffset: 1,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 5);
+    t.is(accounts[0].address, token.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, SYSVAR_INSTRUCTIONS_ADDRESS);
+    t.is(accounts[3].address, equalityRecord.address);
+    t.is(accounts[4].address, authority.address);
+});

--- a/clients/js/test/extensions/confidentialTransfer/configureConfidentialTransferAccount.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/configureConfidentialTransferAccount.test.ts
@@ -1,0 +1,29 @@
+import { address, generateKeyPairSigner } from '@solana/kit';
+import test from 'ava';
+import { getConfigureConfidentialTransferAccountInstruction } from '../../../src';
+
+const SYSVAR_INSTRUCTIONS_ADDRESS = address('Sysvar1nstructions1111111111111111111111111');
+const DECRYPTABLE_ZERO_BALANCE = new Uint8Array(36);
+
+test('it emits exactly 4 accounts in inline-proof mode', async t => {
+    const [token, mint, authority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfigureConfidentialTransferAccountInstruction({
+        token: token.address,
+        mint: mint.address,
+        authority,
+        decryptableZeroBalance: DECRYPTABLE_ZERO_BALANCE,
+        maximumPendingBalanceCreditCounter: 65_536n,
+        proofInstructionOffset: 1,
+    });
+
+    t.is(instruction.accounts.length, 4);
+    t.is(instruction.accounts[0].address, token.address);
+    t.is(instruction.accounts[1].address, mint.address);
+    t.is(instruction.accounts[2].address, SYSVAR_INSTRUCTIONS_ADDRESS);
+    t.is(instruction.accounts[3].address, authority.address);
+});

--- a/clients/js/test/extensions/confidentialTransfer/configureConfidentialTransferAccountWithRegistry.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/configureConfidentialTransferAccountWithRegistry.test.ts
@@ -1,0 +1,87 @@
+import { address, generateKeyPairSigner, type AccountMeta } from '@solana/kit';
+import test from 'ava';
+import {
+    getConfigureConfidentialTransferAccountWithRegistryInstruction,
+    parseConfigureConfidentialTransferAccountWithRegistryInstruction,
+} from '../../../src';
+
+const SYSTEM_PROGRAM_ADDRESS = address('11111111111111111111111111111111');
+
+test('it encodes the 27/14 discriminator pair', async t => {
+    const [token, mint, elgamalRegistry] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfigureConfidentialTransferAccountWithRegistryInstruction({
+        token: token.address,
+        mint: mint.address,
+        elgamalRegistry: elgamalRegistry.address,
+    });
+
+    t.is(instruction.data[0], 27);
+    t.is(instruction.data[1], 14);
+    t.is(instruction.data.length, 2);
+});
+
+test('it emits a 3-account layout when payer and systemProgram are omitted', async t => {
+    const [token, mint, elgamalRegistry] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfigureConfidentialTransferAccountWithRegistryInstruction({
+        token: token.address,
+        mint: mint.address,
+        elgamalRegistry: elgamalRegistry.address,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 3);
+    t.is(accounts[0].address, token.address);
+    t.is(accounts[1].address, mint.address);
+    t.is(accounts[2].address, elgamalRegistry.address);
+});
+
+test('it emits a 5-account layout when payer is provided', async t => {
+    const [token, mint, elgamalRegistry, payer] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfigureConfidentialTransferAccountWithRegistryInstruction({
+        token: token.address,
+        mint: mint.address,
+        elgamalRegistry: elgamalRegistry.address,
+        payer,
+        systemProgram: SYSTEM_PROGRAM_ADDRESS,
+    });
+    const accounts = instruction.accounts as readonly AccountMeta[];
+
+    t.is(accounts.length, 5);
+    t.is(accounts[3].address, payer.address);
+    t.is(accounts[4].address, SYSTEM_PROGRAM_ADDRESS);
+});
+
+test('it round-trips through parse', async t => {
+    const [token, mint, elgamalRegistry] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    const instruction = getConfigureConfidentialTransferAccountWithRegistryInstruction({
+        token: token.address,
+        mint: mint.address,
+        elgamalRegistry: elgamalRegistry.address,
+    });
+    const parsed = parseConfigureConfidentialTransferAccountWithRegistryInstruction(instruction);
+
+    t.is(parsed.accounts.token.address, token.address);
+    t.is(parsed.accounts.mint.address, mint.address);
+    t.is(parsed.accounts.elgamalRegistry.address, elgamalRegistry.address);
+});

--- a/clients/js/test/extensions/confidentialTransfer/getApplyConfidentialPendingBalanceInstructionFromToken.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getApplyConfidentialPendingBalanceInstructionFromToken.test.ts
@@ -1,0 +1,49 @@
+import test from 'ava';
+import {
+    fetchToken,
+    getApplyConfidentialPendingBalanceInstructionFromToken,
+    getConfidentialDepositInstruction,
+    getMintToInstruction,
+} from '../../../src';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccount,
+    createDefaultSolanaClient,
+    fetchAssociatedToken,
+    generateKeyPairSignerWithSol,
+    getTokenExtension,
+    sendAndConfirmInstructions,
+} from '../../_setup';
+
+test('it applies the pending balance to the available balance', async t => {
+    // Given a confidential token account with a deposited (pending) balance.
+    const client = createDefaultSolanaClient();
+    const owner = await generateKeyPairSignerWithSol(client);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer: owner });
+    const decimals = 2;
+    const account = await createConfidentialTokenAccount({ client, payer: owner, owner, mint });
+    await sendAndConfirmInstructions(client, owner, [
+        getMintToInstruction({ mint, token: account.token, mintAuthority, amount: 1000n }),
+        getConfidentialDepositInstruction({ token: account.token, mint, authority: owner, amount: 1000n, decimals }),
+    ]);
+
+    // When we apply the pending balance.
+    const { data: tokenAccount } = await fetchToken(client.rpc, account.token);
+    await sendAndConfirmInstructions(client, owner, [
+        getApplyConfidentialPendingBalanceInstructionFromToken({
+            token: account.token,
+            tokenAccount,
+            authority: owner,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }),
+    ]);
+
+    // Then the pending balance is consumed: its credit counter resets to zero
+    // while the expected and actual applied counters reflect the single deposit.
+    const updated = await fetchAssociatedToken(client, owner.address, mint);
+    const confidentialAccount = getTokenExtension(updated, 'ConfidentialTransferAccount');
+    t.is(confidentialAccount.pendingBalanceCreditCounter, 0n);
+    t.is(confidentialAccount.expectedPendingBalanceCreditCounter, 1n);
+    t.is(confidentialAccount.actualPendingBalanceCreditCounter, 1n);
+});

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
@@ -1,0 +1,62 @@
+import test from 'ava';
+import { fetchToken, getConfidentialTransferInstructionPlan } from '../../../src';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccount,
+    createConfidentialTokenAccountWithBalance,
+    createDefaultSolanaClient,
+    fetchAssociatedToken,
+    generateKeyPairSignerWithSol,
+    getTokenExtension,
+    sendAndConfirmInstructionPlan,
+} from '../../_setup';
+
+test('it transfers tokens confidentially between two accounts', async t => {
+    // Given a funded source account and an empty destination account.
+    const client = createDefaultSolanaClient();
+    const [payer, sourceOwner, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
+    const decimals = 2;
+    const source = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner: sourceOwner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const destination = await createConfidentialTokenAccount({ client, payer, owner: destinationOwner, mint });
+
+    // When the source confidentially transfers part of its balance to the destination.
+    const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }] = await Promise.all([
+        fetchToken(client.rpc, source.token),
+        fetchToken(client.rpc, destination.token),
+    ]);
+    await sendAndConfirmInstructionPlan(
+        client,
+        payer,
+        await getConfidentialTransferInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            sourceToken: source.token,
+            mint,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            authority: sourceOwner,
+            amount: 600n,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+        }),
+    );
+
+    // Then the destination account received a confidential credit in its pending balance.
+    const updatedDestination = await fetchAssociatedToken(client, destinationOwner.address, mint);
+    const destinationConfidential = getTokenExtension(updatedDestination, 'ConfidentialTransferAccount');
+    t.is(destinationConfidential.pendingBalanceCreditCounter, 1n);
+});

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialWithdrawInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialWithdrawInstructionPlan.test.ts
@@ -1,0 +1,52 @@
+import test from 'ava';
+import { fetchToken, getConfidentialWithdrawInstructionPlan } from '../../../src';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccountWithBalance,
+    createDefaultSolanaClient,
+    generateKeyPairSignerWithSol,
+    sendAndConfirmInstructionPlan,
+} from '../../_setup';
+
+test('it withdraws tokens from a confidential balance', async t => {
+    // Given a confidential token account funded with an available confidential balance.
+    const client = createDefaultSolanaClient();
+    const [payer, owner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
+    const decimals = 2;
+    const account = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+
+    // When we withdraw part of the confidential balance back to the public balance.
+    const { data: tokenAccount } = await fetchToken(client.rpc, account.token);
+    await sendAndConfirmInstructionPlan(
+        client,
+        payer,
+        await getConfidentialWithdrawInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: account.token,
+            mint,
+            tokenAccount,
+            authority: owner,
+            amount: 400n,
+            decimals,
+            elgamalKeypair: account.elgamalKeypair,
+            aesKey: account.aesKey,
+        }),
+    );
+
+    // Then the withdrawn amount is reflected in the public token balance.
+    const { data: updated } = await fetchToken(client.rpc, account.token);
+    t.is(updated.amount, 400n);
+});

--- a/clients/js/test/extensions/confidentialTransfer/getCreateConfidentialTransferAccountInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getCreateConfidentialTransferAccountInstructionPlan.test.ts
@@ -1,0 +1,26 @@
+import test from 'ava';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccount,
+    createDefaultSolanaClient,
+    fetchAssociatedToken,
+    generateKeyPairSignerWithSol,
+    getTokenExtension,
+} from '../../_setup';
+
+test('it configures a token account for confidential transfers', async t => {
+    // Given a confidential transfer mint and an account owner.
+    const client = createDefaultSolanaClient();
+    const owner = await generateKeyPairSignerWithSol(client);
+    const { mint } = await createConfidentialMint({ client, payer: owner });
+
+    // When we create and configure an associated token account for confidential transfers.
+    await createConfidentialTokenAccount({ client, payer: owner, owner, mint });
+
+    // Then the token account has an approved ConfidentialTransferAccount extension.
+    const tokenAccount = await fetchAssociatedToken(client, owner.address, mint);
+    const confidentialAccount = getTokenExtension(tokenAccount, 'ConfidentialTransferAccount');
+    t.true(confidentialAccount.approved);
+    t.true(confidentialAccount.allowConfidentialCredits);
+    t.true(confidentialAccount.allowNonConfidentialCredits);
+});

--- a/clients/js/tsconfig.json
+++ b/clients/js/tsconfig.json
@@ -9,7 +9,7 @@
         "inlineSources": false,
         "isolatedModules": true,
         "module": "ESNext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "noFallthroughCasesInSwitch": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

Adds handwritten JavaScript helper plans for confidential mint/burn flows:

- `getConfidentialMintInstructionPlan`
- `getConfidentialBurnInstructionPlan`
- `getPermissionedConfidentialBurnInstructionPlan`
- `getApplyConfidentialPendingBurnInstructionPlan`

& tests