### PR TITLE
interface: add allocation-free account length helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11001,6 +11001,7 @@ dependencies = [
  "spl-type-length-value",
  "strum 0.28.0",
  "strum_macros 0.28.0",
+ "test-case",
  "thiserror 2.0.18",
 ]
 

--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -882,6 +882,7 @@ where
     ) -> TokenResult<T::Output> {
         let state = self.get_mint_info().await?;
         let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
+        #[allow(deprecated)]
         let mut required_extensions =
             ExtensionType::get_required_init_account_extensions(&mint_extensions);
         for extension_type in extensions.into_iter() {

--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -56,6 +56,7 @@ use {
     spl_token_2022::offchain,
     spl_token_2022_interface::{
         extension::{
+            account_len::try_for_each_required_init_account_extension,
             confidential_mint_burn::{self, ConfidentialMintBurn},
             confidential_transfer::{self, ConfidentialTransferAccount, DecryptableBalance},
             confidential_transfer_fee::{
@@ -881,10 +882,11 @@ where
         extensions: Vec<ExtensionType>,
     ) -> TokenResult<T::Output> {
         let state = self.get_mint_info().await?;
-        let mint_extensions: Vec<ExtensionType> = state.get_extension_types()?;
-        #[allow(deprecated)]
-        let mut required_extensions =
-            ExtensionType::get_required_init_account_extensions(&mint_extensions);
+        let mut required_extensions = Vec::new();
+        try_for_each_required_init_account_extension(state.get_tlv_data(), |extension_type| {
+            required_extensions.push(extension_type);
+            Ok(())
+        })?;
         for extension_type in extensions.into_iter() {
             if !required_extensions.contains(&extension_type) {
                 required_extensions.push(extension_type);

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -50,6 +50,7 @@ spl-token-2022-interface = { path = ".", features = ["serde"] }
 spl-token-interface = { version = "3.0" }
 strum = "0.28"
 strum_macros = "0.28"
+test-case = "3.3.1"
 
 [lib]
 crate-type = ["lib"]

--- a/interface/src/extension/account_len.rs
+++ b/interface/src/extension/account_len.rs
@@ -1,141 +1,125 @@
 use {
     super::{
-        adjust_len_for_multisig, try_for_each_tlv_extension_type, AccountType,
-        BaseStateWithExtensions, ExtensionType, PodStateWithExtensions,
-        BASE_ACCOUNT_AND_TYPE_LENGTH,
+        try_for_each_tlv_extension_type, AccountType, BaseStateWithExtensions, ExtensionType,
+        PodStateWithExtensions,
     },
-    crate::{
-        check_program_account,
-        error::TokenError,
-        pod::PodMint,
-        state::{Account, PackedSizeOf},
-    },
-    solana_address::Address,
+    crate::{error::TokenError, pod::PodMint, state::Account},
     solana_program_error::ProgramError,
 };
 
-/// Must stay at or above the number of `AccountType::Account` extension types that exist,
-/// which is verified by the capacity test in this module. Note there are currently only 9
-/// `AccountType::Account` extension types today but the added slack makes updates easier
-/// on external consumers.
-const SEEN_ACCOUNT_EXTENSIONS_CAPACITY: usize = 24;
+/// Must stay at or above the total number of `ExtensionType`s that exist, which is verified
+/// by the capacity test in this module
+pub(crate) const EXTENSION_TYPE_BUFFER_CAPACITY: usize = 50;
 
-/// A small fixed-capacity set that records which account extension types have already
-/// been counted toward an account length.
-#[derive(Debug, Default)]
-struct SeenAccountExtensions {
-    /// The recorded extension types, filled from the front. Only the first `count` slots
-    /// are occupied, the rest remain `None`
-    seen: [Option<ExtensionType>; SEEN_ACCOUNT_EXTENSIONS_CAPACITY],
+/// A fixed-capacity unique list of extension types. A no-alloc version of a set.
+#[derive(Debug)]
+pub(crate) struct ExtensionTypeBuffer {
+    /// The recorded extension types, filled from the front. Slots past `count` are unused
+    /// and hold `Uninitialized` as filler
+    types: [ExtensionType; EXTENSION_TYPE_BUFFER_CAPACITY],
     /// How many slots are occupied
     count: usize,
 }
 
-impl SeenAccountExtensions {
-    /// Records an extension type, returning `true` if it was new and `false` if it
-    /// was already in the set
-    fn insert(&mut self, extension_type: ExtensionType) -> Result<bool, ProgramError> {
-        if self.seen[..self.count].contains(&Some(extension_type)) {
-            return Ok(false);
+impl Default for ExtensionTypeBuffer {
+    fn default() -> Self {
+        Self {
+            types: [ExtensionType::Uninitialized; EXTENSION_TYPE_BUFFER_CAPACITY],
+            count: 0,
+        }
+    }
+}
+
+impl ExtensionTypeBuffer {
+    /// Records the extension type unless it is already present
+    pub(crate) fn insert(&mut self, extension_type: ExtensionType) -> Result<(), ProgramError> {
+        if self.types().contains(&extension_type) {
+            return Ok(());
         }
 
         // Not seen, so take the next free slot
         let slot = self
-            .seen
+            .types
             .get_mut(self.count)
             .ok_or(ProgramError::InvalidAccountData)?;
-        *slot = Some(extension_type);
+        *slot = extension_type;
         self.count = self.count.saturating_add(1);
 
-        Ok(true)
+        Ok(())
     }
 
-    fn is_empty(&self) -> bool {
-        self.count == 0
+    /// The recorded extension types in insertion order
+    pub(crate) fn types(&self) -> &[ExtensionType] {
+        &self.types[..self.count]
     }
 }
 
-/// Calculate the account length for a token account of the given initialized mint,
-/// with `additional_account_extensions` requested on top of the account extensions
-/// required by the mint.
+/// Visit the account extensions that `InitializeAccount` must create for the given mint TLV
+/// data, in TLV order. The allocation-free equivalent of calling `f` on
+/// [`ExtensionType::get_required_init_account_extensions`]
+pub fn try_for_each_required_init_account_extension<F>(
+    mint_tlv_data: &[u8],
+    mut f: F,
+) -> Result<(), ProgramError>
+where
+    F: FnMut(ExtensionType) -> Result<(), ProgramError>,
+{
+    try_for_each_tlv_extension_type(mint_tlv_data, |mint_extension_type| {
+        for &extension_type in mint_extension_type.required_init_account_extensions() {
+            f(extension_type)?;
+        }
+        Ok(())
+    })
+    .map(|_| ())
+}
+
+/// Calculate the account length for a token account of the given mint data, with
+/// `additional_account_extensions` requested on top of the account extensions the mint requires.
 pub fn try_calculate_account_len_from_mint_data(
-    token_program_id: &Address,
     mint_data: &[u8],
     additional_account_extensions: &[ExtensionType],
 ) -> Result<usize, ProgramError> {
-    check_account_extensions(additional_account_extensions)?;
-    check_program_account(token_program_id)?;
+    if additional_account_extensions
+        .iter()
+        .any(|&extension_type| extension_type.get_account_type() != AccountType::Account)
+    {
+        return Err(TokenError::ExtensionTypeMismatch.into());
+    }
 
-    let mint = PodStateWithExtensions::<PodMint>::unpack(mint_data)
+    let state = PodStateWithExtensions::<PodMint>::unpack(mint_data)
         .map_err(|_| TokenError::InvalidMint)?;
 
-    // Tracks already counted extension types so overlap between the requested extensions
-    // and the mint's required ones is only sized once
-    let mut seen = SeenAccountExtensions::default();
-
-    let mut total_tlv_len: usize = 0;
-
-    // Sum the TLV lengths of the requested account extensions
-    for &extension_type in additional_account_extensions {
-        if seen.insert(extension_type)? {
-            total_tlv_len = total_tlv_len.saturating_add(extension_type.try_get_tlv_len()?);
-        }
-    }
-
-    // Walk the mint's extensions, summing the TLV lengths of the account extensions
-    // each one requires
-    try_for_each_tlv_extension_type(mint.get_tlv_data(), |mint_extension_type| {
-        for &extension_type in mint_extension_type.required_init_account_extensions() {
-            if seen.insert(extension_type)? {
-                total_tlv_len = total_tlv_len.saturating_add(extension_type.try_get_tlv_len()?);
-            }
-        }
-        Ok(())
+    // Collect the account extensions the mint requires
+    let mut account_extensions = ExtensionTypeBuffer::default();
+    try_for_each_required_init_account_extension(state.get_tlv_data(), |extension_type| {
+        account_extensions.insert(extension_type)
     })?;
 
-    // With no extensions, the account stays at the base size
-    if seen.is_empty() {
-        Ok(Account::SIZE_OF)
-    } else {
-        // Extensions follow the base account data and account type byte
-        let total_len = total_tlv_len.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH);
-        // the total length must be padded if it collides with `Multisig::LEN`
-        Ok(adjust_len_for_multisig(total_len))
+    // Add the requested ones. `insert` dedupes, so overlap with the required
+    // extensions is only sized once.
+    for &extension_type in additional_account_extensions {
+        account_extensions.insert(extension_type)?;
     }
-}
 
-/// Check that every extension type is an `AccountType::Account` extension
-fn check_account_extensions(account_extensions: &[ExtensionType]) -> Result<(), ProgramError> {
-    for extension_type in account_extensions {
-        if extension_type.get_account_type() != AccountType::Account {
-            return Err(TokenError::ExtensionTypeMismatch.into());
-        }
-    }
-    Ok(())
+    ExtensionType::try_calculate_account_len::<Account>(account_extensions.types())
 }
 
 #[cfg(test)]
 mod tests {
     use {
-        super::super::{
-            transfer_fee::TransferFeeConfig, BaseStateWithExtensionsMut, StateWithExtensionsMut,
-            BASE_ACCOUNT_LENGTH,
+        super::{
+            super::{
+                AccountType, BaseStateWithExtensions, PodStateWithExtensions, BASE_ACCOUNT_LENGTH,
+            },
+            *,
         },
-        super::*,
-        crate::state::{test::TEST_MINT_SLICE, Mint, Multisig},
+        crate::state::{test::TEST_MINT_SLICE, Mint, Multisig, PackedSizeOf},
         alloc::{vec, vec::Vec},
         core::mem::size_of,
-        proptest::prelude::*,
         solana_program_pack::Pack,
         strum::IntoEnumIterator,
         test_case::test_case,
     };
-
-    fn all_account_extensions() -> Vec<ExtensionType> {
-        ExtensionType::iter()
-            .filter(|extension_type| extension_type.get_account_type() == AccountType::Account)
-            .collect()
-    }
 
     fn push_tlv_entry(data: &mut Vec<u8>, extension_type: ExtensionType, value_len: usize) {
         data.extend_from_slice(&u16::from(extension_type).to_le_bytes());
@@ -153,211 +137,103 @@ mod tests {
         data
     }
 
-    /// The legacy sizing code path formerly used by `GetAccountDataSize`
-    /// which the new helper must match exactly
-    fn legacy_account_len(
-        mint_data: &[u8],
-        additional_account_extensions: &[ExtensionType],
-    ) -> Result<usize, ProgramError> {
-        let state = PodStateWithExtensions::<PodMint>::unpack(mint_data)
-            .map_err(|_| TokenError::InvalidMint)?;
-        let mut account_extensions =
-            ExtensionType::get_required_init_account_extensions(&state.get_extension_types()?);
-        account_extensions.extend_from_slice(additional_account_extensions);
-        ExtensionType::try_calculate_account_len::<Account>(&account_extensions)
-    }
-
-    fn assert_matches_legacy_sizing(
-        mint_data: &[u8],
-        additional_account_extensions: &[ExtensionType],
-    ) {
-        assert_eq!(
-            try_calculate_account_len_from_mint_data(
-                &crate::id(),
-                mint_data,
-                additional_account_extensions,
-            ),
-            legacy_account_len(mint_data, additional_account_extensions),
-        );
-    }
-
     #[test_case(
-        TEST_MINT_SLICE.to_vec(), &[];
+        TEST_MINT_SLICE.to_vec(), &[],
+        Account::SIZE_OF;
         "mint with no extensions"
     )]
     #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]), &[],
+        Account::SIZE_OF;
+        "account extension inside mint tlv"
+    )]
+    // 165 base + 1 account type + (4 header + 0 `ImmutableOwner`) + (4 header + 1
+    // `MemoTransfer`) + (4 header + 1 `CpiGuard`)
+    #[test_case(
         TEST_MINT_SLICE.to_vec(),
-        &[ExtensionType::ImmutableOwner, ExtensionType::MemoTransfer, ExtensionType::CpiGuard];
+        &[
+            ExtensionType::ImmutableOwner,
+            ExtensionType::MemoTransfer,
+            ExtensionType::CpiGuard,
+        ],
+        180;
         "standalone account extensions"
     )]
-    #[test_case(
-        mint_data_with_tlv_entries(&[
-            (ExtensionType::TransferFeeConfig, 0),
-            (ExtensionType::MintCloseAuthority, 0),
-            (ExtensionType::DefaultAccountState, 0),
-            (ExtensionType::NonTransferable, 0),
-        ]),
-        &[];
-        "multiple mint extensions"
-    )]
-    #[test_case(
-        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]), &[];
-        "account extension inside mint tlv is ignored"
-    )]
+    // 165 base + 1 account type + (4 header + 0 `NonTransferableAccount`) + (4 header + 0
+    // `ImmutableOwner`)
     #[test_case(
         mint_data_with_tlv_entries(&[(ExtensionType::NonTransferable, 0)]),
         &[
             ExtensionType::ImmutableOwner,
             ExtensionType::NonTransferableAccount,
             ExtensionType::ImmutableOwner,
-        ];
-        "required and additional extensions overlap"
+        ],
+        174;
+        "requested extensions overlap required ones"
     )]
     #[test_case(
         mint_data_with_tlv_entries(&[
             (ExtensionType::NonTransferable, 0),
             (ExtensionType::NonTransferable, 0),
         ]),
-        &[];
+        &[],
+        174;
         "duplicate mint extensions"
     )]
     #[test_case(
-        mint_data_with_tlv_entries(&[
-            (ExtensionType::TransferFeeConfig, 0),
-            (ExtensionType::NonTransferable, 0),
-            (ExtensionType::TransferHook, 0),
-            (ExtensionType::Pausable, 0),
-        ]),
-        &all_account_extensions();
-        "every account extension at once"
-    )]
-    fn matches_legacy_sizing(mint_data: Vec<u8>, additional_account_extensions: &[ExtensionType]) {
-        assert_matches_legacy_sizing(&mint_data, additional_account_extensions);
-    }
-
-    #[test_case(
-        TEST_MINT_SLICE.to_vec();
-        "mint with no extensions"
+        mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 5)]), &[],
+        178;
+        "declared tlv value length is ignored"
     )]
     #[test_case(
