### PR TITLE
feat: add transfer hook helpers to the JS client

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -9,3 +9,4 @@ export * from './confidentialTransferKeys';
 export * from './getInitializeInstructionsForExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';
+export * from './transferHook';

--- a/clients/js/src/transferHook.ts
+++ b/clients/js/src/transferHook.ts
@@ -1,0 +1,499 @@
+import {
+    type Account,
+    AccountRole,
+    type AccountMeta,
+    type Address,
+    assertAccountExists,
+    combineCodec,
+    decodeAccount,
+    type EncodedAccount,
+    type FetchAccountConfig,
+    fetchEncodedAccount,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    fixDecoderSize,
+    fixEncoderSize,
+    getAddressDecoder,
+    getAddressEncoder,
+    getArrayDecoder,
+    getArrayEncoder,
+    getBooleanDecoder,
+    getBooleanEncoder,
+    getBytesDecoder,
+    getBytesEncoder,
+    getProgramDerivedAddress,
+    getStructDecoder,
+    getStructEncoder,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Decoder,
+    getU64Encoder,
+    getU8Decoder,
+    getU8Encoder,
+    type GetAccountInfoApi,
+    getUtf8Encoder,
+    type Instruction,
+    isSignerRole,
+    isSome,
+    isWritableRole,
+    type MaybeAccount,
+    type MaybeEncodedAccount,
+    type ProgramDerivedAddress,
+    type ReadonlyUint8Array,
+    type Rpc,
+    type VariableSizeCodec,
+    type VariableSizeDecoder,
+    type VariableSizeEncoder,
+} from '@solana/kit';
+import {
+    fetchMint,
+    getTransferCheckedInstruction,
+    getTransferCheckedWithFeeInstruction,
+    type Mint,
+    type TransferCheckedInput,
+    type TransferCheckedWithFeeInput,
+} from './generated';
+
+const DEFAULT_ADDRESS = '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
+const EXTERNAL_PDA_DISCRIMINATOR_OFFSET = 1 << 7;
+const EXTRA_ACCOUNT_METAS_SEED = 'extra-account-metas';
+const PUBKEY_LENGTH = 32;
+
+function roleFromFlags(isSigner: boolean, isWritable: boolean): AccountRole {
+    if (isSigner && isWritable) return AccountRole.WRITABLE_SIGNER;
+    if (isSigner) return AccountRole.READONLY_SIGNER;
+    if (isWritable) return AccountRole.WRITABLE;
+    return AccountRole.READONLY;
+}
+
+async function fetchAccountData(rpc: Rpc<GetAccountInfoApi>, address: Address): Promise<ReadonlyUint8Array> {
+    const account = await fetchEncodedAccount(rpc, address);
+    assertAccountExists(account);
+    return account.data;
+}
+
+async function unpackSeeds(
+    seedsConfig: ReadonlyUint8Array,
+    previousMetas: AccountMeta[],
+    instructionData: ReadonlyUint8Array,
+    rpc: Rpc<GetAccountInfoApi>,
+): Promise<ReadonlyUint8Array[]> {
+    const seeds: ReadonlyUint8Array[] = [];
+    let i = 0;
+    while (i < seedsConfig.length) {
+        const discriminator = seedsConfig[i];
+        const rest = seedsConfig.subarray(i + 1);
+        if (discriminator === 0) {
+            break;
+        } else if (discriminator === 1) {
+            if (rest.length < 1) throw new Error('Invalid transfer hook literal seed.');
+            const length = rest[0];
+            if (rest.length < 1 + length) throw new Error('Invalid transfer hook literal seed.');
+            seeds.push(rest.subarray(1, 1 + length));
+            i += 2 + length;
+        } else if (discriminator === 2) {
+            if (rest.length < 2) throw new Error('Invalid transfer hook instruction data seed.');
+            const [index, length] = [rest[0], rest[1]];
+            if (instructionData.length < index + length) {
+                throw new Error('Invalid transfer hook instruction data seed.');
+            }
+            seeds.push(instructionData.subarray(index, index + length));
+            i += 3;
+        } else if (discriminator === 3) {
+            if (rest.length < 1) throw new Error('Invalid transfer hook account key seed.');
+            const index = rest[0];
+            if (previousMetas.length <= index) throw new Error('Invalid transfer hook account key seed.');
+            seeds.push(getAddressEncoder().encode(previousMetas[index].address));
+            i += 2;
+        } else if (discriminator === 4) {
+            if (rest.length < 3) throw new Error('Invalid transfer hook account data seed.');
+            const [accountIndex, dataIndex, length] = [rest[0], rest[1], rest[2]];
+            if (previousMetas.length <= accountIndex) {
+                throw new Error('Invalid transfer hook account data seed.');
+            }
+            const data = await fetchAccountData(rpc, previousMetas[accountIndex].address);
+            if (data.length < dataIndex + length) throw new Error('Invalid transfer hook account data seed.');
+            seeds.push(data.subarray(dataIndex, dataIndex + length));
+            i += 4;
+        } else {
+            throw new Error(`Invalid transfer hook seed discriminator ${discriminator}.`);
+        }
+    }
+    return seeds;
+}
+
+async function unpackPubkeyData(
+    keyDataConfig: ReadonlyUint8Array,
+    previousMetas: AccountMeta[],
+    instructionData: ReadonlyUint8Array,
+    rpc: Rpc<GetAccountInfoApi>,
+): Promise<Address> {
+    const discriminator = keyDataConfig[0];
+    const rest = keyDataConfig.subarray(1);
+    if (discriminator === 1) {
+        const dataIndex = rest[0];
+        if (instructionData.length < dataIndex + PUBKEY_LENGTH) {
+            throw new Error('Transfer hook pubkey data too small.');
+        }
+        return getAddressDecoder().decode(instructionData.subarray(dataIndex, dataIndex + PUBKEY_LENGTH));
+    }
+    if (discriminator === 2) {
+        const [accountIndex, dataIndex] = [rest[0], rest[1]];
+        if (previousMetas.length <= accountIndex) {
+            throw new Error('Transfer hook pubkey data account not found.');
+        }
+        const data = await fetchAccountData(rpc, previousMetas[accountIndex].address);
+        if (data.length < dataIndex + PUBKEY_LENGTH) {
+            throw new Error('Transfer hook pubkey data too small.');
+        }
+        return getAddressDecoder().decode(data.subarray(dataIndex, dataIndex + PUBKEY_LENGTH));
+    }
+    throw new Error(`Invalid transfer hook pubkey data discriminator ${discriminator}.`);
+}
+
+function deEscalateAccountMeta(accountMeta: AccountMeta, accountMetas: AccountMeta[]): AccountMeta {
+    const matching = accountMetas.filter(meta => meta.address === accountMeta.address);
+    if (matching.length === 0) return accountMeta;
+    const isSigner = matching.some(meta => isSignerRole(meta.role)) && isSignerRole(accountMeta.role);
+    const isWritable = matching.some(meta => isWritableRole(meta.role)) && isWritableRole(accountMeta.role);
+    return { ...accountMeta, role: roleFromFlags(isSigner, isWritable) };
+}
+
+function getExecuteInstructionData(amount: bigint): ReadonlyUint8Array {
+    const data = new Uint8Array(16);
+    data.set(EXECUTE_DISCRIMINATOR, 0);
+    data.set(getU64Encoder().encode(amount), 8);
+    return data;
+}
+
+function getOwnerAddress(authority: TransferCheckedInput['authority']): Address {
+    return typeof authority === 'string' ? authority : authority.address;
+}
+
+async function addTransferHookAccountsToInstruction<TInstruction extends Instruction>(
+    rpc: Rpc<GetAccountInfoApi>,
+    instruction: TInstruction,
+    input: {
+        amount: bigint | number;
+        authority: TransferCheckedInput['authority'];
+        destination: Address;
+        mint: Address;
+        source: Address;
+    },
+): Promise<TInstruction> {
+    const mint = await fetchMint(rpc, input.mint);
+    const transferHookProgramId = getTransferHookProgramId(mint);
+    if (!transferHookProgramId) {
+        return instruction;
+    }
+    return await addExtraAccountMetasForExecute(rpc, instruction, transferHookProgramId, {
+        amount: input.amount,
+        destination: input.destination,
+        mint: input.mint,
+        owner: getOwnerAddress(input.authority),
+        source: input.source,
+    });
+}
+
+/**
+ * The discriminator of the transfer hook interface's `Execute` instruction:
+ * `sha256("spl-transfer-hook-interface:execute")[0..8]`.
+ */
+export const EXECUTE_DISCRIMINATOR: ReadonlyUint8Array = new Uint8Array([105, 37, 101, 197, 75, 251, 102, 26]);
+
+/** An additional account required by a transfer hook, as stored in the validation account. */
+export type ExtraAccountMeta = {
+    /**
+     * How to resolve the address: 0 = literal key, 1 = PDA off the hook program,
+     * 2 = pubkey data, 128+ = PDA off the program at account index `discriminator - 128`.
+     */
+    discriminator: number;
+    /** 32 bytes of configuration data, interpreted according to the discriminator. */
+    addressConfig: ReadonlyUint8Array;
+    isSigner: boolean;
+    isWritable: boolean;
+};
+
+/** The data of a validation account, listing the extra accounts required by a transfer hook. */
+export type ExtraAccountMetaAccountData = {
+    instructionDiscriminator: bigint;
+    /** The length, in bytes, of the extra account meta list. */
+    length: number;
+    extraAccountMetas: ExtraAccountMeta[];
+};
+
+export type ExtraAccountMetaAccountDataArgs = {
+    instructionDiscriminator: bigint | number;
+    /** The length, in bytes, of the extra account meta list. */
+    length: number;
+    extraAccountMetas: ExtraAccountMeta[];
+};
+
+export function getExtraAccountMetaEncoder(): FixedSizeEncoder<ExtraAccountMeta> {
+    return getStructEncoder([
+        ['discriminator', getU8Encoder()],
+        ['addressConfig', fixEncoderSize(getBytesEncoder(), PUBKEY_LENGTH)],
+        ['isSigner', getBooleanEncoder()],
+        ['isWritable', getBooleanEncoder()],
+    ]);
+}
+
+export function getExtraAccountMetaDecoder(): FixedSizeDecoder<ExtraAccountMeta> {
+    return getStructDecoder([
+        ['discriminator', getU8Decoder()],
+        ['addressConfig', fixDecoderSize(getBytesDecoder(), PUBKEY_LENGTH)],
+        ['isSigner', getBooleanDecoder()],
+        ['isWritable', getBooleanDecoder()],
+    ]);
+}
+
+export function getExtraAccountMetaCodec(): FixedSizeCodec<ExtraAccountMeta> {
+    return combineCodec(getExtraAccountMetaEncoder(), getExtraAccountMetaDecoder());
+}
+
+export function getExtraAccountMetaAccountDataEncoder(): VariableSizeEncoder<ExtraAccountMetaAccountDataArgs> {
+    return getStructEncoder([
+        ['instructionDiscriminator', getU64Encoder()],
+        ['length', getU32Encoder()],
+        ['extraAccountMetas', getArrayEncoder(getExtraAccountMetaEncoder(), { size: getU32Encoder() })],
+    ]);
+}
+
+export function getExtraAccountMetaAccountDataDecoder(): VariableSizeDecoder<ExtraAccountMetaAccountData> {
+    return getStructDecoder([
+        ['instructionDiscriminator', getU64Decoder()],
+        ['length', getU32Decoder()],
+        ['extraAccountMetas', getArrayDecoder(getExtraAccountMetaDecoder(), { size: getU32Decoder() })],
+    ]);
+}
+
+export function getExtraAccountMetaAccountDataCodec(): VariableSizeCodec<
+    ExtraAccountMetaAccountDataArgs,
+    ExtraAccountMetaAccountData
+> {
+    return combineCodec(getExtraAccountMetaAccountDataEncoder(), getExtraAccountMetaAccountDataDecoder());
+}
+
+export type ExtraAccountMetasSeeds = {
+    /** The mint of the token whose transfers invoke the hook. */
+    mint: Address;
+};
+
+/** Derives the address of the validation account that stores a mint's extra account metas. */
+export async function findExtraAccountMetasPda(
+    seeds: ExtraAccountMetasSeeds,
+    config: { programAddress: Address },
+): Promise<ProgramDerivedAddress> {
+    return await getProgramDerivedAddress({
+        programAddress: config.programAddress,
+        seeds: [getUtf8Encoder().encode(EXTRA_ACCOUNT_METAS_SEED), getAddressEncoder().encode(seeds.mint)],
+    });
+}
+
+export function decodeExtraAccountMetaList<TAddress extends string = string>(
+    encodedAccount: EncodedAccount<TAddress>,
+): Account<ExtraAccountMetaAccountData, TAddress>;
+export function decodeExtraAccountMetaList<TAddress extends string = string>(
+    encodedAccount: MaybeEncodedAccount<TAddress>,
+): MaybeAccount<ExtraAccountMetaAccountData, TAddress>;
+export function decodeExtraAccountMetaList<TAddress extends string = string>(
+    encodedAccount: EncodedAccount<TAddress> | MaybeEncodedAccount<TAddress>,
+): Account<ExtraAccountMetaAccountData, TAddress> | MaybeAccount<ExtraAccountMetaAccountData, TAddress> {
+    return decodeAccount(encodedAccount as MaybeEncodedAccount<TAddress>, getExtraAccountMetaAccountDataDecoder());
+}
+
+export async function fetchExtraAccountMetaList<TAddress extends string = string>(
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig,
+): Promise<Account<ExtraAccountMetaAccountData, TAddress>> {
+    const maybeAccount = await fetchMaybeExtraAccountMetaList(rpc, address, config);
+    assertAccountExists(maybeAccount);
+    return maybeAccount;
+}
+
+export async function fetchMaybeExtraAccountMetaList<TAddress extends string = string>(
+    rpc: Parameters<typeof fetchEncodedAccount>[0],
+    address: Address<TAddress>,
+    config?: FetchAccountConfig,
+): Promise<MaybeAccount<ExtraAccountMetaAccountData, TAddress>> {
+    const maybeAccount = await fetchEncodedAccount(rpc, address, config);
+    return decodeExtraAccountMetaList(maybeAccount);
+}
+
+/**
+ * Resolves a single `ExtraAccountMeta` into a concrete `AccountMeta`, given the
+ * metas resolved so far and the data of the instruction being executed.
+ */
+export async function resolveExtraAccountMeta(
+    rpc: Rpc<GetAccountInfoApi>,
+    extraMeta: ExtraAccountMeta,
+    previousMetas: AccountMeta[],
+    instructionData: ReadonlyUint8Array,
+    transferHookProgramId: Address,
+): Promise<AccountMeta> {
+    const role = roleFromFlags(extraMeta.isSigner, extraMeta.isWritable);
+    if (extraMeta.discriminator === 0) {
+        return { address: getAddressDecoder().decode(extraMeta.addressConfig), role };
+    }
+    if (extraMeta.discriminator === 2) {
+        const address = await unpackPubkeyData(extraMeta.addressConfig, previousMetas, instructionData, rpc);
+        return { address, role };
+    }
+
+    let programAddress: Address;
+    if (extraMeta.discriminator === 1) {
+        programAddress = transferHookProgramId;
+    } else if (extraMeta.discriminator >= EXTERNAL_PDA_DISCRIMINATOR_OFFSET) {
+        const accountIndex = extraMeta.discriminator - EXTERNAL_PDA_DISCRIMINATOR_OFFSET;
+        if (previousMetas.length <= accountIndex) {
+            throw new Error('Transfer hook extra account not found.');
+        }
+        programAddress = previousMetas[accountIndex].address;
+    } else {
+        throw new Error(`Invalid transfer hook extra account discriminator ${extraMeta.discriminator}.`);
+    }
+
+    const seeds = await unpackSeeds(extraMeta.addressConfig, previousMetas, instructionData, rpc);
+    const [address] = await getProgramDerivedAddress({ programAddress, seeds });
+    return { address, role };
+}
+
+export type ExecuteInput = {
+    amount: bigint | number;
+    destination: Address;
+    mint: Address;
+    owner: Address;
+    source: Address;
+};
+
+/**
+ * Builds the transfer hook interface's `Execute` instruction, without the
+ * additional accounts listed in the validation account.
+ */
+export function getExecuteInstruction(
+    input: ExecuteInput & { validationAccount: Address },
+    config: { programAddress: Address },
+): Instruction {
+    const accounts: AccountMeta[] = [
+        { address: input.source, role: AccountRole.READONLY },
+        { address: input.mint, role: AccountRole.READONLY },
+        { address: input.destination, role: AccountRole.READONLY },
+        { address: input.owner, role: AccountRole.READONLY },
+        { address: input.validationAccount, role: AccountRole.READONLY },
+    ];
+    return Object.freeze({
+        accounts,
+        data: getExecuteInstructionData(BigInt(input.amount)),
+        programAddress: config.programAddress,
+    });
+}
+
+/**
+ * Resolves the extra account metas stored in a mint's validation account and
+ * returns them — followed by the transfer hook program and the validation
+ * account itself — ready to be appended to a transfer instruction.
+ *
+ * Throws when the validation account does not exist.
+ */
+export async function getExtraAccountMetasForExecute(
+    rpc: Rpc<GetAccountInfoApi>,
+    transferHookProgramId: Address,
+    input: ExecuteInput,
+): Promise<AccountMeta[]> {
+    const [validationAddress] = await findExtraAccountMetasPda(
+        { mint: input.mint },
+        { programAddress: transferHookProgramId },
+    );
+    const validationAccount = await fetchExtraAccountMetaList(rpc, validationAddress);
+
+    const instructionData = getExecuteInstructionData(BigInt(input.amount));
+    const executeMetas: AccountMeta[] = [
+        { address: input.source, role: AccountRole.READONLY },
+        { address: input.mint, role: AccountRole.READONLY },
+        { address: input.destination, role: AccountRole.READONLY },
+        { address: input.owner, role: AccountRole.READONLY },
+        { address: validationAddress, role: AccountRole.READONLY },
+    ];
+
+    for (const extraMeta of validationAccount.data.extraAccountMetas) {
+        const resolved = await resolveExtraAccountMeta(
+            rpc,
+            extraMeta,
+            executeMetas,
+            instructionData,
+            transferHookProgramId,
+        );
+        executeMetas.push(deEscalateAccountMeta(resolved, executeMetas));
+    }
+
+    return [
+        ...executeMetas.slice(5),
+        { address: transferHookProgramId, role: AccountRole.READONLY },
+        { address: validationAddress, role: AccountRole.READONLY },
+    ];
+}
+
+/**
+ * Appends the extra accounts needed by a transfer hook to a transfer
+ * instruction. Throws when the mint's validation account does not exist.
+ */
+export async function addExtraAccountMetasForExecute<TInstruction extends Instruction>(
+    rpc: Rpc<GetAccountInfoApi>,
+    instruction: TInstruction,
+    transferHookProgramId: Address,
+    input: ExecuteInput,
+): Promise<TInstruction> {
+    const requiredAccounts = [input.source, input.mint, input.destination, input.owner];
+    const instructionAccounts = instruction.accounts ?? [];
+    if (!requiredAccounts.every(address => instructionAccounts.some(meta => meta.address === address))) {
+        throw new Error('Missing required account in instruction.');
+    }
+
+    const extraMetas = await getExtraAccountMetasForExecute(rpc, transferHookProgramId, input);
+    return Object.freeze({
+        ...instruction,
+        accounts: [...instructionAccounts, ...extraMetas],
+    });
+}
+
+/**
+ * Returns the program id of the mint's active transfer hook, or `null` when the
+ * mint has no transfer hook extension or the hook program is unset.
+ */
+export function getTransferHookProgramId(mint: Account<Mint>): Address | null {
+    const extensions = mint.data.extensions;
+    if (!isSome(extensions)) return null;
+    const transferHook = extensions.value.find(extension => extension.__kind === 'TransferHook');
+    if (!transferHook || transferHook.programId === DEFAULT_ADDRESS) return null;
+    return transferHook.programId;
+}
+
+/**
+ * Builds a `TransferChecked` instruction with the extra accounts required by
+ * the mint's transfer hook, resolved from its validation account. Throws when
+ * the mint has an active hook whose validation account does not exist.
+ */
+export async function getTransferCheckedWithTransferHookInstructionAsync(
+    rpc: Rpc<GetAccountInfoApi>,
+    input: TransferCheckedInput,
+    config?: { programAddress?: Address },
+): Promise<Instruction> {
+    const instruction = getTransferCheckedInstruction(input, config);
+    return await addTransferHookAccountsToInstruction(rpc, instruction, input);
+}
+
+/**
+ * Builds a `TransferCheckedWithFee` instruction with the extra accounts
+ * required by the mint's transfer hook, resolved from its validation account.
+ * Throws when the mint has an active hook whose validation account does not exist.
+ */
+export async function getTransferCheckedWithFeeAndTransferHookInstructionAsync(
+    rpc: Rpc<GetAccountInfoApi>,
+    input: TransferCheckedWithFeeInput,
+    config?: { programAddress?: Address },
+): Promise<Instruction> {
+    const instruction = getTransferCheckedWithFeeInstruction(input, config);
+    return await addTransferHookAccountsToInstruction(rpc, instruction, input);
+}

