### PR TITLE
fix(js): move confidential transfer helpers to /confidential subpath

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -12,6 +12,11 @@
             "types": "./dist/types/index.d.ts",
             "import": "./dist/src/index.mjs",
             "require": "./dist/src/index.js"
+        },
+        "./confidential": {
+            "types": "./dist/types/confidential.d.ts",
+            "import": "./dist/src/confidential.mjs",
+            "require": "./dist/src/confidential.js"
         }
     },
     "files": [

--- a/clients/js/src/confidential.ts
+++ b/clients/js/src/confidential.ts
@@ -1,0 +1,2 @@
+export * from './confidentialTransferHelpers';
+export * from './confidentialTransferKeys';

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -4,8 +4,6 @@ export * from './generated';
 export { type BatchInstruction, getBatchInstruction, parseBatchInstruction } from './batch';
 
 export * from './amountToUiAmount';
-export * from './confidentialTransferHelpers';
-export * from './confidentialTransferKeys';
 export * from './getInitializeInstructionsForExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -42,9 +42,7 @@ import {
     extension,
     fetchToken,
     findAssociatedTokenPda,
-    getApplyConfidentialPendingBalanceInstructionFromToken,
     getConfidentialDepositInstruction,
-    getCreateConfidentialTransferAccountInstructionPlan,
     getInitializeAccountInstruction,
     getInitializeMintInstruction,
     getMintSize,
@@ -54,6 +52,10 @@ import {
     getPreInitializeInstructionsForMintExtensions,
     getTokenSize,
 } from '../src';
+import {
+    getApplyConfidentialPendingBalanceInstructionFromToken,
+    getCreateConfidentialTransferAccountInstructionPlan,
+} from '../src/confidential';
 
 export type Client = {
     rpc: Rpc<SolanaRpcApi>;

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -8,13 +8,15 @@ import {
 } from '@solana/kit';
 import test from 'ava';
 import {
+    getInitializeConfidentialTransferMintInstruction,
+    parseInitializeConfidentialTransferMintInstruction,
+} from '../src';
+import {
     deriveAeKey,
     deriveAeKeyForOwnerMint,
     deriveElGamalKeypair,
     deriveElGamalKeypairForOwnerMint,
-    getInitializeConfidentialTransferMintInstruction,
-    parseInitializeConfidentialTransferMintInstruction,
-} from '../src';
+} from '../src/confidential';
 
 const ADDRESS_DECODER = getAddressDecoder();
 const ADDRESS_ENCODER = getAddressEncoder();

--- a/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/confidentialTransferHelpers.test.ts
@@ -1,7 +1,7 @@
 import { generateKeyPairSigner } from '@solana/kit';
 import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import test from 'ava';
-import { getCreateConfidentialTransferAccountInstructionPlan } from '../../../src';
+import { getCreateConfidentialTransferAccountInstructionPlan } from '../../../src/confidential';
 import { createDefaultSolanaClient } from '../../_setup';
 
 test('it rejects create helper authority that does not match the owner ATA flow', async t => {

--- a/clients/js/test/extensions/confidentialTransfer/getApplyConfidentialPendingBalanceInstructionFromToken.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getApplyConfidentialPendingBalanceInstructionFromToken.test.ts
@@ -1,10 +1,6 @@
 import test from 'ava';
-import {
-    fetchToken,
-    getApplyConfidentialPendingBalanceInstructionFromToken,
-    getConfidentialDepositInstruction,
-    getMintToInstruction,
-} from '../../../src';
+import { fetchToken, getConfidentialDepositInstruction, getMintToInstruction } from '../../../src';
+import { getApplyConfidentialPendingBalanceInstructionFromToken } from '../../../src/confidential';
 import {
     createConfidentialMint,
     createConfidentialTokenAccount,

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import { fetchToken, getConfidentialTransferInstructionPlan } from '../../../src';
+import { fetchToken } from '../../../src';
+import { getConfidentialTransferInstructionPlan } from '../../../src/confidential';
 import {
     createConfidentialMint,
     createConfidentialTokenAccount,

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialWithdrawInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialWithdrawInstructionPlan.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
-import { fetchToken, getConfidentialWithdrawInstructionPlan } from '../../../src';
+import { fetchToken } from '../../../src';
+import { getConfidentialWithdrawInstructionPlan } from '../../../src/confidential';
 import {
     createConfidentialMint,
     createConfidentialTokenAccountWithBalance,

--- a/clients/js/tsup.config.ts
+++ b/clients/js/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, Options } from 'tsup';
 
 const SHARED_OPTIONS: Options = {
     define: { __VERSION__: `"${env.npm_package_version}"` },
-    entry: ['./src/index.ts'],
+    entry: ['./src/index.ts', './src/confidential.ts'],
     outDir: './dist/src',
     outExtension: ({ format }) => ({ js: format === 'cjs' ? '.js' : '.mjs' }),
     sourcemap: true,

--- a/clients/js/typedoc.json
+++ b/clients/js/typedoc.json
@@ -1,5 +1,5 @@
 {
-    "entryPoints": ["src/index.ts"],
+    "entryPoints": ["src/index.ts", "src/confidential.ts"],
     "includeVersion": true,
     "readme": "none",
     "out": "docs"


### PR DESCRIPTION
Importing `@solana-program/token-2022` failed with `ERR_MODULE_NOT_FOUND: Cannot find package '@solana/zk-sdk'` even when confidential transfer helpers were never used.

`@solana/zk-sdk` is declared as an optional peer dependency, but that only suppresses install-time warnings. The root barrel statically re-exported the confidential transfer modules, which import `@solana/zk-sdk` at the top level — so any import of the package eagerly resolved zk-sdk and threw when it wasn't installed.

## Changes

- Move the zk-sdk-dependent confidential transfer helpers to a dedicated `@solana-program/token-2022/confidential` subpath export.
- Remove confidential transfer exports from the root barrel so the main entry no longer references `@solana/zk-sdk`.
- Add the `./confidential` entry to the build config and `exports` map.
- Update tests to import the moved helpers from the subpath.

## Migration

Consumers using confidential transfers should import from the subpath and install the optional peer dependency:

```ts
import { 
    deriveElGamalKeypair, 
    getConfidentialTransferInstructionPlan 
} from '@solana-program/token-2022/confidential';
```

The root import no longer requires `@solana/zk-sdk`.

## Testing

- `tsc --noEmit`, `eslint`, and the build all pass.
- Locally tested that the published 0.10.0 build reproduces the error, and the local build resolves it: the root entry imports cleanly without `@solana/zk-sdk` installed, while the `/confidential` subpath loads correctly once the peer dependency is present.