-        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]);
-        "account extension inside mint tlv"
+        {
+            let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
+            data.push(0);
+            data
+        },
+        &[],
+        178;
+        "trailing realloc byte is ignored"
     )]
-    fn sizes_to_exactly_the_base_account_len(mint_data: Vec<u8>) {
+    #[test_case(
+        {
+            let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
+            data.extend_from_slice(&u16::from(ExtensionType::Uninitialized).to_le_bytes());
+            data.extend_from_slice(&[0xff; 7]);
+            data
+        },
+        &[],
+        178;
+        "bytes after uninitialized terminator are ignored"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::MintPaddingTest, 0)]), &[],
+        Multisig::LEN + size_of::<ExtensionType>();
+        "multisig len from mint extension is padded"
+    )]
+    #[test_case(
+        TEST_MINT_SLICE.to_vec(), &[ExtensionType::AccountPaddingTest],
+        Multisig::LEN + size_of::<ExtensionType>();
+        "multisig len from requested extension is padded"
+    )]
+    fn sizes_to_known_len(
+        mint_data: Vec<u8>,
+        additional_account_extensions: &[ExtensionType],
+        expected_len: usize,
+    ) {
         assert_eq!(
-            try_calculate_account_len_from_mint_data(&crate::id(), &mint_data, &[]).unwrap(),
-            Account::SIZE_OF,
-        );
-    }
-
-    #[test]
-    fn real_mint_data_sizes_to_known_len() {
-        // A wrong TLV layout assumption shared by the test fixtures and the sizing code would
-        // cancel out and pass. So here we test a hand-computed length
-        let space =
-            ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
-                .unwrap();
-        let mut mint_data = vec![0; space];
-        let mut state =
-            StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
-        state.init_extension::<TransferFeeConfig>(true).unwrap();
-        state.base = Mint {
-            is_initialized: true,
-            ..Mint::default()
-        };
-        state.pack_base();
-        state.init_account_type().unwrap();
-
-        assert_matches_legacy_sizing(&mint_data, &[ExtensionType::ImmutableOwner]);
-
-        // 165 base + 1 account type + (4 header + 8 `TransferFeeAmount`) + (4 header + 0
-        // `ImmutableOwner`)
-        assert_eq!(
-            try_calculate_account_len_from_mint_data(
-                &crate::id(),
-                &mint_data,
-                &[ExtensionType::ImmutableOwner],
-            )
-            .unwrap(),
-            182,
-        );
-    }
-
-    #[test]
-    fn multisig_len_adjustment_matches_legacy_sizing() {
-        // The padding test extensions exist to push the account length to exactly `Multisig::LEN`,
-        // which must be adjusted by two bytes
-        let mint_data = mint_data_with_tlv_entries(&[(ExtensionType::MintPaddingTest, 0)]);
-        assert_matches_legacy_sizing(&mint_data, &[]);
-        assert_eq!(
-            try_calculate_account_len_from_mint_data(&crate::id(), &mint_data, &[]).unwrap(),
-            Multisig::LEN.saturating_add(size_of::<ExtensionType>()),
-        );
-
-        assert_matches_legacy_sizing(TEST_MINT_SLICE, &[ExtensionType::AccountPaddingTest]);
-    }
-
-    #[test]
-    fn declared_tlv_value_length_is_ignored_for_sizing() {
-        // Summing the declared value lengths instead of the canonical per-type lengths would
-        // pass every well-formed test. So here the entry lies about its length and must size
-        // identically to one that does not.
-        let lying_length = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 5)]);
-        let zero_length = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
-        assert_matches_legacy_sizing(&lying_length, &[]);
-        assert_eq!(
-            try_calculate_account_len_from_mint_data(&crate::id(), &lying_length, &[]),
-            try_calculate_account_len_from_mint_data(&crate::id(), &zero_length, &[]),
-        );
-    }
-
-    #[test]
-    fn trailing_realloc_byte_ends_the_walk() {
-        // A single trailing byte that cannot hold another TLV entry marks the end of the data
-        // rather than malforming it
-        let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
-        data.push(0);
-        assert_matches_legacy_sizing(&data, &[]);
-        assert!(try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]).is_ok());
-    }
-
-    #[test]
-    fn bytes_after_uninitialized_terminator_are_ignored() {
-        // An `Uninitialized` entry terminates the walk, anything after it is never read
-        let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
-        data.extend_from_slice(&u16::from(ExtensionType::Uninitialized).to_le_bytes());
-        data.extend_from_slice(&[0xff; 7]);
-        assert_matches_legacy_sizing(&data, &[]);
-        assert!(try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]).is_ok());
-    }
-
-    #[test_case(ExtensionType::TransferFeeConfig; "mint extension")]
-    #[test_case(ExtensionType::Uninitialized; "uninitialized")]
-    fn rejects_non_account_additional_extension(extension_type: ExtensionType) {
-        assert_eq!(
-            try_calculate_account_len_from_mint_data(
-                &crate::id(),
-                TEST_MINT_SLICE,
-                &[extension_type],
-            ),
-            Err(TokenError::ExtensionTypeMismatch.into()),
-        );
-    }
-
-    #[test]
-    fn rejects_wrong_token_program_id() {
-        assert_eq!(
-            try_calculate_account_len_from_mint_data(&Address::default(), TEST_MINT_SLICE, &[]),
-            Err(ProgramError::IncorrectProgramId),
+            try_calculate_account_len_from_mint_data(&mint_data, additional_account_extensions)
+                .unwrap(),
+            expected_len,
         );
     }
 
     #[test_case(
