### PR TITLE
deps: Bump solana-zk-sdk to v7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -899,7 +899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1203,7 +1203,7 @@ dependencies = [
  "getrandom 0.2.15",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -3019,7 +3019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_xorshift 0.3.0",
  "subtle",
@@ -3169,6 +3169,15 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hmac"
@@ -4748,7 +4757,7 @@ dependencies = [
  "lazy_static",
  "percent-encoding 2.3.2",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
 ]
 
@@ -5303,9 +5312,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6342,7 +6351,7 @@ dependencies = [
  "futures 0.3.32",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -6696,7 +6705,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "serde",
  "serde_json",
@@ -8545,7 +8554,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "percentage",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "solana-account",
  "solana-account-info",
@@ -8697,7 +8706,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "solana-address 1.1.0",
 ]
 
@@ -9225,7 +9234,7 @@ dependencies = [
  "hash32",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-demangle",
  "thiserror 2.0.18",
  "winapi",
@@ -9242,7 +9251,7 @@ dependencies = [
  "hash32",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-demangle",
  "thiserror 2.0.18",
  "winapi",
@@ -9827,7 +9836,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3f2dab6bc6fd16f43942922ba53d7bc947666ef3a121d74ccb426f01ae1eaf"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10557,7 +10566,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -10592,7 +10601,7 @@ dependencies = [
  "merlin",
  "num-derive",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -10612,21 +10621,23 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "6.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9664f023aac0b5976cb036684cd3d5ab3c4f12beadafafdcf87c3ba19f868887"
+checksum = "96cd8535d2f40d43a1d47af2849e1c86706a597a2ad84207441f51a50f09d8fd"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
  "bincode",
  "bytemuck",
  "curve25519-dalek 4.1.3",
+ "hkdf",
  "itertools 0.14.0",
  "merlin",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.9",
  "sha3",
  "solana-address 2.6.1",
  "solana-derivation-path",
@@ -11019,7 +11030,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-system-interface 3.2.0",
  "solana-test-validator",
- "solana-zk-sdk 6.0.1",
+ "solana-zk-sdk 7.0.1",
  "solana-zk-sdk-pod",
  "spl-associated-token-account-interface",
  "spl-memo-interface",
@@ -11069,7 +11080,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-zk-elgamal-proof-interface",
- "solana-zk-sdk 6.0.1",
+ "solana-zk-sdk 7.0.1",
  "solana-zk-sdk-pod",
  "spl-associated-token-account-interface",
  "spl-elgamal-registry",
@@ -11098,7 +11109,7 @@ dependencies = [
  "bytemuck",
  "curve25519-dalek 4.1.3",
  "solana-curve25519 4.0.1",
- "solana-zk-sdk 6.0.1",
+ "solana-zk-sdk 7.0.1",
  "solana-zk-sdk-pod",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
 ]
@@ -11158,7 +11169,7 @@ version = "0.6.0"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-elgamal-proof-interface",
- "solana-zk-sdk 6.0.1",
+ "solana-zk-sdk 7.0.1",
  "solana-zk-sdk-pod",
  "thiserror 2.0.18",
 ]
@@ -11169,7 +11180,7 @@ version = "0.0.1"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-elgamal-proof-interface",
- "solana-zk-sdk 6.0.1",
+ "solana-zk-sdk 7.0.1",
  "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-confidential-transfer-proof-generation 0.6.0",
  "thiserror 2.0.18",
@@ -11530,7 +11541,7 @@ dependencies = [
  "humantime",
  "opentelemetry",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "static_assertions",
  "tarpc-plugins",
@@ -11747,7 +11758,7 @@ checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash 1.1.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -12003,7 +12014,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util 0.7.18",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -30,7 +30,7 @@ solana-logger = "3.0.0"
 solana-remote-wallet = { version = "3.1.0", features = ["agave-unstable-api"] }
 solana-sdk = "3.0.0"
 solana-system-interface = "3.2.0"
-solana-zk-sdk = "6.0.1"
+solana-zk-sdk = "7.0.1"
 solana-zk-sdk-pod = "0.1.2"
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-memo-interface = "2.1.0"

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -35,6 +35,7 @@ use {
     solana_system_interface::program as system_program,
     solana_zk_sdk::encryption::{
         auth_encryption::AeKey,
+        derivation::derive_confidential_keys,
         elgamal::{self, ElGamalKeypair},
     },
     solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey,
@@ -338,8 +339,8 @@ async fn command_create_token(
             //
             // NOTE: Seed bytes are hardcoded to be empty bytes for now. They
             // will be updated once custom ElGamal keys are supported.
-            let elgamal_keypair =
-                ElGamalKeypair::new_from_signer(config.default_signer()?.as_ref(), b"").unwrap();
+            let (elgamal_keypair, _) =
+                derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap();
             extensions.push(
                 ExtensionInitializationParams::ConfidentialTransferFeeConfig {
                     authority: Some(authority),
@@ -4188,9 +4189,8 @@ pub async fn process_command(
                 //
                 // NOTE:: Seed bytes are hardcoded to be empty bytes for now. They will be
                 // updated once custom ElGamal and AES keys are supported.
-                let sender_elgamal_keypair =
-                    ElGamalKeypair::new_from_signer(&*owner_signer, b"").unwrap();
-                let sender_aes_key = AeKey::new_from_signer(&*owner_signer, b"").unwrap();
+                let (sender_elgamal_keypair, sender_aes_key) =
+                    derive_confidential_keys(&*owner_signer, b"").unwrap();
 
                 // Sign-only mode is not yet supported for confidential transfers, so set
                 // recipient and auditor ElGamal public to `None` by default.
@@ -4863,8 +4863,7 @@ pub async fn process_command(
             //
             // NOTE:: Seed bytes are hardcoded to be empty bytes for now. They will be
             // updated once custom ElGamal and AES keys are supported.
-            let elgamal_keypair = ElGamalKeypair::new_from_signer(&*owner_signer, b"").unwrap();
-            let aes_key = AeKey::new_from_signer(&*owner_signer, b"").unwrap();
+            let (elgamal_keypair, aes_key) = derive_confidential_keys(&*owner_signer, b"").unwrap();
 
             if config.multisigner_pubkeys.is_empty() {
                 push_signer_with_dedup(owner_signer, &mut bulk_signers);
@@ -4949,9 +4948,8 @@ pub async fn process_command(
                     //
                     // NOTE:: Seed bytes are hardcoded to be empty bytes for now. They will be
                     // updated once custom ElGamal and AES keys are supported.
-                    let elgamal_keypair =
-                        ElGamalKeypair::new_from_signer(&*owner_signer, b"").unwrap();
-                    let aes_key = AeKey::new_from_signer(&*owner_signer, b"").unwrap();
+                    let (elgamal_keypair, aes_key) =
+                        derive_confidential_keys(&*owner_signer, b"").unwrap();
 
                     (
                         ConfidentialInstructionType::Withdraw,
@@ -4993,8 +4991,7 @@ pub async fn process_command(
             //
             // NOTE:: Seed bytes are hardcoded to be empty bytes for now. They will be
             // updated once custom ElGamal and AES keys are supported.
-            let elgamal_keypair = ElGamalKeypair::new_from_signer(&*owner_signer, b"").unwrap();
-            let aes_key = AeKey::new_from_signer(&*owner_signer, b"").unwrap();
+            let (elgamal_keypair, aes_key) = derive_confidential_keys(&*owner_signer, b"").unwrap();
 
             if config.multisigner_pubkeys.is_empty() {
                 push_signer_with_dedup(owner_signer, &mut bulk_signers);

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -44,7 +44,7 @@ solana-signature = "3.0.0"
 solana-signer = "3.0.0"
 solana-system-interface = "3.2.0"
 solana-transaction = "3.0.0"
-solana-zk-sdk = "6.0.1"
+solana-zk-sdk = "7.0.1"
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-elgamal-registry = { version = "0.5.0", path = "../../confidential/elgamal-registry", features = ["no-entrypoint"] }
 spl-memo-interface = "2.1.0"

--- a/clients/rust-legacy/tests/confidential_mint_burn.rs
+++ b/clients/rust-legacy/tests/confidential_mint_burn.rs
@@ -10,7 +10,9 @@ use {
         transaction::TransactionError,
         transport::TransportError,
     },
-    solana_zk_sdk::encryption::{auth_encryption::*, elgamal::*},
+    solana_zk_sdk::encryption::{
+        auth_encryption::*, derivation::derive_confidential_keys, elgamal::*,
+    },
     solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext,
     spl_token_2022_interface::{
         error::TokenError,
@@ -60,9 +62,8 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
 
         let token_account = token_account_keypair.pubkey();
-        let elgamal_keypair =
-            ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes()).unwrap();
-        let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+        let (elgamal_keypair, aes_key) =
+            derive_confidential_keys(owner, &token_account.to_bytes()).unwrap();
 
         token
             .confidential_transfer_configure_token_account(

--- a/clients/rust-legacy/tests/confidential_transfer.rs
+++ b/clients/rust-legacy/tests/confidential_transfer.rs
@@ -16,7 +16,7 @@ use {
     },
     solana_system_interface::instruction as system_instruction,
     solana_zk_sdk::{
-        encryption::{auth_encryption::*, elgamal::*},
+        encryption::{auth_encryption::*, derivation::derive_confidential_keys, elgamal::*},
         zk_elgamal_proof_program::build_pubkey_validity_proof_data,
     },
     solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext,
@@ -159,11 +159,8 @@ async fn confidential_transfer_configure_token_account_with_option(
         )
         .await
         .unwrap();
-    let elgamal_keypair =
-        ElGamalKeypair::new_from_signer(&alice, &alice_account_keypair.pubkey().to_bytes())
-            .unwrap();
-    let aes_key =
-        AeKey::new_from_signer(&alice, &alice_account_keypair.pubkey().to_bytes()).unwrap();
+    let (elgamal_keypair, aes_key) =
+        derive_confidential_keys(&alice, &alice_account_keypair.pubkey().to_bytes()).unwrap();
 
     let alice_meta = ConfidentialTokenAccountMeta {
         token_account: alice_account_keypair.pubkey(),
@@ -2680,9 +2677,8 @@ async fn confidential_transfer_configure_token_account_with_registry() {
     ctx.banks_client.process_transaction(tx).await.unwrap();
 
     // update ElGamal registry
-    let new_elgamal_keypair =
-        ElGamalKeypair::new_from_signer(&alice, &alice_account_keypair.pubkey().to_bytes())
-            .unwrap();
+    let (new_elgamal_keypair, _) =
+        derive_confidential_keys(&alice, &alice_account_keypair.pubkey().to_bytes()).unwrap();
     let proof_data = build_pubkey_validity_proof_data(&new_elgamal_keypair).unwrap();
     let proof_location = ProofLocation::InstructionOffset(1.try_into().unwrap(), &proof_data);
 

--- a/clients/rust-legacy/tests/confidential_transfer_fee.rs
+++ b/clients/rust-legacy/tests/confidential_transfer_fee.rs
@@ -13,7 +13,7 @@ use {
     },
     solana_system_interface::instruction as system_instruction,
     solana_zk_sdk::{
-        encryption::{auth_encryption::*, elgamal::*},
+        encryption::{auth_encryption::*, derivation::derive_confidential_keys, elgamal::*},
         zk_elgamal_proof_program::build_pubkey_validity_proof_data,
     },
     solana_zk_sdk_pod::encryption::elgamal::PodElGamalCiphertext,
@@ -79,9 +79,8 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
         let token_account = token_account_keypair.pubkey();
 
-        let elgamal_keypair =
-            ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes()).unwrap();
-        let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+        let (elgamal_keypair, aes_key) =
+            derive_confidential_keys(owner, &token_account.to_bytes()).unwrap();
 
         token
             .confidential_transfer_configure_token_account(
@@ -1241,11 +1240,9 @@ async fn test_withdraw_withheld_tokens_with_max_pending_counter() {
         .await
         .unwrap();
 
-    let fc_elgamal =
-        ElGamalKeypair::new_from_signer(&fee_collector, &fee_collector_account.pubkey().to_bytes())
+    let (fc_elgamal, fc_aes) =
+        derive_confidential_keys(&fee_collector, &fee_collector_account.pubkey().to_bytes())
             .unwrap();
-    let fc_aes =
-        AeKey::new_from_signer(&fee_collector, &fee_collector_account.pubkey().to_bytes()).unwrap();
 
     // Configure with max_pending_balance_credit_counter = 1
     token

--- a/clients/rust-legacy/tests/program_test.rs
+++ b/clients/rust-legacy/tests/program_test.rs
@@ -6,7 +6,9 @@ use {
         pubkey::Pubkey,
         signer::{keypair::Keypair, Signer},
     },
-    solana_zk_sdk::encryption::{auth_encryption::*, elgamal::*},
+    solana_zk_sdk::encryption::{
+        auth_encryption::*, derivation::derive_confidential_keys, elgamal::*,
+    },
     spl_token_2022_interface::{
         extension::{
             confidential_transfer::ConfidentialTransferAccount, BaseStateWithExtensions,
@@ -217,9 +219,8 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
         let token_account = token_account_keypair.pubkey();
 
-        let elgamal_keypair =
-            ElGamalKeypair::new_from_signer(owner, &token_account.to_bytes()).unwrap();
-        let aes_key = AeKey::new_from_signer(owner, &token_account.to_bytes()).unwrap();
+        let (elgamal_keypair, aes_key) =
+            derive_confidential_keys(owner, &token_account.to_bytes()).unwrap();
 
         token
             .confidential_transfer_configure_token_account(

--- a/confidential/ciphertext-arithmetic/Cargo.toml
+++ b/confidential/ciphertext-arithmetic/Cargo.toml
@@ -15,5 +15,5 @@ solana-zk-sdk-pod = "0.1.2"
 
 [dev-dependencies]
 spl-token-confidential-transfer-proof-generation = { version = "0.6.0", path = "../proof-generation" }
-solana-zk-sdk = "6.0.1"
+solana-zk-sdk = "7.0.1"
 curve25519-dalek = "4.1.3"

--- a/confidential/proof-generation/Cargo.toml
+++ b/confidential/proof-generation/Cargo.toml
@@ -10,7 +10,7 @@ edition = { workspace = true }
 
 [dependencies]
 curve25519-dalek = "4.1.3"
-solana-zk-sdk = "6.0.1"
+solana-zk-sdk = "7.0.1"
 solana-zk-sdk-pod = "0.1.2"
 solana-zk-elgamal-proof-interface = "0.1.2"
 thiserror = "2.0.18"

--- a/confidential/proof-tests/Cargo.toml
+++ b/confidential/proof-tests/Cargo.toml
@@ -10,7 +10,7 @@ edition = { workspace = true }
 
 [dev-dependencies]
 curve25519-dalek = "4.1.3"
-solana-zk-sdk = "6.0.1"
+solana-zk-sdk = "7.0.1"
 solana-zk-elgamal-proof-interface = "0.1.2"
 thiserror = "2.0.18"
 spl-token-confidential-transfer-proof-extraction = { version = "0.6.0", path = "../proof-extraction" }


### PR DESCRIPTION
#### Problem

solana-zk-sdk v7 introduced new key derivation methods, but we're still on the old stuff.

#### Summary of changes

Update the crates and stop using removed functions.