--- a/clients/js/src/transferHook.ts
+++ b/clients/js/src/transferHook.ts
@@ -6,6 +6,8 @@ import {
     assertAccountExists,
     combineCodec,
     decodeAccount,
+    downgradeRoleToNonSigner,
+    downgradeRoleToReadonly,
     type EncodedAccount,
     type FetchAccountConfig,
     fetchEncodedAccount,
@@ -42,6 +44,8 @@ import {
     type ProgramDerivedAddress,
     type ReadonlyUint8Array,
     type Rpc,
+    transformEncoder,
+    upgradeRoleToSigner,
     type VariableSizeCodec,
     type VariableSizeDecoder,
     type VariableSizeEncoder,
@@ -61,14 +65,16 @@ const EXTRA_ACCOUNT_METAS_SEED = 'extra-account-metas';
 const PUBKEY_LENGTH = 32;
 
 function roleFromFlags(isSigner: boolean, isWritable: boolean): AccountRole {
-    if (isSigner && isWritable) return AccountRole.WRITABLE_SIGNER;
-    if (isSigner) return AccountRole.READONLY_SIGNER;
-    if (isWritable) return AccountRole.WRITABLE;
-    return AccountRole.READONLY;
+    const role = isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+    return isSigner ? upgradeRoleToSigner(role) : role;
 }
 
-async function fetchAccountData(rpc: Rpc<GetAccountInfoApi>, address: Address): Promise<ReadonlyUint8Array> {
-    const account = await fetchEncodedAccount(rpc, address);
+async function fetchAccountData(
+    rpc: Rpc<GetAccountInfoApi>,
+    address: Address,
+    config?: FetchAccountConfig,
+): Promise<ReadonlyUint8Array> {
+    const account = await fetchEncodedAccount(rpc, address, config);
     assertAccountExists(account);
     return account.data;
 }
@@ -78,6 +84,7 @@ async function unpackSeeds(
     previousMetas: AccountMeta[],
     instructionData: ReadonlyUint8Array,
     rpc: Rpc<GetAccountInfoApi>,
+    config?: FetchAccountConfig,
 ): Promise<ReadonlyUint8Array[]> {
     const seeds: ReadonlyUint8Array[] = [];
     let i = 0;
@@ -112,7 +119,7 @@ async function unpackSeeds(
             if (previousMetas.length <= accountIndex) {
                 throw new Error('Invalid transfer hook account data seed.');
             }
-            const data = await fetchAccountData(rpc, previousMetas[accountIndex].address);
+            const data = await fetchAccountData(rpc, previousMetas[accountIndex].address, config);
             if (data.length < dataIndex + length) throw new Error('Invalid transfer hook account data seed.');
             seeds.push(data.subarray(dataIndex, dataIndex + length));
             i += 4;
@@ -128,6 +135,7 @@ async function unpackPubkeyData(
     previousMetas: AccountMeta[],
     instructionData: ReadonlyUint8Array,
     rpc: Rpc<GetAccountInfoApi>,
+    config?: FetchAccountConfig,
 ): Promise<Address> {
     const discriminator = keyDataConfig[0];
     const rest = keyDataConfig.subarray(1);
@@ -143,7 +151,7 @@ async function unpackPubkeyData(
         if (previousMetas.length <= accountIndex) {
             throw new Error('Transfer hook pubkey data account not found.');
         }
-        const data = await fetchAccountData(rpc, previousMetas[accountIndex].address);
+        const data = await fetchAccountData(rpc, previousMetas[accountIndex].address, config);
         if (data.length < dataIndex + PUBKEY_LENGTH) {
             throw new Error('Transfer hook pubkey data too small.');
         }
@@ -155,16 +163,10 @@ async function unpackPubkeyData(
 function deEscalateAccountMeta(accountMeta: AccountMeta, accountMetas: AccountMeta[]): AccountMeta {
     const matching = accountMetas.filter(meta => meta.address === accountMeta.address);
     if (matching.length === 0) return accountMeta;
-    const isSigner = matching.some(meta => isSignerRole(meta.role)) && isSignerRole(accountMeta.role);
-    const isWritable = matching.some(meta => isWritableRole(meta.role)) && isWritableRole(accountMeta.role);
-    return { ...accountMeta, role: roleFromFlags(isSigner, isWritable) };
-}
-
-function getExecuteInstructionData(amount: bigint): ReadonlyUint8Array {
-    const data = new Uint8Array(16);
-    data.set(EXECUTE_DISCRIMINATOR, 0);
-    data.set(getU64Encoder().encode(amount), 8);
-    return data;
+    let role = accountMeta.role;
+    if (!matching.some(meta => isSignerRole(meta.role))) role = downgradeRoleToNonSigner(role);
+    if (!matching.some(meta => isWritableRole(meta.role))) role = downgradeRoleToReadonly(role);
+    return { ...accountMeta, role };
 }
 
 function getOwnerAddress(authority: TransferCheckedInput['authority']): Address {
@@ -181,19 +183,26 @@ async function addTransferHookAccountsToInstruction<TInstruction extends Instruc
         mint: Address;
         source: Address;
     },
+    config?: FetchAccountConfig,
 ): Promise<TInstruction> {
-    const mint = await fetchMint(rpc, input.mint);
+    const mint = await fetchMint(rpc, input.mint, config);
     const transferHookProgramId = getTransferHookProgramId(mint);
     if (!transferHookProgramId) {
         return instruction;
     }
-    return await addExtraAccountMetasForExecute(rpc, instruction, transferHookProgramId, {
-        amount: input.amount,
-        destination: input.destination,
-        mint: input.mint,
-        owner: getOwnerAddress(input.authority),
-        source: input.source,
-    });
+    return await addExtraAccountMetasForExecute(
+        rpc,
+        instruction,
+        transferHookProgramId,
+        {
+            amount: input.amount,
+            destination: input.destination,
+            mint: input.mint,
+            owner: getOwnerAddress(input.authority),
+            source: input.source,
+        },
+        config,
+    );
 }
 
 /**
@@ -201,6 +210,41 @@ async function addTransferHookAccountsToInstruction<TInstruction extends Instruc
  * `sha256("spl-transfer-hook-interface:execute")[0..8]`.
  */
 export const EXECUTE_DISCRIMINATOR: ReadonlyUint8Array = new Uint8Array([105, 37, 101, 197, 75, 251, 102, 26]);
+
+export function getExecuteDiscriminatorBytes(): ReadonlyUint8Array {
+    return fixEncoderSize(getBytesEncoder(), 8).encode(EXECUTE_DISCRIMINATOR);
+}
+
+/** The data of the transfer hook interface's `Execute` instruction. */
+export type ExecuteInstructionData = {
+    discriminator: ReadonlyUint8Array;
+    amount: bigint;
+};
+
+export type ExecuteInstructionDataArgs = {
+    amount: bigint | number;
+};
+
+export function getExecuteInstructionDataEncoder(): FixedSizeEncoder<ExecuteInstructionDataArgs> {
+    return transformEncoder(
+        getStructEncoder([
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
+            ['amount', getU64Encoder()],
+        ]),
+        value => ({ ...value, discriminator: EXECUTE_DISCRIMINATOR }),
+    );
+}
+
+export function getExecuteInstructionDataDecoder(): FixedSizeDecoder<ExecuteInstructionData> {
+    return getStructDecoder([
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
+        ['amount', getU64Decoder()],
+    ]);
+}
+
+export function getExecuteInstructionDataCodec(): FixedSizeCodec<ExecuteInstructionDataArgs, ExecuteInstructionData> {
+    return combineCodec(getExecuteInstructionDataEncoder(), getExecuteInstructionDataDecoder());
+}
 
 /** An additional account required by a transfer hook, as stored in the validation account. */
 export type ExtraAccountMeta = {
@@ -332,13 +376,14 @@ export async function resolveExtraAccountMeta(
     previousMetas: AccountMeta[],
     instructionData: ReadonlyUint8Array,
     transferHookProgramId: Address,
+    config?: FetchAccountConfig,
 ): Promise<AccountMeta> {
     const role = roleFromFlags(extraMeta.isSigner, extraMeta.isWritable);
     if (extraMeta.discriminator === 0) {
         return { address: getAddressDecoder().decode(extraMeta.addressConfig), role };
     }
     if (extraMeta.discriminator === 2) {
-        const address = await unpackPubkeyData(extraMeta.addressConfig, previousMetas, instructionData, rpc);
+        const address = await unpackPubkeyData(extraMeta.addressConfig, previousMetas, instructionData, rpc, config);
         return { address, role };
     }
 
@@ -355,7 +400,7 @@ export async function resolveExtraAccountMeta(
         throw new Error(`Invalid transfer hook extra account discriminator ${extraMeta.discriminator}.`);
     }
 
-    const seeds = await unpackSeeds(extraMeta.addressConfig, previousMetas, instructionData, rpc);
+    const seeds = await unpackSeeds(extraMeta.addressConfig, previousMetas, instructionData, rpc, config);
     const [address] = await getProgramDerivedAddress({ programAddress, seeds });
     return { address, role };
 }
@@ -385,7 +430,7 @@ export function getExecuteInstruction(
     ];
     return Object.freeze({
         accounts,
-        data: getExecuteInstructionData(BigInt(input.amount)),
+        data: getExecuteInstructionDataEncoder().encode({ amount: input.amount }),
         programAddress: config.programAddress,
     });
 }
@@ -401,14 +446,15 @@ export async function getExtraAccountMetasForExecute(
     rpc: Rpc<GetAccountInfoApi>,
     transferHookProgramId: Address,
     input: ExecuteInput,
+    config?: FetchAccountConfig,
 ): Promise<AccountMeta[]> {
     const [validationAddress] = await findExtraAccountMetasPda(
         { mint: input.mint },
         { programAddress: transferHookProgramId },
     );
-    const validationAccount = await fetchExtraAccountMetaList(rpc, validationAddress);
+    const validationAccount = await fetchExtraAccountMetaList(rpc, validationAddress, config);
 
-    const instructionData = getExecuteInstructionData(BigInt(input.amount));
+    const instructionData = getExecuteInstructionDataEncoder().encode({ amount: input.amount });
     const executeMetas: AccountMeta[] = [
         { address: input.source, role: AccountRole.READONLY },
         { address: input.mint, role: AccountRole.READONLY },
@@ -424,6 +470,7 @@ export async function getExtraAccountMetasForExecute(
             executeMetas,
             instructionData,
             transferHookProgramId,
+            config,
         );
         executeMetas.push(deEscalateAccountMeta(resolved, executeMetas));
     }
@@ -444,6 +491,7 @@ export async function addExtraAccountMetasForExecute<TInstruction extends Instru
     instruction: TInstruction,
     transferHookProgramId: Address,
     input: ExecuteInput,
+    config?: FetchAccountConfig,
 ): Promise<TInstruction> {
     const requiredAccounts = [input.source, input.mint, input.destination, input.owner];
     const instructionAccounts = instruction.accounts ?? [];
@@ -451,7 +499,7 @@ export async function addExtraAccountMetasForExecute<TInstruction extends Instru
         throw new Error('Missing required account in instruction.');
     }
 
-    const extraMetas = await getExtraAccountMetasForExecute(rpc, transferHookProgramId, input);
+    const extraMetas = await getExtraAccountMetasForExecute(rpc, transferHookProgramId, input, config);
     return Object.freeze({
         ...instruction,
         accounts: [...instructionAccounts, ...extraMetas],
@@ -478,10 +526,10 @@ export function getTransferHookProgramId(mint: Account<Mint>): Address | null {
 export async function getTransferCheckedWithTransferHookInstructionAsync(
     rpc: Rpc<GetAccountInfoApi>,
     input: TransferCheckedInput,
-    config?: { programAddress?: Address },
-): Promise<Instruction> {
-    const instruction = getTransferCheckedInstruction(input, config);
-    return await addTransferHookAccountsToInstruction(rpc, instruction, input);
+    config?: { fetchAccountConfig?: FetchAccountConfig; programAddress?: Address },
+) {
+    const instruction = getTransferCheckedInstruction(input, { programAddress: config?.programAddress });
+    return await addTransferHookAccountsToInstruction(rpc, instruction, input, config?.fetchAccountConfig);
 }
 
 /**
@@ -492,8 +540,8 @@ export async function getTransferCheckedWithTransferHookInstructionAsync(
 export async function getTransferCheckedWithFeeAndTransferHookInstructionAsync(
     rpc: Rpc<GetAccountInfoApi>,
     input: TransferCheckedWithFeeInput,
-    config?: { programAddress?: Address },
-): Promise<Instruction> {
-    const instruction = getTransferCheckedWithFeeInstruction(input, config);
-    return await addTransferHookAccountsToInstruction(rpc, instruction, input);
+    config?: { fetchAccountConfig?: FetchAccountConfig; programAddress?: Address },
+) {
+    const instruction = getTransferCheckedWithFeeInstruction(input, { programAddress: config?.programAddress });
+    return await addTransferHookAccountsToInstruction(rpc, instruction, input, config?.fetchAccountConfig);
 }

--- a/clients/js/test/extensions/transferHook/resolveExtraAccountMetas.test.ts
+++ b/clients/js/test/extensions/transferHook/resolveExtraAccountMetas.test.ts
@@ -1,0 +1,444 @@
+import {
+    AccountRole,
+    type AccountMeta,
+    type Address,
+    address,
+    type Base64EncodedBytes,
+    fixEncoderSize,
+    getAddressEncoder,
+    type GetAccountInfoApi,
+    getBase64Decoder,
+    getBytesEncoder,
+    getProgramDerivedAddress,
+    getU64Decoder,
+    getU64Encoder,
+    isSolanaError,
+    type Lamports,
+    none,
+    SOLANA_ERROR__ACCOUNTS__ACCOUNT_NOT_FOUND,
+    type ReadonlyUint8Array,
+    type Rpc,
+    some,
+} from '@solana/kit';
+import test from 'ava';
+import {
+    addExtraAccountMetasForExecute,
+    EXECUTE_DISCRIMINATOR,
+    extension,
+    type ExtraAccountMeta,
+    fetchExtraAccountMetaList,
+    findExtraAccountMetasPda,
+    getExecuteInstruction,
+    getExtraAccountMetaAccountDataCodec,
+    getMintEncoder,
+    getTransferCheckedWithFeeAndTransferHookInstructionAsync,
+    getTransferCheckedWithTransferHookInstructionAsync,
+    resolveExtraAccountMeta,
+    TOKEN_2022_PROGRAM_ADDRESS,
+} from '../../../src';
+
+const TEST_PROGRAM_ID = address('7N4HggYEJAtCLJdnHGCtFqfxcB5rhQCsQTze3ftYstVj');
+const PLAIN_ACCOUNT = address('6c5q79ccBTWvZTEx3JkdHThtMa2eALba5bfvHGf8kA2c');
+const TRANSFER_HOOK_PROGRAM_ID = address('FrgrnfMR3cpnHwbDeZZHnf2rDhmwBDQAhuviVHHzMrAB');
+const ARBITRARY_PROGRAM_ID = address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+const SOURCE = address('Hr87FrCCpgZ2QSDarUDhXZbhe1m9LBpVAEhCMjpiZ1Nu');
+const MINT = address('5gSwsLGzyCwgwPJSnxjsQCaFeE19ZFaibHMLky9TDFim');
+const DESTINATION = address('FtL1iJDFcoBYW3qZRmp45RFMtacKgEqJqkqEHCQ4UTog');
+const AUTHORITY = address('4bxbXTminNNNGsGNeZ8VgvyVnTNVCBjPFHM9DJ4QpvBe');
+
+const addressEncoder = getAddressEncoder();
+
+function getMockRpc(accounts: Record<Address, ReadonlyUint8Array>): Rpc<GetAccountInfoApi> {
+    const getAccountInfo = (address: Address) => ({
+        send: () => {
+            const data = accounts[address];
+            return Promise.resolve({
+                context: { slot: 0n },
+                value: data
+                    ? {
+                          data: [getBase64Decoder().decode(data), 'base64'] as [Base64EncodedBytes, 'base64'],
+                          executable: false,
+                          lamports: 1_000_000n as Lamports,
+                          owner: TOKEN_2022_PROGRAM_ADDRESS,
+                          rentEpoch: 0n,
+                          space: BigInt(data.length),
+                      }
+                    : null,
+            });
+        },
+    });
+    return { getAccountInfo } as unknown as Rpc<GetAccountInfoApi>;
+}
+
+const addressConfigEncoder = fixEncoderSize(getBytesEncoder(), 32);
+const padTo32 = (bytes: number[]) => addressConfigEncoder.encode(new Uint8Array(bytes));
+
+function extraAccountMeta(
+    discriminator: number,
+    addressConfig: ReadonlyUint8Array,
+    isSigner = false,
+    isWritable = false,
+): ExtraAccountMeta {
+    return { addressConfig, discriminator, isSigner, isWritable };
+}
+
+const fixedAddress = (account: Address, isSigner = false, isWritable = false) =>
+    extraAccountMeta(0, new Uint8Array(addressEncoder.encode(account)), isSigner, isWritable);
+const pda = (seeds: number[], isSigner = false, isWritable = false) =>
+    extraAccountMeta(1, padTo32(seeds), isSigner, isWritable);
+const externalPda = (programKeyIndex: number, seeds: number[], isSigner = false, isWritable = false) =>
+    extraAccountMeta((1 << 7) + programKeyIndex, padTo32(seeds), isSigner, isWritable);
+
+function encodeValidationData(extraAccountMetas: ExtraAccountMeta[]): ReadonlyUint8Array {
+    return getExtraAccountMetaAccountDataCodec().encode({
+        extraAccountMetas,
+        instructionDiscriminator: getU64Decoder().decode(EXECUTE_DISCRIMINATOR),
+        length: 4 + 35 * extraAccountMetas.length,
+    });
+}
+
+function createMintData(transferHookProgramId: Address): ReadonlyUint8Array {
+    return getMintEncoder().encode({
+        decimals: 0,
+        extensions: some([
+            extension('TransferHook', {
+                authority: TEST_PROGRAM_ID,
+                programId: transferHookProgramId,
+            }),
+        ]),
+        freezeAuthority: none(),
+        isInitialized: true,
+        mintAuthority: none(),
+        supply: 10_000n,
+    });
+}
+
+test('it fetches and decodes a validation account', async t => {
+    // Given a validation account encoding three kinds of extra account metas.
+    const metas = [fixedAddress(PLAIN_ACCOUNT), pda([3, 0], true, false), externalPda(0, [3, 0], false, true)];
+    const rpc = getMockRpc({ [PLAIN_ACCOUNT]: encodeValidationData(metas) });
+
+    // When we fetch and decode it.
+    const validationAccount = await fetchExtraAccountMetaList(rpc, PLAIN_ACCOUNT);
+
+    // Then we expect the same extra account metas back.
+    t.deepEqual(validationAccount.data.extraAccountMetas, metas);
+});
+
+test('it resolves each kind of extra account meta', async t => {
+    // Given an RPC returning fixed account data, some instruction data and a previously resolved meta.
+    const accountData = new Uint8Array([0, 0, 2, 2, 2, 2, ...addressEncoder.encode(PLAIN_ACCOUNT)]);
+    const rpc = getMockRpc({ [PLAIN_ACCOUNT]: accountData });
+
+    const instructionData = new Uint8Array(64);
+    instructionData.set(Array.from(Array(32).keys()), 0);
+    instructionData.set(addressEncoder.encode(PLAIN_ACCOUNT), 32);
+
+    const previousMetas: AccountMeta[] = [{ address: PLAIN_ACCOUNT, role: AccountRole.READONLY }];
+
+    const seedsConfig = [
+        1,
+        4,
+        ...Buffer.from('seed'), // Literal seed "seed".
+        2,
+        4,
+        4, // Instruction data 4..8.
+        3,
+        0, // Account key at index 0.
+        4,
+        0,
+        2,
+        4, // Account data of account 0, offset 2, length 4.
+    ];
+    const expectedSeeds = [
+        new Uint8Array(Buffer.from('seed')),
+        instructionData.subarray(4, 8),
+        addressEncoder.encode(PLAIN_ACCOUNT),
+        accountData.subarray(2, 6),
+    ];
+
+    // When we resolve a fixed-address meta.
+    const resolvedPlain = await resolveExtraAccountMeta(
+        rpc,
+        fixedAddress(PLAIN_ACCOUNT),
+        [],
+        instructionData,
+        TEST_PROGRAM_ID,
+    );
+
+    // Then we expect its literal address.
+    t.deepEqual(resolvedPlain, { address: PLAIN_ACCOUNT, role: AccountRole.READONLY });
+
+    // When we resolve a PDA meta.
+    const [expectedPda] = await getProgramDerivedAddress({ programAddress: TEST_PROGRAM_ID, seeds: expectedSeeds });
+    const resolvedPda = await resolveExtraAccountMeta(
+        rpc,
+        pda(seedsConfig, true, false),
+        previousMetas,
+        instructionData,
+        TEST_PROGRAM_ID,
+    );
+
+    // Then we expect the address derived from the hook program.
+    t.deepEqual(resolvedPda, { address: expectedPda, role: AccountRole.READONLY_SIGNER });
+
+    // When we resolve an external PDA meta.
+    const [expectedExternalPda] = await getProgramDerivedAddress({
+        programAddress: PLAIN_ACCOUNT,
+        seeds: expectedSeeds,
+    });
+    const resolvedExternalPda = await resolveExtraAccountMeta(
+        rpc,
+        externalPda(0, seedsConfig, false, true),
+        previousMetas,
+        instructionData,
+        TEST_PROGRAM_ID,
+    );
+
+    // Then we expect the address derived from the referenced program.
+    t.deepEqual(resolvedExternalPda, { address: expectedExternalPda, role: AccountRole.WRITABLE });
+
+    // When we resolve pubkey-data metas.
+    const resolvedKeyDataFromInstruction = await resolveExtraAccountMeta(
+        rpc,
+        extraAccountMeta(2, padTo32([1, 32])),
+        [],
+        instructionData,
+        TEST_PROGRAM_ID,
+    );
+    const resolvedKeyDataFromAccount = await resolveExtraAccountMeta(
+        rpc,
+        extraAccountMeta(2, padTo32([2, 0, 6])),
+        previousMetas,
+        instructionData,
+        TEST_PROGRAM_ID,
+    );
+
+    // Then we expect the addresses read from the instruction data and the
+    // referenced account's data.
+    t.deepEqual(resolvedKeyDataFromInstruction, { address: PLAIN_ACCOUNT, role: AccountRole.READONLY });
+    t.deepEqual(resolvedKeyDataFromAccount, { address: PLAIN_ACCOUNT, role: AccountRole.READONLY });
+});
+
+test('it adds extra account metas to a transfer instruction', async t => {
+    // Given a mint with a transfer hook and a validation account listing
+    // a fixed extra account and two seed-derived PDAs.
+    const amount = 100n;
+    const validationAddress = (
+        await findExtraAccountMetasPda({ mint: MINT }, { programAddress: TRANSFER_HOOK_PROGRAM_ID })
+    )[0];
+    const fixedExtra = address('GLQGTjqsTaxjqkqKra2J9C2oTLAW8KPS3SBVLpEsbBED');
+    const validationData = encodeValidationData([
+        fixedAddress(fixedExtra),
+        pda([3, 0, 3, 4]), // Seeds: account key 0 (source), account key 4 (validation account).
+        pda([1, 6, ...Buffer.from('prefix'), 2, 8, 8]), // Seeds: literal "prefix", instruction data 8..16.
+        fixedAddress(ARBITRARY_PROGRAM_ID),
+        // PDA off the program at index 8, seeded by a literal, instruction
+        // data 8..16 and the previously resolved meta at index 6.
+        externalPda(8, [1, 6, ...Buffer.from('prefix'), 2, 8, 8, 3, 6]),
+    ]);
+
+    const rpc = getMockRpc({
+        [MINT]: createMintData(TRANSFER_HOOK_PROGRAM_ID),
+        [validationAddress]: validationData,
+    });
+
+    const [expectedPda1] = await getProgramDerivedAddress({
+        programAddress: TRANSFER_HOOK_PROGRAM_ID,
+        seeds: [addressEncoder.encode(SOURCE), addressEncoder.encode(validationAddress)],
+    });
+    const [expectedPda2] = await getProgramDerivedAddress({
+        programAddress: TRANSFER_HOOK_PROGRAM_ID,
+        seeds: ['prefix', getU64Encoder().encode(amount)],
+    });
+    const [expectedChainedPda] = await getProgramDerivedAddress({
+        programAddress: ARBITRARY_PROGRAM_ID,
+        seeds: ['prefix', getU64Encoder().encode(amount), addressEncoder.encode(expectedPda1)],
+    });
+
+    // When we build a transfer checked instruction with the transfer hook helper.
+    const instruction = await getTransferCheckedWithTransferHookInstructionAsync(rpc, {
+        amount,
+        authority: AUTHORITY,
+        decimals: 0,
+        destination: DESTINATION,
+        mint: MINT,
+        source: SOURCE,
+    });
+
+    // Then we expect the resolved extra accounts, the hook program and the
+    // validation account to be appended to the instruction.
+    t.deepEqual(instruction.accounts, [
+        { address: SOURCE, role: AccountRole.WRITABLE },
+        { address: MINT, role: AccountRole.READONLY },
+        { address: DESTINATION, role: AccountRole.WRITABLE },
+        { address: AUTHORITY, role: AccountRole.READONLY },
+        { address: fixedExtra, role: AccountRole.READONLY },
+        { address: expectedPda1, role: AccountRole.READONLY },
+        { address: expectedPda2, role: AccountRole.READONLY },
+        { address: ARBITRARY_PROGRAM_ID, role: AccountRole.READONLY },
+        { address: expectedChainedPda, role: AccountRole.READONLY },
+        { address: TRANSFER_HOOK_PROGRAM_ID, role: AccountRole.READONLY },
+        { address: validationAddress, role: AccountRole.READONLY },
+    ]);
+});
+
+test('it adds extra account metas to a transfer with fee instruction', async t => {
+    // Given a mint with a transfer hook and a validation account listing a fixed extra account.
+    const validationAddress = (
+        await findExtraAccountMetasPda({ mint: MINT }, { programAddress: TRANSFER_HOOK_PROGRAM_ID })
+    )[0];
+    const fixedExtra = address('GLQGTjqsTaxjqkqKra2J9C2oTLAW8KPS3SBVLpEsbBED');
+    const rpc = getMockRpc({
+        [MINT]: createMintData(TRANSFER_HOOK_PROGRAM_ID),
+        [validationAddress]: encodeValidationData([fixedAddress(fixedExtra)]),
+    });
+
+    // When we build a transfer checked with fee instruction with the transfer hook helper.
+    const instruction = await getTransferCheckedWithFeeAndTransferHookInstructionAsync(rpc, {
+        amount: 100n,
+        authority: AUTHORITY,
+        decimals: 0,
+        destination: DESTINATION,
+        fee: 1n,
+        mint: MINT,
+        source: SOURCE,
+    });
+
+    // Then we expect the extra account, the hook program and the validation
+    // account to be appended to the instruction.
+    t.deepEqual(
+        (instruction.accounts ?? []).slice(4).map(meta => meta.address),
+        [fixedExtra, TRANSFER_HOOK_PROGRAM_ID, validationAddress],
+    );
+});
+
+test('it fails to resolve an extra account meta with an invalid discriminator', async t => {
+    // Given an extra account meta using the reserved discriminator 3.
+    const rpc = getMockRpc({});
+
+    // When we try to resolve it.
+    const promise = resolveExtraAccountMeta(
+        rpc,
+        extraAccountMeta(3, padTo32([])),
+        [],
+        new Uint8Array(),
+        TEST_PROGRAM_ID,
+    );
+
+    // Then we expect an error to be thrown.
+    await t.throwsAsync(promise, { message: 'Invalid transfer hook extra account discriminator 3.' });
+});
+
+test('it fails to resolve a PDA meta whose seed config is truncated', async t => {
+    // Given a PDA meta whose instruction data seed starts on the last config byte.
+    const rpc = getMockRpc({});
+    const truncatedConfig = [1, 28, ...Array<number>(28).fill(7), 2];
+
+    // When we try to resolve it.
+    const promise = resolveExtraAccountMeta(rpc, pda(truncatedConfig), [], new Uint8Array(16), TEST_PROGRAM_ID);
+
+    // Then we expect an error to be thrown.
+    await t.throwsAsync(promise, { message: 'Invalid transfer hook instruction data seed.' });
+});
+
+test('it fails when a required account is missing from the instruction', async t => {
+    // Given an instruction missing the source account.
+    const rpc = getMockRpc({});
+    const instructionMissingSource = {
+        accounts: [
+            { address: MINT, role: AccountRole.READONLY },
+            { address: DESTINATION, role: AccountRole.WRITABLE },
+            { address: AUTHORITY, role: AccountRole.READONLY_SIGNER },
+        ],
+        data: new Uint8Array(),
+        programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    };
+
+    // When we try to add the extra account metas to the instruction.
+    const promise = addExtraAccountMetasForExecute(rpc, instructionMissingSource, TRANSFER_HOOK_PROGRAM_ID, {
+        amount: 100n,
+        destination: DESTINATION,
+        mint: MINT,
+        owner: AUTHORITY,
+        source: SOURCE,
+    });
+
+    // Then we expect an error to be thrown.
+    await t.throwsAsync(promise, { message: 'Missing required account in instruction.' });
+});
+
+test('it fails when the validation account does not exist', async t => {
+    // Given a mint with a transfer hook but no initialized validation account.
+    const rpc = getMockRpc({ [MINT]: createMintData(TRANSFER_HOOK_PROGRAM_ID) });
+
+    // When we try to build a transfer checked instruction with the transfer hook helper.
+    const promise = getTransferCheckedWithTransferHookInstructionAsync(rpc, {
+        amount: 100n,
+        authority: AUTHORITY,
+        decimals: 0,
+        destination: DESTINATION,
+        mint: MINT,
+        source: SOURCE,
+    });
+
+    // Then we expect an account-not-found error to be thrown.
+    const error = await t.throwsAsync(promise);
+    t.true(isSolanaError(error, SOLANA_ERROR__ACCOUNTS__ACCOUNT_NOT_FOUND));
+});
+
+test('it returns the instruction unchanged when the mint has no transfer hook', async t => {
+    // Given a mint without a transfer hook extension.
+    const mintData = getMintEncoder().encode({
+        decimals: 0,
+        extensions: none(),
+        freezeAuthority: none(),
+        isInitialized: true,
+        mintAuthority: none(),
+        supply: 10_000n,
+    });
+    const rpc = getMockRpc({ [MINT]: mintData });
+
+    // When we build a transfer checked instruction with the transfer hook helper.
+    const instruction = await getTransferCheckedWithTransferHookInstructionAsync(rpc, {
+        amount: 100n,
+        authority: AUTHORITY,
+        decimals: 0,
+        destination: DESTINATION,
+        mint: MINT,
+        source: SOURCE,
+    });
+
+    // Then we expect only the four base accounts.
+    t.is(instruction.accounts?.length, 4);
+});
+
+test('it builds an execute instruction', async t => {
+    // Given the base accounts of a transfer with a hooked mint.
+    const validationAccount = (
+        await findExtraAccountMetasPda({ mint: MINT }, { programAddress: TRANSFER_HOOK_PROGRAM_ID })
+    )[0];
+
+    // When we build the execute instruction.
+    const instruction = getExecuteInstruction(
+        {
+            amount: 100n,
+            destination: DESTINATION,
+            mint: MINT,
+            owner: AUTHORITY,
+            source: SOURCE,
+            validationAccount,
+        },
+        { programAddress: TRANSFER_HOOK_PROGRAM_ID },
+    );
+
+    // Then we expect it to target the hook program with the discriminator,
+    // the amount and the base accounts.
+    t.deepEqual(instruction.data, new Uint8Array([...EXECUTE_DISCRIMINATOR, ...getU64Encoder().encode(100n)]));
+    t.is(instruction.programAddress, TRANSFER_HOOK_PROGRAM_ID);
+    t.deepEqual(
+        instruction.accounts?.map(meta => meta.address),
+        [SOURCE, MINT, DESTINATION, AUTHORITY, validationAccount],
+    );
+    t.true(instruction.accounts?.every(meta => meta.role === AccountRole.READONLY));
+});

--- a/clients/js/test/extensions/transferHook/resolveExtraAccountMetas.test.ts
+++ b/clients/js/test/extensions/transferHook/resolveExtraAccountMetas.test.ts
@@ -442,3 +442,46 @@ test('it builds an execute instruction', async t => {
     );
     t.true(instruction.accounts?.every(meta => meta.role === AccountRole.READONLY));
 });
+
+test('it de-escalates extra account metas to the privileges already present', async t => {
+    // Given a validation account listing a writable signer meta for the source
+    // account, already present as readonly, and a writable meta for an
+    // unrelated account.
+    const validationAddress = (
+        await findExtraAccountMetasPda({ mint: MINT }, { programAddress: TRANSFER_HOOK_PROGRAM_ID })
+    )[0];
+    const rpc = getMockRpc({
+        [validationAddress]: encodeValidationData([
+            fixedAddress(SOURCE, true, true),
+            fixedAddress(PLAIN_ACCOUNT, false, true),
+        ]),
+    });
+    const instruction = {
+        accounts: [
+            { address: SOURCE, role: AccountRole.WRITABLE },
+            { address: MINT, role: AccountRole.READONLY },
+            { address: DESTINATION, role: AccountRole.WRITABLE },
+            { address: AUTHORITY, role: AccountRole.READONLY_SIGNER },
+        ],
+        data: new Uint8Array(),
+        programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+    };
+
+    // When we add the extra account metas to the instruction.
+    const withExtraMetas = await addExtraAccountMetasForExecute(rpc, instruction, TRANSFER_HOOK_PROGRAM_ID, {
+        amount: 100n,
+        destination: DESTINATION,
+        mint: MINT,
+        owner: AUTHORITY,
+        source: SOURCE,
+    });
+
+    // Then we expect the source meta to be de-escalated to readonly and the
+    // unrelated meta to keep its privileges.
+    t.deepEqual(withExtraMetas.accounts.slice(4), [
+        { address: SOURCE, role: AccountRole.READONLY },
+        { address: PLAIN_ACCOUNT, role: AccountRole.WRITABLE },
+        { address: TRANSFER_HOOK_PROGRAM_ID, role: AccountRole.READONLY },
+        { address: validationAddress, role: AccountRole.READONLY },
+    ]);
+});

--- a/clients/js/test/extensions/transferHook/transferCheckedWithTransferHook.test.ts
+++ b/clients/js/test/extensions/transferHook/transferCheckedWithTransferHook.test.ts
@@ -1,0 +1,254 @@
+import { getTransferSolInstruction, SYSTEM_PROGRAM_ADDRESS } from '@solana-program/system';
+import {
+    type AccountMeta,
+    AccountRole,
+    type AccountSignerMeta,
+    type Address,
+    address,
+    fixEncoderSize,
+    generateKeyPairSigner,
+    getAddressEncoder,
+    getArrayEncoder,
+    getBytesEncoder,
+    getProgramDerivedAddress,
+    getU32Encoder,
+    getUtf8Encoder,
+    type Instruction,
+    isSolanaError,
+    lamports,
+    SOLANA_ERROR__INSTRUCTION_ERROR__MISSING_ACCOUNT,
+    type TransactionSigner,
+} from '@solana/kit';
+import test from 'ava';
+import {
+    extension,
+    type ExtraAccountMeta,
+    fetchToken,
+    findExtraAccountMetasPda,
+    getExtraAccountMetaEncoder,
+    getTransferCheckedWithTransferHookInstructionAsync,
+    type Token,
+} from '../../../src';
+import {
+    type Client,
+    createDefaultSolanaClient,
+    createMint,
+    createToken,
+    createTokenWithAmount,
+    generateKeyPairSignerWithSol,
+    sendAndConfirmInstructions,
+} from '../../_setup';
+
+const TRANSFER_HOOK_TEST_PROGRAM_ID = address('TokenHookExampLe8smaVNrxTBezWTRbEwxwb1Zykrb');
+
+// sha256("spl-transfer-hook-interface:initialize-extra-account-metas")[0..8]
+const INITIALIZE_EXTRA_ACCOUNT_METAS_DISCRIMINATOR = new Uint8Array([43, 34, 13, 49, 167, 88, 235, 235]);
+
+function getInitializeExtraAccountMetaListInstruction(input: {
+    authority: TransactionSigner;
+    extraAccountMetas: ExtraAccountMeta[];
+    mint: Address;
+    validationAccount: Address;
+}): Instruction {
+    const metasData = getArrayEncoder(getExtraAccountMetaEncoder(), { size: getU32Encoder() }).encode(
+        input.extraAccountMetas,
+    );
+    const data = new Uint8Array(8 + metasData.length);
+    data.set(INITIALIZE_EXTRA_ACCOUNT_METAS_DISCRIMINATOR, 0);
+    data.set(metasData, 8);
+
+    const accounts: (AccountMeta | AccountSignerMeta)[] = [
+        { address: input.validationAccount, role: AccountRole.WRITABLE },
+        { address: input.mint, role: AccountRole.READONLY },
+        { address: input.authority.address, role: AccountRole.READONLY_SIGNER, signer: input.authority },
+        { address: SYSTEM_PROGRAM_ADDRESS, role: AccountRole.READONLY },
+    ];
+
+    return { accounts, data, programAddress: TRANSFER_HOOK_TEST_PROGRAM_ID };
+}
+
+async function createMintWithTransferHook(client: Client, authority: TransactionSigner) {
+    return await createMint({
+        authority,
+        client,
+        decimals: 2,
+        extensions: [
+            extension('TransferHook', {
+                authority: authority.address,
+                programId: TRANSFER_HOOK_TEST_PROGRAM_ID,
+            }),
+        ],
+        payer: authority,
+    });
+}
+
+test('it transfers tokens by resolving the extra accounts required by the transfer hook', async t => {
+    // Given some signer accounts.
+    const client = createDefaultSolanaClient();
+    const [authority, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
+    ]);
+
+    // And a mint with a transfer hook pointing at the example hook program.
+    const mint = await createMintWithTransferHook(client, authority);
+
+    // And source and destination token accounts with transfer hook extensions.
+    const transferHookAccount = extension('TransferHookAccount', { transferring: false });
+    const [source, destination] = await Promise.all([
+        createTokenWithAmount({
+            amount: 1000n,
+            client,
+            extensions: [transferHookAccount],
+            mint,
+            mintAuthority: authority,
+            owner: authority,
+            payer: authority,
+        }),
+        createToken({
+            client,
+            extensions: [transferHookAccount],
+            mint,
+            owner: destinationOwner,
+            payer: authority,
+        }),
+    ]);
+
+    // And a validation account listing a fixed extra account and a seed-derived PDA.
+    const validationAccount = (
+        await findExtraAccountMetasPda({ mint }, { programAddress: TRANSFER_HOOK_TEST_PROGRAM_ID })
+    )[0];
+    const fixedExtraAccount = address('GLQGTjqsTaxjqkqKra2J9C2oTLAW8KPS3SBVLpEsbBED');
+    const pdaSeedsConfig = fixEncoderSize(getBytesEncoder(), 32).encode(
+        new Uint8Array([1, 6, ...getUtf8Encoder().encode('prefix'), 3, 0]),
+    );
+    await sendAndConfirmInstructions(client, authority, [
+        getInitializeExtraAccountMetaListInstruction({
+            authority,
+            extraAccountMetas: [
+                {
+                    addressConfig: getAddressEncoder().encode(fixedExtraAccount),
+                    discriminator: 0,
+                    isSigner: false,
+                    isWritable: false,
+                },
+                {
+                    addressConfig: pdaSeedsConfig,
+                    discriminator: 1,
+                    isSigner: false,
+                    isWritable: false,
+                },
+            ],
+            mint,
+            validationAccount,
+        }),
+        getTransferSolInstruction({
+            amount: lamports(10_000_000n),
+            destination: validationAccount,
+            source: authority,
+        }),
+    ]);
+
+    // When we build and send a transfer using the transfer hook helper.
+    const transferInstruction = await getTransferCheckedWithTransferHookInstructionAsync(client.rpc, {
+        amount: 100n,
+        authority,
+        decimals: 2,
+        destination,
+        mint,
+        source,
+    });
+    await sendAndConfirmInstructions(client, authority, [transferInstruction]);
+
+    // Then the helper resolved the hook accounts onto the instruction.
+    const [expectedPda] = await getProgramDerivedAddress({
+        programAddress: TRANSFER_HOOK_TEST_PROGRAM_ID,
+        seeds: ['prefix', getAddressEncoder().encode(source)],
+    });
+    const appendedAddresses = (transferInstruction.accounts ?? []).slice(4).map(meta => meta.address);
+    t.deepEqual(appendedAddresses, [fixedExtraAccount, expectedPda, TRANSFER_HOOK_TEST_PROGRAM_ID, validationAccount]);
+
+    // And we expect the tokens to have been transferred.
+    const [{ data: sourceData }, { data: destinationData }] = await Promise.all([
+        fetchToken(client.rpc, source),
+        fetchToken(client.rpc, destination),
+    ]);
+    t.like(sourceData, <Token>{ amount: 900n });
+    t.like(destinationData, <Token>{ amount: 100n });
+});
+
+test('it fails to transfer when the hook accounts are not forwarded', async t => {
+    // Given some signer accounts.
+    const client = createDefaultSolanaClient();
+    const [authority, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
+    ]);
+
+    // And a mint with a transfer hook pointing at the example hook program.
+    const mint = await createMintWithTransferHook(client, authority);
+
+    const transferHookAccount = extension('TransferHookAccount', { transferring: false });
+    const [source, destination] = await Promise.all([
+        createTokenWithAmount({
+            amount: 1000n,
+            client,
+            extensions: [transferHookAccount],
+            mint,
+            mintAuthority: authority,
+            owner: authority,
+            payer: authority,
+        }),
+        createToken({
+            client,
+            extensions: [transferHookAccount],
+            mint,
+            owner: destinationOwner,
+            payer: authority,
+        }),
+    ]);
+
+    const validationAccount = (
+        await findExtraAccountMetasPda({ mint }, { programAddress: TRANSFER_HOOK_TEST_PROGRAM_ID })
+    )[0];
+    const fixedExtraAccount = address('GLQGTjqsTaxjqkqKra2J9C2oTLAW8KPS3SBVLpEsbBED');
+    await sendAndConfirmInstructions(client, authority, [
+        getInitializeExtraAccountMetaListInstruction({
+            authority,
+            extraAccountMetas: [
+                {
+                    addressConfig: getAddressEncoder().encode(fixedExtraAccount),
+                    discriminator: 0,
+                    isSigner: false,
+                    isWritable: false,
+                },
+            ],
+            mint,
+            validationAccount,
+        }),
+        getTransferSolInstruction({
+            amount: lamports(10_000_000n),
+            destination: validationAccount,
+            source: authority,
+        }),
+    ]);
+
+    // When we send a transfer without the resolved hook accounts.
+    const transferInstruction = await getTransferCheckedWithTransferHookInstructionAsync(client.rpc, {
+        amount: 100n,
+        authority,
+        decimals: 2,
+        destination,
+        mint,
+        source,
+    });
+    const strippedInstruction = {
+        ...transferInstruction,
+        accounts: (transferInstruction.accounts ?? []).slice(0, 4),
+    };
+    const promise = sendAndConfirmInstructions(client, authority, [strippedInstruction]);
+
+    // Then we expect a missing-account error.
+    const error = await t.throwsAsync(promise, { message: 'Transaction simulation failed' });
+    t.true(isSolanaError(error?.cause, SOLANA_ERROR__INSTRUCTION_ERROR__MISSING_ACCOUNT));
+});


### PR DESCRIPTION
## Summary

Adds transfer hook support to the kit-based JS client as hand-written helpers in `clients/js/src`, porting the extra-account-meta resolution that previously only existed in `clients/js-legacy`. Closes #736.

- **Codecs**: `ExtraAccountMeta` and `ExtraAccountMetaAccountData` (with an `Args` type for encoding), plus `EXECUTE_DISCRIMINATOR`.
- **Account and PDA helpers**, following the generated client conventions: `decodeExtraAccountMetaList`, `fetchExtraAccountMetaList`, `fetchMaybeExtraAccountMetaList` and `findExtraAccountMetasPda`.
- **Resolution**: `resolveExtraAccountMeta` covering every address config — literal key, hook-program PDA, pubkey data (from instruction or account data) and external-program PDA — and every seed type (literal, instruction data, account key, account data); `getExtraAccountMetasForExecute` and `addExtraAccountMetasForExecute`, including the legacy client's privilege de-escalation.
- **Instruction builders**: `getExecuteInstruction`, `getTransferCheckedWithTransferHookInstructionAsync` and `getTransferCheckedWithFeeAndTransferHookInstructionAsync`, which fetch the mint, resolve the hook's extra accounts and append them (plus hook program and validation account) to the generated instruction. `getTransferHookProgramId` exposes the mint's active hook.

Behavior:

- Mints without a transfer hook, or with an inert one (`programId` unset), build the plain transfer instruction with no extra RPC calls.
- An active hook whose validation account does not exist throws `SOLANA_ERROR__ACCOUNTS__ACCOUNT_NOT_FOUND`, matching the Rust offchain helper. (The legacy JS client silently returns the instruction unchanged, which fails on-chain later.)
- Reserved discriminators 3..127 and truncated seed configs are rejected with explicit errors. (The legacy JS client crashes on the former and mis-resolves the latter.)

## Tests

- `test/extensions/transferHook/resolveExtraAccountMetas.test.ts` — mock-RPC unit tests: validation account fetch/decode round-trip, every address-config discriminator including a chained external PDA, the with-fee builder, missing required account, missing validation account, invalid discriminator and truncated seed config.
- `test/extensions/transferHook/transferCheckedWithTransferHook.test.ts` — e2e against the test validator's `spl-transfer-hook-example` fixture: the builder resolves a fixed extra account and a seed-derived PDA, the transfer succeeds with the hook executing, and a transfer without the forwarded hook accounts fails with `SOLANA_ERROR__INSTRUCTION_ERROR__MISSING_ACCOUNT`.

`pnpm test` (tsc + ava, 140 tests) passes against the local test validator; `eslint` and `prettier` clean.