-        vec![], &[ExtensionType::ImmutableOwner];
+        vec![];
         "empty mint data"
     )]
     #[test_case(
-        vec![0; Mint::LEN], &[];
+        vec![0; Mint::LEN];
         "uninitialized mint"
     )]
     #[test_case(
@@ -365,79 +241,98 @@ mod tests {
             let mut data = mint_data_with_tlv_entries(&[]);
             data.resize(Multisig::LEN, 0);
             data
-        },
-        &[];
+        };
         "mint data of multisig len"
     )]
-    fn rejects_invalid_mint_data(
-        mint_data: Vec<u8>,
-        additional_account_extensions: &[ExtensionType],
-    ) {
-        assert_matches_legacy_sizing(&mint_data, additional_account_extensions);
+    fn rejects_invalid_mint_data(mint_data: Vec<u8>) {
         assert_eq!(
-            try_calculate_account_len_from_mint_data(
-                &crate::id(),
-                &mint_data,
-                additional_account_extensions,
-            ),
+            try_calculate_account_len_from_mint_data(&mint_data, &[]),
             Err(TokenError::InvalidMint.into()),
         );
     }
 
-    #[test]
-    fn truncated_tlv_entry_is_invalid_account_data() {
-        // A type with only one byte after it cannot hold the entry's length
-        let mut data = mint_data_with_tlv_entries(&[]);
-        data.extend_from_slice(&u16::from(ExtensionType::TransferFeeConfig).to_le_bytes());
-        data.push(0);
-        assert_matches_legacy_sizing(&data, &[]);
+    #[test_case(ExtensionType::TransferFeeConfig; "mint extension")]
+    #[test_case(ExtensionType::Uninitialized; "uninitialized")]
+    fn rejects_non_account_additional_extension(extension_type: ExtensionType) {
         assert_eq!(
-            try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]),
+            try_calculate_account_len_from_mint_data(TEST_MINT_SLICE, &[extension_type]),
+            Err(TokenError::ExtensionTypeMismatch.into()),
+        );
+    }
+
+    #[test_case(
+        {
+            let mut tail = u16::from(ExtensionType::TransferFeeConfig).to_le_bytes().to_vec();
+            tail.push(0);
+            tail
+        };
+        "entry truncated after its type"
+    )]
+    #[test_case(
+        [999u16.to_le_bytes(), 0u16.to_le_bytes()].concat();
+        "unknown extension type"
+    )]
+    fn malformed_tlv_tail_is_invalid_account_data(tail: Vec<u8>) {
+        let mut data = mint_data_with_tlv_entries(&[]);
+        data.extend_from_slice(&tail);
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&data, &[]),
             Err(ProgramError::InvalidAccountData),
         );
     }
 
     #[test]
-    fn unknown_mint_extension_is_invalid_account_data() {
-        let mut data = mint_data_with_tlv_entries(&[]);
-        data.extend_from_slice(&999u16.to_le_bytes());
-        data.extend_from_slice(&0u16.to_le_bytes());
-        assert_matches_legacy_sizing(&data, &[]);
+    fn visits_required_account_extensions_in_tlv_order() {
+        let mint_data = mint_data_with_tlv_entries(&[
+            (ExtensionType::TransferFeeConfig, 0),
+            (ExtensionType::NonTransferable, 0),
+        ]);
+        let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data).unwrap();
+
+        let mut visited = Vec::new();
+        try_for_each_required_init_account_extension(mint.get_tlv_data(), |extension_type| {
+            visited.push(extension_type);
+            Ok(())
+        })
+        .unwrap();
+
         assert_eq!(
-            try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]),
-            Err(ProgramError::InvalidAccountData),
+            visited,
+            [
+                ExtensionType::TransferFeeAmount,
+                ExtensionType::NonTransferableAccount,
+                ExtensionType::ImmutableOwner,
+            ]
         );
     }
 
     #[test]
-    fn seen_set_capacity_covers_every_account_extension_type() {
-        assert!(all_account_extensions().len() <= SEEN_ACCOUNT_EXTENSIONS_CAPACITY);
+    fn visitor_error_aborts_the_walk() {
+        let mint_data = mint_data_with_tlv_entries(&[
+            (ExtensionType::NonTransferable, 0),
+            (ExtensionType::TransferFeeConfig, 0),
+        ]);
+        let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data).unwrap();
+
+        let mut visits = 0;
+        assert_eq!(
+            try_for_each_required_init_account_extension(mint.get_tlv_data(), |_| {
+                visits += 1;
+                Err(ProgramError::Custom(42))
+            }),
+            Err(ProgramError::Custom(42)),
+        );
+        assert_eq!(visits, 1);
     }
 
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(1_000))]
-
-        // Differential fuzz over well-formed mints, random TLV entries drawn from every extension
-        // type with random declared value lengths
-        #[test]
-        fn arbitrary_mint_extension_lists_match_legacy_sizing(
-            entries in prop::collection::vec(
-                (
-                    prop::sample::select(ExtensionType::iter().collect::<Vec<_>>()),
-                    0usize..16,
-                ),
-                0..5,
-            ),
-            additional in prop::collection::vec(
-                prop::sample::select(all_account_extensions()),
-                0..12,
-            ),
-        ) {
-            let mint_data = mint_data_with_tlv_entries(&entries);
-            prop_assert_eq!(
-                try_calculate_account_len_from_mint_data(&crate::id(), &mint_data, &additional),
-                legacy_account_len(&mint_data, &additional),
-            );
+    #[test]
+    fn buffer_holds_every_extension_type_once() {
+        let mut buffer = ExtensionTypeBuffer::default();
+        for _ in 0..2 {
+            for extension_type in ExtensionType::iter() {
+                buffer.insert(extension_type).unwrap();
+            }
         }
+        assert_eq!(buffer.types().len(), ExtensionType::iter().count());
     }
 }

