### PR TITLE
Fix CPI Guard bypass: block close_authority set to None during CPI

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -769,7 +769,7 @@ impl Processor {
                     )?;
 
                     if let Ok(cpi_guard) = account.get_extension::<CpiGuard>() {
-                        if cpi_guard.lock_cpi.into() && in_cpi() && new_authority.is_some() {
+                        if cpi_guard.lock_cpi.into() && in_cpi() {
                             return Err(TokenError::CpiGuardSetAuthorityBlocked.into());
                         }
                     }
@@ -2349,6 +2349,7 @@ mod tests {
         solana_sdk_ids::sysvar::rent,
         spl_token_2022_interface::{
             extension::{
+                cpi_guard::instruction::enable_cpi_guard,
                 permissioned_burn, transfer_fee::instruction::initialize_transfer_fee_config,
                 ExtensionType,
             },
@@ -5864,6 +5865,96 @@ mod tests {
                 )
                 .unwrap(),
                 vec![&mut account_account, &mut owner_account],
+            )
+        );
+    }
+
+    #[test]
+    fn test_set_authority_with_cpi_guard_extension() {
+        let program_id = crate::id();
+        let account_key = Address::new_unique();
+
+        let account_len =
+            ExtensionType::try_calculate_account_len::<Account>(&[ExtensionType::CpiGuard])
+                .unwrap();
+        let mut account_account = SolanaAccount::new(
+            Rent::default().minimum_balance(account_len),
+            account_len,
+            &program_id,
+        );
+        let owner_key = Address::new_unique();
+        let mut owner_account = SolanaAccount::default();
+        let owner2_key = Address::new_unique();
+        let mut owner2_account = SolanaAccount::default();
+
+        let mint_key = Address::new_unique();
+        let mut mint_account =
+            SolanaAccount::new(mint_minimum_balance(), Mint::get_packed_len(), &program_id);
+        let mut rent_sysvar = rent_sysvar();
+
+        // create mint
+        assert_eq!(
+            Ok(()),
+            do_process_instruction(
+                initialize_mint(&program_id, &mint_key, &owner_key, None, 2).unwrap(),
+                vec![&mut mint_account, &mut rent_sysvar],
+            )
+        );
+
+        // create account
+        assert_eq!(
+            Ok(()),
+            do_process_instruction(
+                initialize_account(&program_id, &account_key, &mint_key, &owner_key).unwrap(),
+                vec![
+                    &mut account_account,
+                    &mut mint_account,
+                    &mut owner_account,
+                    &mut rent_sysvar,
+                ],
+            )
+        );
+
+        // enable CPI Guard
+        assert_eq!(
+            Ok(()),
+            do_process_instruction(
+                enable_cpi_guard(&program_id, &account_key, &owner_key, &[]).unwrap(),
+                vec![&mut account_account, &mut owner_account],
+            )
+        );
+
+        // close_authority may be set to Some when CPI Guard is enabled
+        assert_eq!(
+            Ok(()),
+            do_process_instruction(
+                set_authority(
+                    &program_id,
+                    &account_key,
+                    Some(&owner2_key),
+                    AuthorityType::CloseAccount,
+                    &owner_key,
+                    &[]
+                )
+                .unwrap(),
+                vec![&mut account_account, &mut owner_account],
+            )
+        );
+
+        // close_authority may be set to None when CPI Guard is enabled (not in CPI)
+        assert_eq!(
+            Ok(()),
+            do_process_instruction(
+                set_authority(
+                    &program_id,
+                    &account_key,
+                    None,
+                    AuthorityType::CloseAccount,
+                    &owner2_key,
+                    &[]
+                )
+                .unwrap(),
+                vec![&mut account_account, &mut owner2_account],
             )
         );
     }


### PR DESCRIPTION
### Problem

In `processor.rs:772`, the CPI Guard check for `AuthorityType::CloseAccount` requires `new_authority.is_some()`:

if cpi_guard.lock_cpi.into() && in_cpi() && new_authority.is_some() {
    return Err(TokenError::CpiGuardSetAuthorityBlocked.into());
}

This means setting `close_authority = None` during CPI bypasses the CPI Guard entirely. The `AccountOwner` path (line 737) does not have this condition.

Per the CPI Guard spec, `SetAuthority` should only allow *removing an existing close authority* during CPI -- but the guard should still be enforced.

### Fix

Remove `&& new_authority.is_some()` so `set_authority(CloseAccount, None)` is also blocked during CPI when CPI Guard is enabled.

### Test

`test_set_authority_with_cpi_guard_extension` creates a token account with CPI Guard, enables it, and verifies that setting `close_authority` to both `Some` and `None` succeeds outside CPI (where `in_cpi()` returns `false`). A full CPI-path validation requires running against a Solana validator.