### PR TITLE
cli: Support permissioned burn authority in burn

### DIFF
--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -1541,6 +1541,17 @@ pub fn app<'a>(
                             Defaults to the client keypair.",
                         ),
                 )
+                .arg(
+                    Arg::with_name("permissioned_burn_authority")
+                        .long("permissioned-burn-authority")
+                        .value_name("KEYPAIR")
+                        .validator(|s| is_valid_signer(s))
+                        .takes_value(true)
+                        .help(
+                            "Specify the permissioned burn authority keypair. \
+                             This may be a keypair file or the ASK keyword."
+                        ),
+                )
                 .arg(multisig_signer_arg())
                 .mint_args()
                 .nonce_args(true)

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -1810,6 +1810,7 @@ async fn command_burn(
     mint_address: Option<Pubkey>,
     mint_decimals: Option<u8>,
     use_unchecked_instruction: bool,
+    permissioned_burn_authority: Option<Pubkey>,
     memo: Option<String>,
     bulk_signers: BulkSigners,
 ) -> CommandResult {
@@ -1851,7 +1852,13 @@ async fn command_burn(
         token.with_memo(text, vec![config.default_signer()?.pubkey()]);
     }
 
-    let res = token.burn(&account, &owner, amount, &bulk_signers).await?;
+    let res = if let Some(authority) = permissioned_burn_authority {
+        token
+            .permissioned_burn(&account, &authority, &owner, amount, &bulk_signers)
+            .await?
+    } else {
+        token.burn(&account, &owner, amount, &bulk_signers).await?
+    };
 
     let tx_return = finish_tx(config, &res, false).await?;
     Ok(match tx_return {
@@ -4250,6 +4257,15 @@ pub async fn process_command(
 
             let (owner_signer, owner) =
                 config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            let permissioned_burn_authority = get_signer(
+                arg_matches,
+                "permissioned_burn_authority",
+                &mut wallet_manager,
+            )
+            .map(|(signer, authority)| {
+                push_signer_with_dedup(signer, &mut bulk_signers);
+                authority
+            });
             if config.multisigner_pubkeys.is_empty() {
                 push_signer_with_dedup(owner_signer, &mut bulk_signers);
             }
@@ -4270,6 +4286,7 @@ pub async fn process_command(
                 mint_address,
                 mint_decimals,
                 use_unchecked_instruction,
+                permissioned_burn_authority,
                 memo,
                 bulk_signers,
             )

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -4822,10 +4822,13 @@ async fn permissioned_burn(test_validator: &TestValidator, payer: &Keypair) {
         test_config_with_default_signer(test_validator, payer, &spl_token_2022_interface::id());
 
     let token = Keypair::new();
-    let burn_authority = Keypair::new();
     let token_keypair_file = NamedTempFile::new().unwrap();
     write_keypair_file(&token, &token_keypair_file).unwrap();
-    let token_pubkey = token.pubkey();
+    let token = token.pubkey();
+
+    let burn_authority = Keypair::new();
+    let burn_authority_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&burn_authority, &burn_authority_keypair_file).unwrap();
 
     process_test_command(
         &config,
@@ -4841,11 +4844,33 @@ async fn permissioned_burn(test_validator: &TestValidator, payer: &Keypair) {
     .await
     .unwrap();
 
-    let account = config.rpc_client.get_account(&token_pubkey).await.unwrap();
+    let account = config.rpc_client.get_account(&token).await.unwrap();
     let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
     let extension = test_mint.get_extension::<PermissionedBurnConfig>().unwrap();
     assert_eq!(
         Option::<Pubkey>::from(extension.authority),
         Some(burn_authority.pubkey())
     );
+
+    // do a burn
+    let source = create_associated_account(&config, payer, &token, &payer.pubkey()).await;
+    let ui_amount = 100.0;
+    mint_tokens(&config, payer, token, ui_amount, source)
+        .await
+        .unwrap();
+
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Burn.into(),
+            &source.to_string(),
+            "10",
+            "--permissioned-burn-authority",
+            burn_authority_keypair_file.path().to_str().unwrap(),
+        ],
+    )
+    .await
+    .unwrap();
 }

--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -1295,6 +1295,44 @@ where
         self.process_ixs(&instructions, signing_keypairs).await
     }
 
+    /// Burn tokens from account with permissioned burn authority
+    pub async fn permissioned_burn<S: Signers>(
+        &self,
+        source: &Address,
+        permissioned_burn_authority: &Address,
+        authority: &Address,
+        amount: u64,
+        signing_keypairs: &S,
+    ) -> TokenResult<T::Output> {
+        let signing_pubkeys = signing_keypairs.pubkeys();
+        let multisig_signers = self.get_multisig_signers(authority, &signing_pubkeys);
+
+        let instructions = if let Some(decimals) = self.decimals {
+            [permissioned_burn::instruction::burn_checked(
+                &self.program_id,
+                source,
+                &self.pubkey,
+                permissioned_burn_authority,
+                authority,
+                &multisig_signers,
+                amount,
+                decimals,
+            )?]
+        } else {
+            [permissioned_burn::instruction::burn(
+                &self.program_id,
+                source,
+                &self.pubkey,
+                permissioned_burn_authority,
+                authority,
+                &multisig_signers,
+                amount,
+            )?]
+        };
+
+        self.process_ixs(&instructions, signing_keypairs).await
+    }
+
     /// Approve a delegate to spend tokens
     pub async fn approve<S: Signers>(
         &self,


### PR DESCRIPTION
#### Problem

The permissioned burn extension exists, and can be created in the CLI, but there's no way to burn with an authority in the CLI.

#### Summary of changes

Add a helper function in the token client, and use it in the CLI.

cc @gitteri 