--- a/interface/src/extension/account_len.rs
+++ b/interface/src/extension/account_len.rs
@@ -1,0 +1,443 @@
+use {
+    super::{
+        adjust_len_for_multisig, try_for_each_tlv_extension_type, AccountType,
+        BaseStateWithExtensions, ExtensionType, PodStateWithExtensions,
+        BASE_ACCOUNT_AND_TYPE_LENGTH,
+    },
+    crate::{
+        check_program_account,
+        error::TokenError,
+        pod::PodMint,
+        state::{Account, PackedSizeOf},
+    },
+    solana_address::Address,
+    solana_program_error::ProgramError,
+};
+
+/// Must stay at or above the number of `AccountType::Account` extension types that exist,
+/// which is verified by the capacity test in this module. Note there are currently only 9
+/// `AccountType::Account` extension types today but the added slack makes updates easier
+/// on external consumers.
+const SEEN_ACCOUNT_EXTENSIONS_CAPACITY: usize = 24;
+
+/// A small fixed-capacity set that records which account extension types have already
+/// been counted toward an account length.
+#[derive(Debug, Default)]
+struct SeenAccountExtensions {
+    /// The recorded extension types, filled from the front. Only the first `count` slots
+    /// are occupied, the rest remain `None`
+    seen: [Option<ExtensionType>; SEEN_ACCOUNT_EXTENSIONS_CAPACITY],
+    /// How many slots are occupied
+    count: usize,
+}
+
+impl SeenAccountExtensions {
+    /// Records an extension type, returning `true` if it was new and `false` if it
+    /// was already in the set
+    fn insert(&mut self, extension_type: ExtensionType) -> Result<bool, ProgramError> {
+        if self.seen[..self.count].contains(&Some(extension_type)) {
+            return Ok(false);
+        }
+
+        // Not seen, so take the next free slot
+        let slot = self
+            .seen
+            .get_mut(self.count)
+            .ok_or(ProgramError::InvalidAccountData)?;
+        *slot = Some(extension_type);
+        self.count = self.count.saturating_add(1);
+
+        Ok(true)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+}
+
+/// Calculate the account length for a token account of the given initialized mint,
+/// with `additional_account_extensions` requested on top of the account extensions
+/// required by the mint.
+pub fn try_calculate_account_len_from_mint_data(
+    token_program_id: &Address,
+    mint_data: &[u8],
+    additional_account_extensions: &[ExtensionType],
+) -> Result<usize, ProgramError> {
+    check_account_extensions(additional_account_extensions)?;
+    check_program_account(token_program_id)?;
+
+    let mint = PodStateWithExtensions::<PodMint>::unpack(mint_data)
+        .map_err(|_| TokenError::InvalidMint)?;
+
+    // Tracks already counted extension types so overlap between the requested extensions
+    // and the mint's required ones is only sized once
+    let mut seen = SeenAccountExtensions::default();
+
+    let mut total_tlv_len: usize = 0;
+
+    // Sum the TLV lengths of the requested account extensions
+    for &extension_type in additional_account_extensions {
+        if seen.insert(extension_type)? {
+            total_tlv_len = total_tlv_len.saturating_add(extension_type.try_get_tlv_len()?);
+        }
+    }
+
+    // Walk the mint's extensions, summing the TLV lengths of the account extensions
+    // each one requires
+    try_for_each_tlv_extension_type(mint.get_tlv_data(), |mint_extension_type| {
+        for &extension_type in mint_extension_type.required_init_account_extensions() {
+            if seen.insert(extension_type)? {
+                total_tlv_len = total_tlv_len.saturating_add(extension_type.try_get_tlv_len()?);
+            }
+        }
+        Ok(())
+    })?;
+
+    // With no extensions, the account stays at the base size
+    if seen.is_empty() {
+        Ok(Account::SIZE_OF)
+    } else {
+        // Extensions follow the base account data and account type byte
+        let total_len = total_tlv_len.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH);
+        // the total length must be padded if it collides with `Multisig::LEN`
+        Ok(adjust_len_for_multisig(total_len))
+    }
+}
+
+/// Check that every extension type is an `AccountType::Account` extension
+fn check_account_extensions(account_extensions: &[ExtensionType]) -> Result<(), ProgramError> {
+    for extension_type in account_extensions {
+        if extension_type.get_account_type() != AccountType::Account {
+            return Err(TokenError::ExtensionTypeMismatch.into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::super::{
+            transfer_fee::TransferFeeConfig, BaseStateWithExtensionsMut, StateWithExtensionsMut,
+            BASE_ACCOUNT_LENGTH,
+        },
+        super::*,
+        crate::state::{test::TEST_MINT_SLICE, Mint, Multisig},
+        alloc::{vec, vec::Vec},
+        core::mem::size_of,
+        proptest::prelude::*,
+        solana_program_pack::Pack,
+        strum::IntoEnumIterator,
+        test_case::test_case,
+    };
+
+    fn all_account_extensions() -> Vec<ExtensionType> {
+        ExtensionType::iter()
+            .filter(|extension_type| extension_type.get_account_type() == AccountType::Account)
+            .collect()
+    }
+
+    fn push_tlv_entry(data: &mut Vec<u8>, extension_type: ExtensionType, value_len: usize) {
+        data.extend_from_slice(&u16::from(extension_type).to_le_bytes());
+        data.extend_from_slice(&u16::try_from(value_len).unwrap().to_le_bytes());
+        data.resize(data.len().saturating_add(value_len), 0);
+    }
+
+    fn mint_data_with_tlv_entries(entries: &[(ExtensionType, usize)]) -> Vec<u8> {
+        let mut data = TEST_MINT_SLICE.to_vec();
+        data.resize(BASE_ACCOUNT_LENGTH, 0);
+        data.push(AccountType::Mint.into());
+        for &(extension_type, value_len) in entries {
+            push_tlv_entry(&mut data, extension_type, value_len);
+        }
+        data
+    }
+
+    /// The legacy sizing code path formerly used by `GetAccountDataSize`
+    /// which the new helper must match exactly
+    fn legacy_account_len(
+        mint_data: &[u8],
+        additional_account_extensions: &[ExtensionType],
+    ) -> Result<usize, ProgramError> {
+        let state = PodStateWithExtensions::<PodMint>::unpack(mint_data)
+            .map_err(|_| TokenError::InvalidMint)?;
+        let mut account_extensions =
+            ExtensionType::get_required_init_account_extensions(&state.get_extension_types()?);
+        account_extensions.extend_from_slice(additional_account_extensions);
+        ExtensionType::try_calculate_account_len::<Account>(&account_extensions)
+    }
+
+    fn assert_matches_legacy_sizing(
+        mint_data: &[u8],
+        additional_account_extensions: &[ExtensionType],
+    ) {
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(
+                &crate::id(),
+                mint_data,
+                additional_account_extensions,
+            ),
+            legacy_account_len(mint_data, additional_account_extensions),
+        );
+    }
+
+    #[test_case(
+        TEST_MINT_SLICE.to_vec(), &[];
+        "mint with no extensions"
+    )]
+    #[test_case(
+        TEST_MINT_SLICE.to_vec(),
+        &[ExtensionType::ImmutableOwner, ExtensionType::MemoTransfer, ExtensionType::CpiGuard];
+        "standalone account extensions"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[
+            (ExtensionType::TransferFeeConfig, 0),
+            (ExtensionType::MintCloseAuthority, 0),
+            (ExtensionType::DefaultAccountState, 0),
+            (ExtensionType::NonTransferable, 0),
+        ]),
+        &[];
+        "multiple mint extensions"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]), &[];
+        "account extension inside mint tlv is ignored"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::NonTransferable, 0)]),
+        &[
+            ExtensionType::ImmutableOwner,
+            ExtensionType::NonTransferableAccount,
+            ExtensionType::ImmutableOwner,
+        ];
+        "required and additional extensions overlap"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[
+            (ExtensionType::NonTransferable, 0),
+            (ExtensionType::NonTransferable, 0),
+        ]),
+        &[];
+        "duplicate mint extensions"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[
+            (ExtensionType::TransferFeeConfig, 0),
+            (ExtensionType::NonTransferable, 0),
+            (ExtensionType::TransferHook, 0),
+            (ExtensionType::Pausable, 0),
+        ]),
+        &all_account_extensions();
+        "every account extension at once"
+    )]
+    fn matches_legacy_sizing(mint_data: Vec<u8>, additional_account_extensions: &[ExtensionType]) {
+        assert_matches_legacy_sizing(&mint_data, additional_account_extensions);
+    }
+
+    #[test_case(
+        TEST_MINT_SLICE.to_vec();
+        "mint with no extensions"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]);
+        "account extension inside mint tlv"
+    )]
+    fn sizes_to_exactly_the_base_account_len(mint_data: Vec<u8>) {
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&crate::id(), &mint_data, &[]).unwrap(),
+            Account::SIZE_OF,
+        );
+    }
+
+    #[test]
+    fn real_mint_data_sizes_to_known_len() {
+        // A wrong TLV layout assumption shared by the test fixtures and the sizing code would
+        // cancel out and pass. So here we test a hand-computed length
+        let space =
+            ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::TransferFeeConfig])
+                .unwrap();
+        let mut mint_data = vec![0; space];
+        let mut state =
+            StateWithExtensionsMut::<Mint>::unpack_uninitialized(&mut mint_data).unwrap();
+        state.init_extension::<TransferFeeConfig>(true).unwrap();
+        state.base = Mint {
+            is_initialized: true,
+            ..Mint::default()
+        };
+        state.pack_base();
+        state.init_account_type().unwrap();
+
+        assert_matches_legacy_sizing(&mint_data, &[ExtensionType::ImmutableOwner]);
+
+        // 165 base + 1 account type + (4 header + 8 `TransferFeeAmount`) + (4 header + 0
+        // `ImmutableOwner`)
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(
+                &crate::id(),
+                &mint_data,
+                &[ExtensionType::ImmutableOwner],
+            )
+            .unwrap(),
+            182,
+        );
+    }
+
+    #[test]
+    fn multisig_len_adjustment_matches_legacy_sizing() {
+        // The padding test extensions exist to push the account length to exactly `Multisig::LEN`,
+        // which must be adjusted by two bytes
+        let mint_data = mint_data_with_tlv_entries(&[(ExtensionType::MintPaddingTest, 0)]);
+        assert_matches_legacy_sizing(&mint_data, &[]);
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&crate::id(), &mint_data, &[]).unwrap(),
+            Multisig::LEN.saturating_add(size_of::<ExtensionType>()),
+        );
+
+        assert_matches_legacy_sizing(TEST_MINT_SLICE, &[ExtensionType::AccountPaddingTest]);
+    }
+
+    #[test]
+    fn declared_tlv_value_length_is_ignored_for_sizing() {
+        // Summing the declared value lengths instead of the canonical per-type lengths would
+        // pass every well-formed test. So here the entry lies about its length and must size
+        // identically to one that does not.
+        let lying_length = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 5)]);
+        let zero_length = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
+        assert_matches_legacy_sizing(&lying_length, &[]);
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&crate::id(), &lying_length, &[]),
+            try_calculate_account_len_from_mint_data(&crate::id(), &zero_length, &[]),
+        );
+    }
+
+    #[test]
+    fn trailing_realloc_byte_ends_the_walk() {
+        // A single trailing byte that cannot hold another TLV entry marks the end of the data
+        // rather than malforming it
+        let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
+        data.push(0);
+        assert_matches_legacy_sizing(&data, &[]);
+        assert!(try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]).is_ok());
+    }
+
+    #[test]
+    fn bytes_after_uninitialized_terminator_are_ignored() {
+        // An `Uninitialized` entry terminates the walk, anything after it is never read
+        let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
+        data.extend_from_slice(&u16::from(ExtensionType::Uninitialized).to_le_bytes());
+        data.extend_from_slice(&[0xff; 7]);
+        assert_matches_legacy_sizing(&data, &[]);
+        assert!(try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]).is_ok());
+    }
+
+    #[test_case(ExtensionType::TransferFeeConfig; "mint extension")]
+    #[test_case(ExtensionType::Uninitialized; "uninitialized")]
+    fn rejects_non_account_additional_extension(extension_type: ExtensionType) {
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(
+                &crate::id(),
+                TEST_MINT_SLICE,
+                &[extension_type],
+            ),
+            Err(TokenError::ExtensionTypeMismatch.into()),
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_token_program_id() {
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&Address::default(), TEST_MINT_SLICE, &[]),
+            Err(ProgramError::IncorrectProgramId),
+        );
+    }
+
+    #[test_case(
+        vec![], &[ExtensionType::ImmutableOwner];
+        "empty mint data"
+    )]
+    #[test_case(
+        vec![0; Mint::LEN], &[];
+        "uninitialized mint"
+    )]
+    #[test_case(
+        {
+            let mut data = mint_data_with_tlv_entries(&[]);
+            data.resize(Multisig::LEN, 0);
+            data
+        },
+        &[];
+        "mint data of multisig len"
+    )]
+    fn rejects_invalid_mint_data(
+        mint_data: Vec<u8>,
+        additional_account_extensions: &[ExtensionType],
+    ) {
+        assert_matches_legacy_sizing(&mint_data, additional_account_extensions);
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(
+                &crate::id(),
+                &mint_data,
+                additional_account_extensions,
+            ),
+            Err(TokenError::InvalidMint.into()),
+        );
+    }
+
+    #[test]
+    fn truncated_tlv_entry_is_invalid_account_data() {
+        // A type with only one byte after it cannot hold the entry's length
+        let mut data = mint_data_with_tlv_entries(&[]);
+        data.extend_from_slice(&u16::from(ExtensionType::TransferFeeConfig).to_le_bytes());
+        data.push(0);
+        assert_matches_legacy_sizing(&data, &[]);
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]),
+            Err(ProgramError::InvalidAccountData),
+        );
+    }
+
+    #[test]
+    fn unknown_mint_extension_is_invalid_account_data() {
+        let mut data = mint_data_with_tlv_entries(&[]);
+        data.extend_from_slice(&999u16.to_le_bytes());
+        data.extend_from_slice(&0u16.to_le_bytes());
+        assert_matches_legacy_sizing(&data, &[]);
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&crate::id(), &data, &[]),
+            Err(ProgramError::InvalidAccountData),
+        );
+    }
+
+    #[test]
+    fn seen_set_capacity_covers_every_account_extension_type() {
+        assert!(all_account_extensions().len() <= SEEN_ACCOUNT_EXTENSIONS_CAPACITY);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1_000))]
+
+        // Differential fuzz over well-formed mints, random TLV entries drawn from every extension
+        // type with random declared value lengths
+        #[test]
+        fn arbitrary_mint_extension_lists_match_legacy_sizing(
+            entries in prop::collection::vec(
+                (
+                    prop::sample::select(ExtensionType::iter().collect::<Vec<_>>()),
+                    0usize..16,
+                ),
+                0..5,
+            ),
+            additional in prop::collection::vec(
+                prop::sample::select(all_account_extensions()),
+                0..12,
+            ),
+        ) {
+            let mint_data = mint_data_with_tlv_entries(&entries);
+            prop_assert_eq!(
+                try_calculate_account_len_from_mint_data(&crate::id(), &mint_data, &additional),
+                legacy_account_len(&mint_data, &additional),
+            );
+        }
+    }
+}

--- a/interface/src/extension/account_len.rs
+++ b/interface/src/extension/account_len.rs
@@ -15,7 +15,7 @@ pub(crate) struct TlvLenAccumulator {
     /// Bitset of the extension types inserted so far
     seen: u64,
     /// Total TLV length of the distinct inserted types
-    total: usize,
+    byte_count: usize,
 }
 
 impl TlvLenAccumulator {
@@ -39,7 +39,9 @@ impl TlvLenAccumulator {
         let bit = Self::bit(extension_type);
         if self.seen & bit == 0 {
             self.seen |= bit;
-            self.total = self.total.saturating_add(extension_type.try_get_tlv_len()?);
+            self.byte_count = self
+                .byte_count
+                .saturating_add(extension_type.try_get_tlv_len()?);
         }
         Ok(())
     }
@@ -49,7 +51,7 @@ impl TlvLenAccumulator {
         if self.seen == 0 {
             S::SIZE_OF
         } else {
-            adjust_len_for_multisig(self.total.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH))
+            adjust_len_for_multisig(self.byte_count.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH))
         }
     }
 }

--- a/interface/src/extension/account_len.rs
+++ b/interface/src/extension/account_len.rs
@@ -1,56 +1,56 @@
 use {
     super::{
-        try_for_each_tlv_extension_type, AccountType, BaseStateWithExtensions, ExtensionType,
-        PodStateWithExtensions,
+        adjust_len_for_multisig, try_for_each_tlv_extension_type, AccountType, BaseState,
+        BaseStateWithExtensions, ExtensionType, PodStateWithExtensions,
+        BASE_ACCOUNT_AND_TYPE_LENGTH,
     },
     crate::{error::TokenError, pod::PodMint, state::Account},
     solana_program_error::ProgramError,
 };
 
-/// Must stay at or above the total number of `ExtensionType`s that exist, which is verified
-/// by the capacity test in this module
-pub(crate) const EXTENSION_TYPE_BUFFER_CAPACITY: usize = 50;
-
-/// A fixed-capacity unique list of extension types. A no-alloc version of a set.
-#[derive(Debug)]
-pub(crate) struct ExtensionTypeBuffer {
-    /// The recorded extension types, filled from the front. Slots past `count` are unused
-    /// and hold `Uninitialized` as filler
-    types: [ExtensionType; EXTENSION_TYPE_BUFFER_CAPACITY],
-    /// How many slots are occupied
-    count: usize,
+/// Accumulates the total TLV length of the inserted extension types, counting each
+/// distinct type once. A no-alloc version of summing over a set.
+#[derive(Debug, Default)]
+pub(crate) struct TlvLenAccumulator {
+    /// Bitset of the extension types inserted so far
+    seen: u64,
+    /// Total TLV length of the distinct inserted types
+    total: usize,
 }
 
-impl Default for ExtensionTypeBuffer {
-    fn default() -> Self {
-        Self {
-            types: [ExtensionType::Uninitialized; EXTENSION_TYPE_BUFFER_CAPACITY],
-            count: 0,
+impl TlvLenAccumulator {
+    /// The bit recording the extension type in `seen`. The bit test in this module
+    /// verifies that every `ExtensionType` holds a distinct bit within the `u64`
+    fn bit(extension_type: ExtensionType) -> u64 {
+        #[cfg(test)]
+        match extension_type {
+            // The test-only types live at the top of the `u16` discriminant range,
+            // so they are mirrored onto the highest bits
+            ExtensionType::VariableLenMintTest => return 1 << 61,
+            ExtensionType::AccountPaddingTest => return 1 << 62,
+            ExtensionType::MintPaddingTest => return 1 << 63,
+            _ => (),
         }
+        1 << u16::from(extension_type)
     }
-}
 
-impl ExtensionTypeBuffer {
-    /// Records the extension type unless it is already present
+    /// Adds the extension type's TLV length unless the type was already inserted
     pub(crate) fn insert(&mut self, extension_type: ExtensionType) -> Result<(), ProgramError> {
-        if self.types().contains(&extension_type) {
-            return Ok(());
+        let bit = Self::bit(extension_type);
+        if self.seen & bit == 0 {
+            self.seen |= bit;
+            self.total = self.total.saturating_add(extension_type.try_get_tlv_len()?);
         }
-
-        // Not seen, so take the next free slot
-        let slot = self
-            .types
-            .get_mut(self.count)
-            .ok_or(ProgramError::InvalidAccountData)?;
-        *slot = extension_type;
-        self.count = self.count.saturating_add(1);
-
         Ok(())
     }
 
-    /// The recorded extension types in insertion order
-    pub(crate) fn types(&self) -> &[ExtensionType] {
-        &self.types[..self.count]
+    /// The account length for base state `S` followed by the accumulated TLV entries
+    pub(crate) fn account_len<S: BaseState>(&self) -> usize {
+        if self.seen == 0 {
+            S::SIZE_OF
+        } else {
+            adjust_len_for_multisig(self.total.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH))
+        }
     }
 }
 
@@ -89,19 +89,19 @@ pub fn try_calculate_account_len_from_mint_data(
     let state = PodStateWithExtensions::<PodMint>::unpack(mint_data)
         .map_err(|_| TokenError::InvalidMint)?;
 
-    // Collect the account extensions the mint requires
-    let mut account_extensions = ExtensionTypeBuffer::default();
+    // Size the account extensions the mint requires
+    let mut tlv_len = TlvLenAccumulator::default();
     try_for_each_required_init_account_extension(state.get_tlv_data(), |extension_type| {
-        account_extensions.insert(extension_type)
+        tlv_len.insert(extension_type)
     })?;
 
     // Add the requested ones. `insert` dedupes, so overlap with the required
     // extensions is only sized once.
     for &extension_type in additional_account_extensions {
-        account_extensions.insert(extension_type)?;
+        tlv_len.insert(extension_type)?;
     }
 
-    ExtensionType::try_calculate_account_len::<Account>(account_extensions.types())
+    Ok(tlv_len.account_len::<Account>())
 }
 
 #[cfg(test)]
@@ -143,9 +143,9 @@ mod tests {
         "mint with no extensions"
     )]
     #[test_case(
-        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]), &[],
+        mint_data_with_tlv_entries(&[(ExtensionType::MintCloseAuthority, 0)]), &[],
         Account::SIZE_OF;
-        "account extension inside mint tlv"
+        "mint extension with no required account extensions"
     )]
     // 165 base + 1 account type + (4 header + 0 `ImmutableOwner`) + (4 header + 1
     // `MemoTransfer`) + (4 header + 1 `CpiGuard`)
@@ -172,20 +172,6 @@ mod tests {
         "requested extensions overlap required ones"
     )]
     #[test_case(
-        mint_data_with_tlv_entries(&[
-            (ExtensionType::NonTransferable, 0),
-            (ExtensionType::NonTransferable, 0),
-        ]),
-        &[],
-        174;
-        "duplicate mint extensions"
-    )]
-    #[test_case(
-        mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 5)]), &[],
-        178;
-        "declared tlv value length is ignored"
-    )]
-    #[test_case(
         {
             let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
             data.push(0);
@@ -194,17 +180,6 @@ mod tests {
         &[],
         178;
         "trailing realloc byte is ignored"
-    )]
-    #[test_case(
-        {
-            let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
-            data.extend_from_slice(&u16::from(ExtensionType::Uninitialized).to_le_bytes());
-            data.extend_from_slice(&[0xff; 7]);
-            data
-        },
-        &[],
-        178;
-        "bytes after uninitialized terminator are ignored"
     )]
     #[test_case(
         mint_data_with_tlv_entries(&[(ExtensionType::MintPaddingTest, 0)]), &[],
@@ -224,6 +199,43 @@ mod tests {
         assert_eq!(
             try_calculate_account_len_from_mint_data(&mint_data, additional_account_extensions)
                 .unwrap(),
+            expected_len,
+        );
+    }
+
+    // Bad input cases that aren't possible from within the token program, but proves
+    // external usage can handle some bogus params.
+    #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::ImmutableOwner, 0)]),
+        Account::SIZE_OF;
+        "account extension inside mint tlv contributes nothing"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[
+            (ExtensionType::NonTransferable, 0),
+            (ExtensionType::NonTransferable, 0),
+        ]),
+        174;
+        "duplicate mint extensions"
+    )]
+    #[test_case(
+        mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 5)]),
+        178;
+        "account size is computed from the extension types alone"
+    )]
+    #[test_case(
+        {
+            let mut data = mint_data_with_tlv_entries(&[(ExtensionType::TransferFeeConfig, 0)]);
+            data.extend_from_slice(&u16::from(ExtensionType::Uninitialized).to_le_bytes());
+            data.extend_from_slice(&[0xff; 7]);
+            data
+        },
+        178;
+        "bytes after uninitialized terminator are ignored"
+    )]
+    fn sizes_unwritable_mint_bytes_to_known_len(mint_data: Vec<u8>, expected_len: usize) {
+        assert_eq!(
+            try_calculate_account_len_from_mint_data(&mint_data, &[]).unwrap(),
             expected_len,
         );
     }
@@ -326,13 +338,16 @@ mod tests {
     }
 
     #[test]
-    fn buffer_holds_every_extension_type_once() {
-        let mut buffer = ExtensionTypeBuffer::default();
-        for _ in 0..2 {
-            for extension_type in ExtensionType::iter() {
-                buffer.insert(extension_type).unwrap();
-            }
+    fn every_extension_type_holds_a_distinct_bit() {
+        let mut seen = 0u64;
+        for extension_type in ExtensionType::iter() {
+            let bit = TlvLenAccumulator::bit(extension_type);
+            assert_eq!(
+                seen & bit,
+                0,
+                "{extension_type:?} shares its bit with another extension type."
+            );
+            seen |= bit;
         }
-        assert_eq!(buffer.types().len(), ExtensionType::iter().count());
     }
 }

--- a/interface/src/extension/mod.rs
+++ b/interface/src/extension/mod.rs
@@ -6,6 +6,7 @@ use {
     crate::{
         error::TokenError,
         extension::{
+            account_len::ExtensionTypeBuffer,
             confidential_mint_burn::ConfidentialMintBurn,
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
             confidential_transfer_fee::{
@@ -47,7 +48,7 @@ use {
     spl_type_length_value::variable_len_pack::VariableLenPack,
 };
 
-/// Account length calculation helpers.
+/// Account length calculation helpers
 pub mod account_len;
 /// Confidential Transfer extension
 pub mod confidential_transfer;
@@ -1241,13 +1242,11 @@ impl ExtensionType {
     /// Fails if any of the extension types has a variable length
     fn try_get_total_tlv_len(extension_types: &[Self]) -> Result<usize, ProgramError> {
         // dedupe extensions
-        let mut extensions = vec![];
-        for extension_type in extension_types {
-            if !extensions.contains(&extension_type) {
-                extensions.push(extension_type);
-            }
+        let mut extensions = ExtensionTypeBuffer::default();
+        for &extension_type in extension_types {
+            extensions.insert(extension_type)?;
         }
-        extensions.iter().map(|e| e.try_get_tlv_len()).sum()
+        extensions.types().iter().map(|e| e.try_get_tlv_len()).sum()
     }
 
     /// Get the required account data length for the given `ExtensionType`s

--- a/interface/src/extension/mod.rs
+++ b/interface/src/extension/mod.rs
@@ -1310,6 +1310,10 @@ impl ExtensionType {
 
     /// Based on a set of `AccountType::Mint` `ExtensionType`s, get the list of
     /// `AccountType::Account` `ExtensionType`s required on `InitializeAccount`
+    #[deprecated(
+        since = "3.0.1",
+        note = "Use `account_len::try_for_each_required_init_account_extension` instead"
+    )]
     pub fn get_required_init_account_extensions(mint_extension_types: &[Self]) -> Vec<Self> {
         mint_extension_types
             .iter()
@@ -2424,6 +2428,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_get_required_init_account_extensions() {
         // Some mint extensions with no required account extensions
         let mint_extensions = vec![

--- a/interface/src/extension/mod.rs
+++ b/interface/src/extension/mod.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         error::TokenError,
         extension::{
-            account_len::ExtensionTypeBuffer,
+            account_len::TlvLenAccumulator,
             confidential_mint_burn::ConfidentialMintBurn,
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
             confidential_transfer_fee::{
@@ -223,7 +223,6 @@ where
                 // not enough bytes to store the length, malformed
                 return Err(ProgramError::InvalidAccountData);
             }
-            f(extension_type)?;
             let length = bytemuck::try_from_bytes::<Length>(
                 &tlv_data[tlv_indices.length_start..tlv_indices.value_start],
             )
@@ -234,6 +233,7 @@ where
                 // value blows past the size of the slice, malformed
                 return Err(ProgramError::InvalidAccountData);
             }
+            f(extension_type)?;
             start_index = value_end_index;
         }
     }
@@ -1237,31 +1237,17 @@ impl ExtensionType {
         Ok(add_type_and_length_to_len(self.try_get_type_len()?))
     }
 
-    /// Get the TLV length for a set of `ExtensionType`s
-    ///
-    /// Fails if any of the extension types has a variable length
-    fn try_get_total_tlv_len(extension_types: &[Self]) -> Result<usize, ProgramError> {
-        // dedupe extensions
-        let mut extensions = ExtensionTypeBuffer::default();
-        for &extension_type in extension_types {
-            extensions.insert(extension_type)?;
-        }
-        extensions.types().iter().map(|e| e.try_get_tlv_len()).sum()
-    }
-
     /// Get the required account data length for the given `ExtensionType`s
     ///
     /// Fails if any of the extension types has a variable length
     pub fn try_calculate_account_len<S: BaseState>(
         extension_types: &[Self],
     ) -> Result<usize, ProgramError> {
-        if extension_types.is_empty() {
-            Ok(S::SIZE_OF)
-        } else {
-            let extension_size = Self::try_get_total_tlv_len(extension_types)?;
-            let total_len = extension_size.saturating_add(BASE_ACCOUNT_AND_TYPE_LENGTH);
-            Ok(adjust_len_for_multisig(total_len))
+        let mut tlv_len = TlvLenAccumulator::default();
+        for &extension_type in extension_types {
+            tlv_len.insert(extension_type)?;
         }
+        Ok(tlv_len.account_len::<S>())
     }
 
     /// Get the associated account type

--- a/interface/src/extension/mod.rs
+++ b/interface/src/extension/mod.rs
@@ -47,6 +47,8 @@ use {
     spl_type_length_value::variable_len_pack::VariableLenPack,
 };
 
+/// Account length calculation helpers.
+pub mod account_len;
 /// Confidential Transfer extension
 pub mod confidential_transfer;
 /// Confidential Transfer Fee extension
@@ -197,34 +199,30 @@ struct TlvDataInfo {
     used_len: usize,
 }
 
-/// Fetches basic information about the TLV buffer by iterating through all
-/// TLV entries.
-fn get_tlv_data_info(tlv_data: &[u8]) -> Result<TlvDataInfo, ProgramError> {
-    let mut extension_types = vec![];
+/// Iterates through all TLV entries, passing each initialized extension type
+/// to `f`, and returns the total number of bytes used by all TLV entries.
+fn try_for_each_tlv_extension_type<F>(tlv_data: &[u8], mut f: F) -> Result<usize, ProgramError>
+where
+    F: FnMut(ExtensionType) -> Result<(), ProgramError>,
+{
     let mut start_index = 0;
     while start_index < tlv_data.len() {
         let tlv_indices = get_tlv_indices(start_index);
         if tlv_data.len() < tlv_indices.length_start {
             // There aren't enough bytes to store the next type, which means we
             // got to the end. The last byte could be used during a realloc!
-            return Ok(TlvDataInfo {
-                extension_types,
-                used_len: tlv_indices.type_start,
-            });
+            return Ok(tlv_indices.type_start);
         }
         let extension_type =
             ExtensionType::try_from(&tlv_data[tlv_indices.type_start..tlv_indices.length_start])?;
         if extension_type == ExtensionType::Uninitialized {
-            return Ok(TlvDataInfo {
-                extension_types,
-                used_len: tlv_indices.type_start,
-            });
+            return Ok(tlv_indices.type_start);
         } else {
             if tlv_data.len() < tlv_indices.value_start {
                 // not enough bytes to store the length, malformed
                 return Err(ProgramError::InvalidAccountData);
             }
-            extension_types.push(extension_type);
+            f(extension_type)?;
             let length = bytemuck::try_from_bytes::<Length>(
                 &tlv_data[tlv_indices.length_start..tlv_indices.value_start],
             )
@@ -238,9 +236,20 @@ fn get_tlv_data_info(tlv_data: &[u8]) -> Result<TlvDataInfo, ProgramError> {
             start_index = value_end_index;
         }
     }
+    Ok(start_index)
+}
+
+/// Fetches basic information about the TLV buffer by iterating through all
+/// TLV entries.
+fn get_tlv_data_info(tlv_data: &[u8]) -> Result<TlvDataInfo, ProgramError> {
+    let mut extension_types = vec![];
+    let used_len = try_for_each_tlv_extension_type(tlv_data, |extension_type| {
+        extension_types.push(extension_type);
+        Ok(())
+    })?;
     Ok(TlvDataInfo {
         extension_types,
-        used_len: start_index,
+        used_len,
     })
 }
 
@@ -315,7 +324,7 @@ fn type_and_tlv_indices<S: BaseState>(
         if rest_input.len() < tlv_start_index {
             return Err(ProgramError::InvalidAccountData);
         }
-        if rest_input[..account_type_index] != vec![0; account_type_index] {
+        if rest_input[..account_type_index].iter().any(|&b| b != 0) {
             Err(ProgramError::InvalidAccountData)
         } else {
             Ok(Some((account_type_index, tlv_start_index)))
@@ -1059,6 +1068,7 @@ pub enum AccountType {
 #[repr(u16)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+#[cfg_attr(test, derive(strum_macros::EnumIter))]
 #[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive, IntoPrimitive)]
 pub enum ExtensionType {
     /// Used as padding if the account size would otherwise be 355, same as a
@@ -1296,33 +1306,31 @@ impl ExtensionType {
         }
     }
 
+    /// Based on an `AccountType::Mint` `ExtensionType`, get the
+    /// `AccountType::Account` `ExtensionType`s required on `InitializeAccount`
+    fn required_init_account_extensions(&self) -> &'static [Self] {
+        match self {
+            ExtensionType::TransferFeeConfig => &[ExtensionType::TransferFeeAmount],
+            ExtensionType::NonTransferable => &[
+                ExtensionType::NonTransferableAccount,
+                ExtensionType::ImmutableOwner,
+            ],
+            ExtensionType::TransferHook => &[ExtensionType::TransferHookAccount],
+            ExtensionType::Pausable => &[ExtensionType::PausableAccount],
+            #[cfg(test)]
+            ExtensionType::MintPaddingTest => &[ExtensionType::AccountPaddingTest],
+            _ => &[],
+        }
+    }
+
     /// Based on a set of `AccountType::Mint` `ExtensionType`s, get the list of
     /// `AccountType::Account` `ExtensionType`s required on `InitializeAccount`
     pub fn get_required_init_account_extensions(mint_extension_types: &[Self]) -> Vec<Self> {
-        let mut account_extension_types = vec![];
-        for extension_type in mint_extension_types {
-            match extension_type {
-                ExtensionType::TransferFeeConfig => {
-                    account_extension_types.push(ExtensionType::TransferFeeAmount);
-                }
-                ExtensionType::NonTransferable => {
-                    account_extension_types.push(ExtensionType::NonTransferableAccount);
-                    account_extension_types.push(ExtensionType::ImmutableOwner);
-                }
-                ExtensionType::TransferHook => {
-                    account_extension_types.push(ExtensionType::TransferHookAccount);
-                }
-                ExtensionType::Pausable => {
-                    account_extension_types.push(ExtensionType::PausableAccount);
-                }
-                #[cfg(test)]
-                ExtensionType::MintPaddingTest => {
-                    account_extension_types.push(ExtensionType::AccountPaddingTest);
-                }
-                _ => {}
-            }
-        }
-        account_extension_types
+        mint_extension_types
+            .iter()
+            .flat_map(|extension_type| extension_type.required_init_account_extensions())
+            .copied()
+            .collect()
     }
 
     /// Check for invalid combination of mint extensions

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -32,7 +32,10 @@ use {
         check_program_account,
         error::TokenError,
         extension::{
-            account_len::try_calculate_account_len_from_mint_data,
+            account_len::{
+                try_calculate_account_len_from_mint_data,
+                try_for_each_required_init_account_extension,
+            },
             confidential_mint_burn::ConfidentialMintBurn,
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
             confidential_transfer_fee::{
@@ -64,7 +67,7 @@ use {
         },
         native_mint,
         pod::{PodAccount, PodCOption, PodMint, PodMultisig},
-        state::{Account, AccountState, Mint, PackedSizeOf},
+        state::{AccountState, Mint, PackedSizeOf},
     },
     spl_token_group_interface::instruction::TokenGroupInstruction,
     spl_token_metadata_interface::instruction::TokenMetadataInstruction,
@@ -196,7 +199,6 @@ impl Processor {
             return Err(TokenError::NotRentExempt.into());
         }
 
-        // get_required_account_extensions checks mint validity
         let mint_data = mint_info.data.borrow();
         let mint = PodStateWithExtensions::<PodMint>::unpack(&mint_data)
             .map_err(|_| Into::<ProgramError>::into(TokenError::InvalidMint))?;
@@ -207,16 +209,17 @@ impl Processor {
         {
             msg!("Warning: Mint has a permanent delegate, so tokens in this account may be seized at any time");
         }
-        let required_extensions =
-            Self::get_required_account_extensions_from_unpacked_mint(mint_info.owner, &mint)?;
-        if ExtensionType::try_calculate_account_len::<Account>(&required_extensions)?
-            > new_account_info_data_len
-        {
+
+        check_program_account(mint_info.owner)?;
+
+        // Sizing walks every TLV entry, so this also validates the extension data
+        let required_account_len = try_calculate_account_len_from_mint_data(&mint_data, &[])?;
+        if required_account_len > new_account_info_data_len {
             return Err(ProgramError::InvalidAccountData);
         }
-        for extension in required_extensions {
-            account.init_account_extension_from_type(extension)?;
-        }
+        try_for_each_required_init_account_extension(mint.get_tlv_data(), |extension_type| {
+            account.init_account_extension_from_type(extension_type)
+        })?;
 
         let starting_state =
             if let Ok(default_account_state) = mint.get_extension::<DefaultAccountState>() {
@@ -1510,12 +1513,11 @@ impl Processor {
         let account_info_iter = &mut accounts.iter();
         let mint_account_info = next_account_info(account_info_iter)?;
 
+        check_program_account(mint_account_info.owner)?;
+
         let mint_data = mint_account_info.data.borrow();
-        let account_len = try_calculate_account_len_from_mint_data(
-            mint_account_info.owner,
-            &mint_data,
-            new_extension_types,
-        )?;
+        let account_len =
+            try_calculate_account_len_from_mint_data(&mint_data, new_extension_types)?;
         set_return_data(&account_len.to_le_bytes());
 
         Ok(())
@@ -2282,17 +2284,6 @@ impl Processor {
         }
         Ok(())
     }
-
-    fn get_required_account_extensions_from_unpacked_mint(
-        token_program_id: &Address,
-        state: &PodStateWithExtensions<PodMint>,
-    ) -> Result<Vec<ExtensionType>, ProgramError> {
-        check_program_account(token_program_id)?;
-        let mint_extensions = state.get_extension_types()?;
-        Ok(ExtensionType::get_required_init_account_extensions(
-            &mint_extensions,
-        ))
-    }
 }
 
 /// Helper function to mostly delete an account in a test environment.  We could
@@ -2336,7 +2327,7 @@ mod tests {
                 ExtensionType,
             },
             instruction::*,
-            state::Multisig,
+            state::{Account, Multisig},
         },
         std::sync::{Arc, RwLock},
     };

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -32,6 +32,7 @@ use {
         check_program_account,
         error::TokenError,
         extension::{
+            account_len::try_calculate_account_len_from_mint_data,
             confidential_mint_burn::ConfidentialMintBurn,
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
             confidential_transfer_fee::{
@@ -53,7 +54,7 @@ use {
             scaled_ui_amount::ScaledUiAmountConfig,
             transfer_fee::{TransferFeeAmount, TransferFeeConfig},
             transfer_hook::{TransferHook, TransferHookAccount},
-            AccountType, BaseStateWithExtensions, BaseStateWithExtensionsMut, ExtensionType,
+            BaseStateWithExtensions, BaseStateWithExtensionsMut, ExtensionType,
             PodStateWithExtensions, PodStateWithExtensionsMut,
         },
         inline_spl_token,
@@ -1506,24 +1507,15 @@ impl Processor {
         accounts: &[AccountInfo],
         new_extension_types: &[ExtensionType],
     ) -> ProgramResult {
-        if new_extension_types
-            .iter()
-            .any(|&t| t.get_account_type() != AccountType::Account)
-        {
-            return Err(TokenError::ExtensionTypeMismatch.into());
-        }
-
         let account_info_iter = &mut accounts.iter();
         let mint_account_info = next_account_info(account_info_iter)?;
 
-        check_program_account(mint_account_info.owner)?;
-
-        let mut account_extensions = Self::get_required_account_extensions(mint_account_info)?;
-        // ExtensionType::try_calculate_account_len() dedupes types, so just a dumb
-        // concatenation is fine here
-        account_extensions.extend_from_slice(new_extension_types);
-
-        let account_len = ExtensionType::try_calculate_account_len::<Account>(&account_extensions)?;
+        let mint_data = mint_account_info.data.borrow();
+        let account_len = try_calculate_account_len_from_mint_data(
+            mint_account_info.owner,
+            &mint_data,
+            new_extension_types,
+        )?;
         set_return_data(&account_len.to_le_bytes());
 
         Ok(())
@@ -2289,15 +2281,6 @@ impl Processor {
             return Err(ProgramError::MissingRequiredSignature);
         }
         Ok(())
-    }
-
-    fn get_required_account_extensions(
-        mint_account_info: &AccountInfo,
-    ) -> Result<Vec<ExtensionType>, ProgramError> {
-        let mint_data = mint_account_info.data.borrow();
-        let state = PodStateWithExtensions::<PodMint>::unpack(&mint_data)
-            .map_err(|_| Into::<ProgramError>::into(TokenError::InvalidMint))?;
-        Self::get_required_account_extensions_from_unpacked_mint(mint_account_info.owner, &state)
     }
 
     fn get_required_account_extensions_from_unpacked_mint(

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -212,7 +212,10 @@ impl Processor {
 
         check_program_account(mint_info.owner)?;
 
-        // Sizing walks every TLV entry, so this also validates the extension data
+        // Sizing walks every TLV entry, which also validates the extension data. It is only a
+        // lower bound since it skips extensions already initialized on the account (e.g.
+        // `ImmutableOwner`), but each init call below still verifies the space for its own write.
+        // Passing the initialized types as `additional_account_extensions` would make it exact.
         let required_account_len = try_calculate_account_len_from_mint_data(&mint_data, &[])?;
         if required_account_len > new_account_info_data_len {
             return Err(ProgramError::InvalidAccountData);

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -70,3 +70,4 @@ cryptographically
 prover
 encryptions
 permissioned
+bitset


### PR DESCRIPTION
Programs like p-ATA want to size Token-2022 token accounts without paying for a `GetAccountDataSize` CPI. Following the discussion in https://github.com/anza-xyz/pinocchio/pull/415, the sizing logic belongs here in `spl-token-2022-interface` rather than duplicated in the pinocchio repo. This unblocks https://github.com/solana-program/associated-token-account/pull/258.

The goal is to have a no-std, allocation-free way of sizing. `try_calculate_account_len_from_mint_data()` was created to fill this gap. It saves the p-ATA program ~2,200 CUs.

The program adopts the new helper, but should see not behavior changes from the perspective of callers.