### PR TITLE
Add a Kit-plugin client to the JS package

### DIFF
--- a/clients/js/src/createMint.ts
+++ b/clients/js/src/createMint.ts
@@ -1,0 +1,91 @@
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    Address,
+    getMinimumBalanceForRentExemption,
+    InstructionPlan,
+    OptionOrNullable,
+    sequentialInstructionPlan,
+    TransactionSigner,
+} from '@solana/kit';
+import { Extension, ExtensionArgs, getInitializeMintInstruction, TOKEN_2022_PROGRAM_ADDRESS } from './generated';
+import {
+    getPostInitializeInstructionsForMintExtensions,
+    getPreInitializeInstructionsForMintExtensions,
+} from './getInitializeInstructionsForExtensions';
+import { getMintSize } from './getMintSize';
+
+/**
+ * Extensions whose data is initialized _after_ the mint and which grow the
+ * account beyond its initially allocated space (they reallocate as needed).
+ * The created account is therefore sized without them.
+ */
+const POST_INITIALIZE_EXTENSIONS: Extension['__kind'][] = ['TokenMetadata', 'TokenGroup', 'TokenGroupMember'];
+
+export type CreateMintInstructionPlanInput = {
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner;
+    /** New mint account to create. */
+    newMint: TransactionSigner;
+    /**
+     * Number of base 10 digits to the right of the decimal place.
+     * @default 0
+     */
+    decimals?: number;
+    /** The authority/multisignature to mint tokens and to configure extensions. */
+    mintAuthority: TransactionSigner;
+    /** The optional freeze authority/multisignature of the mint. */
+    freezeAuthority?: OptionOrNullable<Address>;
+    /** The optional mint extensions to initialize on the account. */
+    extensions?: ExtensionArgs[];
+    /**
+     * Optional override for the amount of Lamports to fund the mint account with.
+     * @default enough to make the account rent-exempt
+     */
+    mintAccountLamports?: number | bigint;
+};
+
+export type CreateMintInstructionPlanConfig = {
+    systemProgram?: Address;
+    tokenProgram?: Address;
+};
+
+export function getCreateMintInstructionPlan(
+    input: CreateMintInstructionPlanInput,
+    config?: CreateMintInstructionPlanConfig,
+): InstructionPlan {
+    const extensions = input.extensions ?? [];
+    // The account is allocated without the post-initialize extensions (which
+    // reallocate the account as needed). `undefined` (no extensions) must be
+    // preserved so the size omits the extension TLV prefix entirely.
+    const space = input.extensions
+        ? getMintSize(input.extensions.filter(e => !POST_INITIALIZE_EXTENSIONS.includes(e.__kind)))
+        : getMintSize();
+    const rentSpace = getMintSize(input.extensions);
+    return sequentialInstructionPlan([
+        getCreateAccountInstruction(
+            {
+                payer: input.payer,
+                newAccount: input.newMint,
+                lamports: input.mintAccountLamports ?? getMinimumBalanceForRentExemption(BigInt(rentSpace)),
+                space,
+                programAddress: config?.tokenProgram ?? TOKEN_2022_PROGRAM_ADDRESS,
+            },
+            {
+                programAddress: config?.systemProgram,
+            },
+        ),
+        ...getPreInitializeInstructionsForMintExtensions(input.newMint.address, extensions),
+        getInitializeMintInstruction(
+            {
+                mint: input.newMint.address,
+                decimals: input.decimals ?? 0,
+                mintAuthority: input.mintAuthority.address,
+                freezeAuthority: input.freezeAuthority,
+            },
+            {
+                programAddress: config?.tokenProgram,
+            },
+        ),
+        ...getPostInitializeInstructionsForMintExtensions(input.newMint.address, input.mintAuthority, extensions),
+    ]);
+}

--- a/clients/js/src/createToken.ts
+++ b/clients/js/src/createToken.ts
@@ -1,0 +1,74 @@
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    Address,
+    getMinimumBalanceForRentExemption,
+    InstructionPlan,
+    sequentialInstructionPlan,
+    TransactionSigner,
+} from '@solana/kit';
+import { ExtensionArgs, getInitializeAccountInstruction, TOKEN_2022_PROGRAM_ADDRESS } from './generated';
+import { getPostInitializeInstructionsForTokenExtensions } from './getInitializeInstructionsForExtensions';
+import { getTokenSize } from './getTokenSize';
+
+export type CreateTokenInstructionPlanInput = {
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner;
+    /** New token account to create. */
+    newToken: TransactionSigner;
+    /** The token mint for the token account. */
+    mint: Address;
+    /** The owner of the token account. */
+    owner: TransactionSigner | Address;
+    /** The optional token-account extensions to initialize on the account. */
+    extensions?: ExtensionArgs[];
+    multiSigners?: TransactionSigner[];
+    /**
+     * Optional override for the amount of Lamports to fund the token account with.
+     * @default enough to make the account rent-exempt
+     */
+    tokenAccountLamports?: number | bigint;
+};
+
+export type CreateTokenInstructionPlanConfig = {
+    systemProgram?: Address;
+    tokenProgram?: Address;
+};
+
+export function getCreateTokenInstructionPlan(
+    input: CreateTokenInstructionPlanInput,
+    config?: CreateTokenInstructionPlanConfig,
+): InstructionPlan {
+    const extensions = input.extensions ?? [];
+    const space = getTokenSize(input.extensions);
+    const owner = typeof input.owner === 'string' ? input.owner : input.owner.address;
+    return sequentialInstructionPlan([
+        getCreateAccountInstruction(
+            {
+                payer: input.payer,
+                newAccount: input.newToken,
+                lamports: input.tokenAccountLamports ?? getMinimumBalanceForRentExemption(BigInt(space)),
+                space,
+                programAddress: config?.tokenProgram ?? TOKEN_2022_PROGRAM_ADDRESS,
+            },
+            {
+                programAddress: config?.systemProgram,
+            },
+        ),
+        getInitializeAccountInstruction(
+            {
+                account: input.newToken.address,
+                mint: input.mint,
+                owner,
+            },
+            {
+                programAddress: config?.tokenProgram,
+            },
+        ),
+        ...getPostInitializeInstructionsForTokenExtensions(
+            input.newToken.address,
+            input.owner,
+            extensions,
+            input.multiSigners,
+        ),
+    ]);
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,9 +1,19 @@
 export * from './generated';
 
 // Generated overrides (must be re-exported explicitly).
+export {
+    token2022Program,
+    type Token2022Plugin,
+    type Token2022PluginInstructions,
+    type Token2022PluginRequirements,
+} from './plugin';
 export { type BatchInstruction, getBatchInstruction, parseBatchInstruction } from './batch';
 
 export * from './amountToUiAmount';
+export * from './createMint';
+export * from './createToken';
 export * from './getInitializeInstructionsForExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';
+export * from './mintToATA';
+export * from './transferToATA';

--- a/clients/js/src/mintToATA.ts
+++ b/clients/js/src/mintToATA.ts
@@ -1,0 +1,95 @@
+import { Address, InstructionPlan, sequentialInstructionPlan, TransactionSigner } from '@solana/kit';
+import {
+    findAssociatedTokenPda,
+    getCreateAssociatedTokenIdempotentInstruction,
+    getMintToCheckedInstruction,
+    TOKEN_2022_PROGRAM_ADDRESS,
+} from './generated';
+import { MakeOptional } from './types';
+
+export type MintToATAInstructionPlanInput = {
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner;
+    /**
+     * Associated token account address to mint to.
+     * Will be created if it does not already exist.
+     * Note: Use {@link getMintToATAInstructionPlanAsync} instead to derive this automatically.
+     * Note: Use {@link findAssociatedTokenPda} to derive the associated token account address.
+     */
+    ata: Address;
+    /** Wallet address for the associated token account. */
+    owner: Address;
+    /** The token mint for the associated token account. */
+    mint: Address;
+    /** The mint's minting authority or its multisignature account. */
+    mintAuthority: Address | TransactionSigner;
+    /** The amount of new tokens to mint. */
+    amount: number | bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
+    multiSigners?: Array<TransactionSigner>;
+};
+
+export type MintToATAInstructionPlanConfig = {
+    systemProgram?: Address;
+    tokenProgram?: Address;
+    associatedTokenProgram?: Address;
+};
+
+export function getMintToATAInstructionPlan(
+    input: MintToATAInstructionPlanInput,
+    config?: MintToATAInstructionPlanConfig,
+): InstructionPlan {
+    return sequentialInstructionPlan([
+        getCreateAssociatedTokenIdempotentInstruction(
+            {
+                payer: input.payer,
+                ata: input.ata,
+                owner: input.owner,
+                mint: input.mint,
+                systemProgram: config?.systemProgram,
+                tokenProgram: config?.tokenProgram ?? TOKEN_2022_PROGRAM_ADDRESS,
+            },
+            {
+                programAddress: config?.associatedTokenProgram,
+            },
+        ),
+        getMintToCheckedInstruction(
+            {
+                mint: input.mint,
+                token: input.ata,
+                mintAuthority: input.mintAuthority,
+                amount: input.amount,
+                decimals: input.decimals,
+                multiSigners: input.multiSigners,
+            },
+            {
+                programAddress: config?.tokenProgram,
+            },
+        ),
+    ]);
+}
+
+export type MintToATAInstructionPlanAsyncInput = MakeOptional<MintToATAInstructionPlanInput, 'ata'>;
+
+export async function getMintToATAInstructionPlanAsync(
+    input: MintToATAInstructionPlanAsyncInput,
+    config?: MintToATAInstructionPlanConfig,
+): Promise<InstructionPlan> {
+    const tokenProgram = config?.tokenProgram ?? TOKEN_2022_PROGRAM_ADDRESS;
+    let ata = input.ata;
+    if (!ata) {
+        [ata] = await findAssociatedTokenPda({
+            owner: input.owner,
+            tokenProgram,
+            mint: input.mint,
+        });
+    }
+    return getMintToATAInstructionPlan(
+        {
+            ...input,
+            ata,
+        },
+        config,
+    );
+}

--- a/clients/js/src/plugin.ts
+++ b/clients/js/src/plugin.ts
@@ -1,0 +1,103 @@
+import { ClientWithPayer, pipe } from '@solana/kit';
+import { addSelfPlanAndSendFunctions, SelfPlanAndSendFunctions } from '@solana/kit/program-client-core';
+
+import { getBatchInstruction } from './batch';
+import {
+    CreateMintInstructionPlanConfig,
+    CreateMintInstructionPlanInput,
+    getCreateMintInstructionPlan,
+} from './createMint';
+import {
+    CreateTokenInstructionPlanConfig,
+    CreateTokenInstructionPlanInput,
+    getCreateTokenInstructionPlan,
+} from './createToken';
+import {
+    Token2022Plugin as GeneratedToken2022Plugin,
+    Token2022PluginInstructions as GeneratedToken2022PluginInstructions,
+    Token2022PluginRequirements as GeneratedToken2022PluginRequirements,
+    token2022Program as generatedToken2022Program,
+} from './generated';
+import {
+    getMintToATAInstructionPlanAsync,
+    MintToATAInstructionPlanAsyncInput,
+    MintToATAInstructionPlanConfig,
+} from './mintToATA';
+import {
+    getTransferToATAInstructionPlanAsync,
+    TransferToATAInstructionPlanAsyncInput,
+    TransferToATAInstructionPlanConfig,
+} from './transferToATA';
+import { MakeOptional } from './types';
+
+export type Token2022PluginRequirements = GeneratedToken2022PluginRequirements & ClientWithPayer;
+
+export type Token2022Plugin = Omit<GeneratedToken2022Plugin, 'instructions'> & {
+    instructions: Token2022PluginInstructions;
+};
+
+export type Token2022PluginInstructions = Omit<GeneratedToken2022PluginInstructions, 'batch'> & {
+    /** Batch multiple instructions into one by using other token instructions as children. */
+    batch: (
+        instructions: Parameters<typeof getBatchInstruction>[0],
+        config?: Parameters<typeof getBatchInstruction>[1],
+    ) => ReturnType<typeof getBatchInstruction> & SelfPlanAndSendFunctions;
+    /** Create a new token mint, optionally with extensions. */
+    createMint: (
+        input: MakeOptional<CreateMintInstructionPlanInput, 'payer'>,
+        config?: CreateMintInstructionPlanConfig,
+    ) => ReturnType<typeof getCreateMintInstructionPlan> & SelfPlanAndSendFunctions;
+    /** Create a new token account, optionally with extensions. */
+    createToken: (
+        input: MakeOptional<CreateTokenInstructionPlanInput, 'payer'>,
+        config?: CreateTokenInstructionPlanConfig,
+    ) => ReturnType<typeof getCreateTokenInstructionPlan> & SelfPlanAndSendFunctions;
+    /** Mint tokens to an owner's ATA (created if needed). */
+    mintToATA: (
+        input: MakeOptional<MintToATAInstructionPlanAsyncInput, 'payer'>,
+        config?: MintToATAInstructionPlanConfig,
+    ) => ReturnType<typeof getMintToATAInstructionPlanAsync> & SelfPlanAndSendFunctions;
+    /** Transfer tokens to a recipient's ATA (created if needed). */
+    transferToATA: (
+        input: MakeOptional<TransferToATAInstructionPlanAsyncInput, 'payer'>,
+        config?: TransferToATAInstructionPlanConfig,
+    ) => ReturnType<typeof getTransferToATAInstructionPlanAsync> & SelfPlanAndSendFunctions;
+};
+
+export function token2022Program() {
+    return <T extends Token2022PluginRequirements>(client: T) => {
+        return pipe(client, generatedToken2022Program(), c => ({
+            ...c,
+            token2022: <Token2022Plugin>{
+                ...c.token2022,
+                instructions: {
+                    ...c.token2022.instructions,
+                    batch: (input, config) => addSelfPlanAndSendFunctions(client, getBatchInstruction(input, config)),
+                    createMint: (input, config) =>
+                        addSelfPlanAndSendFunctions(
+                            client,
+                            getCreateMintInstructionPlan({ ...input, payer: input.payer ?? client.payer }, config),
+                        ),
+                    createToken: (input, config) =>
+                        addSelfPlanAndSendFunctions(
+                            client,
+                            getCreateTokenInstructionPlan({ ...input, payer: input.payer ?? client.payer }, config),
+                        ),
+                    mintToATA: (input, config) =>
+                        addSelfPlanAndSendFunctions(
+                            client,
+                            getMintToATAInstructionPlanAsync({ ...input, payer: input.payer ?? client.payer }, config),
+                        ),
+                    transferToATA: (input, config) =>
+                        addSelfPlanAndSendFunctions(
+                            client,
+                            getTransferToATAInstructionPlanAsync(
+                                { ...input, payer: input.payer ?? client.payer },
+                                config,
+                            ),
+                        ),
+                },
+            },
+        }));
+    };
+}

--- a/clients/js/src/transferToATA.ts
+++ b/clients/js/src/transferToATA.ts
@@ -1,0 +1,116 @@
+import { Address, InstructionPlan, sequentialInstructionPlan, TransactionSigner } from '@solana/kit';
+import {
+    findAssociatedTokenPda,
+    getCreateAssociatedTokenIdempotentInstruction,
+    getTransferCheckedInstruction,
+    TOKEN_2022_PROGRAM_ADDRESS,
+} from './generated';
+import { MakeOptional } from './types';
+
+export type TransferToATAInstructionPlanInput = {
+    /** Funding account (must be a system account). */
+    payer: TransactionSigner;
+    /** The token mint to transfer. */
+    mint: Address;
+    /** The source account for the transfer. */
+    source: Address;
+    /** The source account's owner/delegate or its multisignature account. */
+    authority: Address | TransactionSigner;
+    /**
+     * Associated token account address to transfer to.
+     * Will be created if it does not already exist.
+     * Note: Use {@link getTransferToATAInstructionPlanAsync} instead to derive this automatically.
+     * Note: Use {@link findAssociatedTokenPda} to derive the associated token account address.
+     */
+    destination: Address;
+    /** Wallet address for the destination. */
+    recipient: Address;
+    /** The amount of tokens to transfer. */
+    amount: number | bigint;
+    /** Expected number of base 10 digits to the right of the decimal place. */
+    decimals: number;
+    multiSigners?: Array<TransactionSigner>;
+};
+
+export type TransferToATAInstructionPlanConfig = {
+    systemProgram?: Address;
+    tokenProgram?: Address;
+    associatedTokenProgram?: Address;
+};
+
+export function getTransferToATAInstructionPlan(
+    input: TransferToATAInstructionPlanInput,
+    config?: TransferToATAInstructionPlanConfig,
+): InstructionPlan {
+    return sequentialInstructionPlan([
+        getCreateAssociatedTokenIdempotentInstruction(
+            {
+                payer: input.payer,
+                ata: input.destination,
+                owner: input.recipient,
+                mint: input.mint,
+                systemProgram: config?.systemProgram,
+                tokenProgram: config?.tokenProgram ?? TOKEN_2022_PROGRAM_ADDRESS,
+            },
+            {
+                programAddress: config?.associatedTokenProgram,
+            },
+        ),
+        getTransferCheckedInstruction(
+            {
+                source: input.source,
+                mint: input.mint,
+                destination: input.destination,
+                authority: input.authority,
+                amount: input.amount,
+                decimals: input.decimals,
+                multiSigners: input.multiSigners,
+            },
+            {
+                programAddress: config?.tokenProgram,
+            },
+        ),
+    ]);
+}
+
+export type TransferToATAInstructionPlanAsyncInput = MakeOptional<
+    TransferToATAInstructionPlanInput,
+    'source' | 'destination'
+>;
+
+export async function getTransferToATAInstructionPlanAsync(
+    input: TransferToATAInstructionPlanAsyncInput,
+    config?: TransferToATAInstructionPlanConfig,
+): Promise<InstructionPlan> {
+    const tokenProgram = config?.tokenProgram ?? TOKEN_2022_PROGRAM_ADDRESS;
+
+    let destination = input.destination;
+    if (!destination) {
+        [destination] = await findAssociatedTokenPda({
+            owner: input.recipient,
+            tokenProgram,
+            mint: input.mint,
+        });
+    }
+
+    let source = input.source;
+    if (!source) {
+        const authorityAddress: Address =
+            typeof input.authority === 'string' ? input.authority : input.authority.address;
+        const [sourceAta] = await findAssociatedTokenPda({
+            owner: authorityAddress,
+            tokenProgram,
+            mint: input.mint,
+        });
+        source = sourceAta;
+    }
+
+    return getTransferToATAInstructionPlan(
+        {
+            ...input,
+            source,
+            destination,
+        },
+        config,
+    );
+}

--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -1,0 +1,1 @@
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { getCreateAccountInstruction } from '@solana-program/system';
+import { systemProgram } from '@solana-program/system';
 import {
     Address,
     Transaction,
@@ -19,6 +19,7 @@ import {
     none,
     pipe,
     sendAndConfirmTransactionFactory,
+    sequentialInstructionPlan,
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
     signTransactionMessageWithSigners,
@@ -34,18 +35,14 @@ import {
     ExtensionArgs,
     TOKEN_2022_PROGRAM_ADDRESS,
     Token,
+    associatedTokenProgram,
     extension,
     fetchToken,
     findAssociatedTokenPda,
     getConfidentialDepositInstruction,
-    getInitializeAccountInstruction,
-    getInitializeMintInstruction,
-    getMintSize,
+    getCreateTokenInstructionPlan,
     getMintToInstruction,
-    getPostInitializeInstructionsForMintExtensions,
-    getPostInitializeInstructionsForTokenExtensions,
-    getPreInitializeInstructionsForMintExtensions,
-    getTokenSize,
+    token2022Program,
 } from '../src';
 import {
     getApplyConfidentialPendingBalanceInstructionFromToken,
@@ -66,7 +63,10 @@ export const createTestClient = () => {
             // Must run after the `litesvm()` plugin so `client.svm` is available.
             client.svm.addProgramFromFile(TOKEN_2022_PROGRAM_ADDRESS, TOKEN_2022_BINARY_PATH);
             return client;
-        });
+        })
+        .use(systemProgram())
+        .use(token2022Program())
+        .use(associatedTokenProgram());
 };
 
 // A validator-backed client for the few confidential-transfer tests that
@@ -120,6 +120,9 @@ export const createValidatorClient = () => {
             // Re-wire `sendTransaction(s)` so they capture the client with the
             // overridden planner and executor above.
             .use(planAndSendTransactions())
+            .use(systemProgram())
+            .use(token2022Program())
+            .use(associatedTokenProgram())
     );
 };
 
@@ -151,129 +154,81 @@ export const getSingleTransactionContext = (result: SingleSendResult): ExecutedT
     return result.context as unknown as ExecutedTransactionContext;
 };
 
-export const getCreateMintInstructions = async (input: {
-    authority: Address;
+export const createToken = async (input: {
     client: Client;
-    decimals?: number;
-    extensions?: ExtensionArgs[];
-    freezeAuthority?: Address;
-    mint: TransactionSigner;
     payer: TransactionSigner;
-    programAddress?: Address;
-}) => {
-    const space = getMintSize(input.extensions);
-    const postInitializeExtensions: Extension['__kind'][] = ['TokenMetadata', 'TokenGroup', 'TokenGroupMember'];
-    const spaceWithoutPostInitializeExtensions = input.extensions
-        ? getMintSize(input.extensions.filter(e => !postInitializeExtensions.includes(e.__kind)))
-        : space;
-    const rent = await input.client.rpc.getMinimumBalanceForRentExemption(BigInt(space)).send();
-    return [
-        getCreateAccountInstruction({
-            payer: input.payer,
-            newAccount: input.mint,
-            lamports: rent,
-            space: spaceWithoutPostInitializeExtensions,
-            programAddress: input.programAddress ?? TOKEN_2022_PROGRAM_ADDRESS,
-        }),
-        getInitializeMintInstruction({
-            mint: input.mint.address,
-            decimals: input.decimals ?? 0,
-            freezeAuthority: input.freezeAuthority,
-            mintAuthority: input.authority,
-        }),
-    ];
-};
-
-export const getCreateTokenInstructions = async (input: {
-    client: Client;
-    extensions?: ExtensionArgs[];
     mint: Address;
-    owner: Address;
-    payer: TransactionSigner;
-    programAddress?: Address;
-    token: TransactionSigner;
-}) => {
-    const space = getTokenSize(input.extensions);
-    const rent = await input.client.rpc.getMinimumBalanceForRentExemption(BigInt(space)).send();
-    return [
-        getCreateAccountInstruction({
+    owner: TransactionSigner;
+    extensions?: ExtensionArgs[];
+}): Promise<Address> => {
+    const token = await generateKeyPairSigner();
+    await input.client.token2022.instructions
+        .createToken({
             payer: input.payer,
-            newAccount: input.token,
-            lamports: rent,
-            space,
-            programAddress: input.programAddress ?? TOKEN_2022_PROGRAM_ADDRESS,
-        }),
-        getInitializeAccountInstruction({
-            account: input.token.address,
+            newToken: token,
             mint: input.mint,
             owner: input.owner,
-        }),
-    ];
-};
-
-export const createMint = async (
-    input: Omit<Parameters<typeof getCreateMintInstructions>[0], 'authority' | 'mint'> & {
-        authority: TransactionSigner;
-        mint?: TransactionSigner;
-    },
-): Promise<Address> => {
-    const mint = input.mint ?? (await generateKeyPairSigner());
-    const [createAccount, initMint] = await getCreateMintInstructions({
-        ...input,
-        authority: input.authority.address,
-        mint,
-    });
-    await input.client.sendTransaction([
-        createAccount,
-        ...getPreInitializeInstructionsForMintExtensions(mint.address, input.extensions ?? []),
-        initMint,
-        ...getPostInitializeInstructionsForMintExtensions(mint.address, input.authority, input.extensions ?? []),
-    ]);
-    return mint.address;
-};
-
-export const createToken = async (
-    input: Omit<Parameters<typeof getCreateTokenInstructions>[0], 'token' | 'owner'> & { owner: TransactionSigner },
-): Promise<Address> => {
-    const token = await generateKeyPairSigner();
-    const [createAccount, initToken] = await getCreateTokenInstructions({
-        ...input,
-        owner: input.owner.address,
-        token,
-    });
-    await input.client.sendTransaction([
-        createAccount,
-        initToken,
-        ...getPostInitializeInstructionsForTokenExtensions(token.address, input.owner, input.extensions ?? []),
-    ]);
+            extensions: input.extensions,
+        })
+        .sendTransaction();
     return token.address;
 };
 
-export const createTokenWithAmount = async (
-    input: Omit<Parameters<typeof getCreateTokenInstructions>[0], 'token' | 'owner'> & {
-        amount: number | bigint;
-        mintAuthority: TransactionSigner;
-        owner: TransactionSigner;
-    },
-): Promise<Address> => {
+export const createTokenWithAmount = async (input: {
+    client: Client;
+    payer: TransactionSigner;
+    mint: Address;
+    owner: TransactionSigner;
+    mintAuthority: TransactionSigner;
+    amount: number | bigint;
+    extensions?: ExtensionArgs[];
+}): Promise<Address> => {
     const token = await generateKeyPairSigner();
-    const [createAccount, initToken] = await getCreateTokenInstructions({
-        ...input,
-        owner: input.owner.address,
-        token,
-    });
-    await input.client.sendTransaction([
-        createAccount,
-        initToken,
-        ...getPostInitializeInstructionsForTokenExtensions(token.address, input.owner, input.extensions ?? []),
-        getMintToInstruction({
+    await input.client.sendTransaction(
+        sequentialInstructionPlan([
+            getCreateTokenInstructionPlan({
+                payer: input.payer,
+                newToken: token,
+                mint: input.mint,
+                owner: input.owner,
+                extensions: input.extensions,
+            }),
+            getMintToInstruction({
+                mint: input.mint,
+                token: token.address,
+                mintAuthority: input.mintAuthority,
+                amount: input.amount,
+            }),
+        ]),
+    );
+    return token.address;
+};
+
+// Mints `amount` tokens to an owner's associated token account (created if
+// needed) via the plugin's `mintToATA` helper, and returns the ATA address.
+export const createTokenPdaWithAmount = async (input: {
+    client: Client;
+    mint: Address;
+    mintAuthority: TransactionSigner;
+    owner: Address;
+    amount: bigint;
+    decimals: number;
+}): Promise<Address> => {
+    await input.client.token2022.instructions
+        .mintToATA({
             mint: input.mint,
-            token: token.address,
+            owner: input.owner,
             mintAuthority: input.mintAuthority,
             amount: input.amount,
-        }),
-    ]);
-    return token.address;
+            decimals: input.decimals,
+        })
+        .sendTransaction();
+    const [token] = await findAssociatedTokenPda({
+        owner: input.owner,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+        mint: input.mint,
+    });
+    return token;
 };
 
 export const getTokenExtension = <TKind extends Extension['__kind']>(
@@ -304,21 +259,23 @@ export const createConfidentialMint = async (input: {
     payer: TransactionSigner;
     decimals?: number;
 }): Promise<{ mint: Address; mintAuthority: TransactionSigner }> => {
-    const mintAuthority = await generateKeyPairSigner();
-    const mint = await createMint({
-        client: input.client,
-        payer: input.payer,
-        authority: mintAuthority,
-        decimals: input.decimals ?? 2,
-        extensions: [
-            extension('ConfidentialTransferMint', {
-                authority: some(mintAuthority.address),
-                autoApproveNewAccounts: true,
-                auditorElgamalPubkey: none(),
-            }),
-        ],
-    });
-    return { mint, mintAuthority };
+    const [mintAuthority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    await input.client.token2022.instructions
+        .createMint({
+            payer: input.payer,
+            newMint: mint,
+            decimals: input.decimals ?? 2,
+            mintAuthority,
+            extensions: [
+                extension('ConfidentialTransferMint', {
+                    authority: some(mintAuthority.address),
+                    autoApproveNewAccounts: true,
+                    auditorElgamalPubkey: none(),
+                }),
+            ],
+        })
+        .sendTransaction();
+    return { mint: mint.address, mintAuthority };
 };
 
 export type ConfidentialTokenAccount = {

--- a/clients/js/test/createAssociatedToken.test.ts
+++ b/clients/js/test/createAssociatedToken.test.ts
@@ -8,32 +8,36 @@ import {
     findAssociatedTokenPda,
     getCreateAssociatedTokenInstructionAsync,
 } from '../src';
-import { createTestClient, createMint } from './_setup';
+import { createTestClient } from './_setup';
 
 it('creates a new associated token account', async () => {
     // Given a mint account, its mint authority and a token owner.
     const client = await createTestClient();
-    const [mintAuthority, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const mint = await createMint({ client, payer: client.payer, authority: mintAuthority });
+    const [mintAuthority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
 
     // When we create and initialize a token account at this address.
     const createAta = await getCreateAssociatedTokenInstructionAsync({
         payer: client.payer,
-        mint,
+        mint: mint.address,
         owner: owner.address,
     });
     await client.sendTransaction([createAta]);
 
     // Then we expect the token account to exist and have the following data.
     const [ata] = await findAssociatedTokenPda({
-        mint,
+        mint: mint.address,
         owner: owner.address,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     });
     expect(await fetchToken(client.rpc, ata)).toMatchObject(<Account<Token>>{
         address: ata,
         data: {
-            mint,
+            mint: mint.address,
             owner: owner.address,
             amount: 0n,
             delegate: none(),

--- a/clients/js/test/createAssociatedTokenIdempotent.test.ts
+++ b/clients/js/test/createAssociatedTokenIdempotent.test.ts
@@ -8,32 +8,36 @@ import {
     findAssociatedTokenPda,
     getCreateAssociatedTokenIdempotentInstructionAsync,
 } from '../src';
-import { createTestClient, createMint } from './_setup';
+import { createTestClient } from './_setup';
 
 it('creates a new associated token account', async () => {
     // Given a mint account, its mint authority and a token owner.
     const client = await createTestClient();
-    const [mintAuthority, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const mint = await createMint({ client, payer: client.payer, authority: mintAuthority });
+    const [mintAuthority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
 
     // When we create and initialize a token account at this address.
     const createAta = await getCreateAssociatedTokenIdempotentInstructionAsync({
         payer: client.payer,
-        mint,
+        mint: mint.address,
         owner: owner.address,
     });
     await client.sendTransaction([createAta]);
 
     // Then we expect the token account to exist and have the following data.
     const [ata] = await findAssociatedTokenPda({
-        mint,
+        mint: mint.address,
         owner: owner.address,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     });
     expect(await fetchToken(client.rpc, ata)).toMatchObject(<Account<Token>>{
         address: ata,
         data: {
-            mint,
+            mint: mint.address,
             owner: owner.address,
             amount: 0n,
             delegate: none(),

--- a/clients/js/test/createMint.test.ts
+++ b/clients/js/test/createMint.test.ts
@@ -1,0 +1,92 @@
+import { Account, address, generateKeyPairSigner, none, some } from '@solana/kit';
+import { expect, it } from 'vitest';
+import { Mint, extension, fetchMint } from '../src';
+import { createTestClient } from './_setup';
+
+it('creates and initializes a new mint account', async () => {
+    // Given an authority and a mint account.
+    const client = await createTestClient();
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+
+    // When we create and initialize a mint account at this address.
+    await client.token2022.instructions
+        .createMint({ newMint: mint, decimals: 2, mintAuthority: authority })
+        .sendTransaction();
+
+    // Then we expect the mint account to exist and have the following data.
+    const mintAccount = await fetchMint(client.rpc, mint.address);
+    expect(mintAccount).toMatchObject(<Account<Mint>>{
+        address: mint.address,
+        data: {
+            mintAuthority: some(authority.address),
+            supply: 0n,
+            decimals: 2,
+            isInitialized: true,
+            freezeAuthority: none(),
+            extensions: none(),
+        },
+    });
+});
+
+it('creates a new mint account with a freeze authority', async () => {
+    // Given an authority and a mint account.
+    const client = await createTestClient();
+    const [mintAuthority, freezeAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+
+    // When we create and initialize a mint account with a freeze authority.
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority,
+            freezeAuthority: freezeAuthority.address,
+        })
+        .sendTransaction();
+
+    // Then we expect the mint account to exist and have the following data.
+    const mintAccount = await fetchMint(client.rpc, mint.address);
+    expect(mintAccount).toMatchObject(<Account<Mint>>{
+        address: mint.address,
+        data: {
+            mintAuthority: some(mintAuthority.address),
+            freezeAuthority: some(freezeAuthority.address),
+        },
+    });
+});
+
+it('creates a new mint account with extensions', async () => {
+    // Given an authority and a mint account.
+    const client = await createTestClient();
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+
+    // And a mint close authority extension.
+    const mintCloseAuthorityExtension = extension('MintCloseAuthority', {
+        closeAuthority: address('HHS1XymmkBpYAkg3XTbZLxgHa5n11PAWUCWdiVtRmzzS'),
+    });
+
+    // When we create and initialize a mint account with this extension.
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [mintCloseAuthorityExtension],
+        })
+        .sendTransaction();
+
+    // Then we expect the mint account to exist with the extension.
+    const mintAccount = await fetchMint(client.rpc, mint.address);
+    expect(mintAccount).toMatchObject(<Account<Mint>>{
+        address: mint.address,
+        data: {
+            mintAuthority: some(authority.address),
+            decimals: 2,
+            isInitialized: true,
+            extensions: some([mintCloseAuthorityExtension]),
+        },
+    });
+});

--- a/clients/js/test/createNativeMint.test.ts
+++ b/clients/js/test/createNativeMint.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from 'vitest';
 import { Account, address, none } from '@solana/kit';
-import { Mint, fetchMint, getCreateNativeMintInstruction } from '../src';
+import { Mint, fetchMint } from '../src';
 import { createTestClient } from './_setup';
 
 //Mint for native SOL Token accounts
@@ -11,12 +11,9 @@ it('creates a native mint account', async () => {
     const client = await createTestClient();
 
     // When we create a native mint account.
-    await client.sendTransaction([
-        getCreateNativeMintInstruction({
-            payer: client.payer,
-            nativeMint: NATIVE_MINT,
-        }),
-    ]);
+    await client.token2022.instructions
+        .createNativeMint({ payer: client.payer, nativeMint: NATIVE_MINT })
+        .sendTransaction();
 
     // Then we expect the native mint account to exist with the following data.
     const nativeMintAccount = await fetchMint(client.rpc, NATIVE_MINT);

--- a/clients/js/test/createToken.test.ts
+++ b/clients/js/test/createToken.test.ts
@@ -1,0 +1,61 @@
+import { Account, generateKeyPairSigner, none, some } from '@solana/kit';
+import { expect, it } from 'vitest';
+import { AccountState, Token, extension, fetchToken } from '../src';
+import { createTestClient } from './_setup';
+
+it('creates and initializes a new token account', async () => {
+    // Given a mint account and a token owner.
+    const client = await createTestClient();
+    const [mintAuthority, owner, token, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
+
+    // When we create and initialize a token account at this address.
+    await client.token2022.instructions.createToken({ newToken: token, mint: mint.address, owner }).sendTransaction();
+
+    // Then we expect the token account to exist and have the following data.
+    expect(await fetchToken(client.rpc, token.address)).toMatchObject(<Account<Token>>{
+        address: token.address,
+        data: {
+            mint: mint.address,
+            owner: owner.address,
+            amount: 0n,
+            delegate: none(),
+            state: AccountState.Initialized,
+        },
+    });
+});
+
+it('creates a token account with extensions', async () => {
+    // Given a mint account and a token owner.
+    const client = await createTestClient();
+    const [mintAuthority, owner, token, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
+
+    // And a CPI guard extension.
+    const cpiGuardExtension = extension('CpiGuard', { lockCpi: true });
+
+    // When we create and initialize a token account with this extension.
+    await client.token2022.instructions
+        .createToken({ newToken: token, mint: mint.address, owner, extensions: [cpiGuardExtension] })
+        .sendTransaction();
+
+    // Then we expect the token account to exist with the extension.
+    expect(await fetchToken(client.rpc, token.address)).toMatchObject(<Account<Token>>{
+        address: token.address,
+        data: {
+            mint: mint.address,
+            owner: owner.address,
+            extensions: some([cpiGuardExtension]),
+        },
+    });
+});

--- a/clients/js/test/extensions/confidentialMintBurn/initializeConfidentialMintBurn.test.ts
+++ b/clients/js/test/extensions/confidentialMintBurn/initializeConfidentialMintBurn.test.ts
@@ -1,18 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import {
-    Mint,
-    extension,
-    fetchMint,
-    getInitializeConfidentialMintBurnInstruction,
-    getInitializeConfidentialTransferMintInstruction,
-} from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint with confidential mint burn', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a confidential transfer extension, which is required by the
     // confidential mint burn extension.
@@ -36,29 +30,13 @@ it('initializes a mint with confidential mint burn', async () => {
     });
 
     // When we create and initialize a mint account with these extensions.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [confidentialTransferMintExtension, confidentialMintBurnExtension],
-        mint,
-        payer: authority,
-    });
-
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeConfidentialTransferMintInstruction({
-            mint: mint.address,
-            authority: some(confidentialTransferAuthority),
-            autoApproveNewAccounts: true,
-            auditorElgamalPubkey: some(auditorElgamalPubkey),
-        }),
-        getInitializeConfidentialMintBurnInstruction({
-            mint: mint.address,
-            supplyElgamalPubkey,
-            decryptableSupply,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [confidentialTransferMintExtension, confidentialMintBurnExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have both extensions.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/confidentialTransfer/initializeConfidentialTransferMint.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/initializeConfidentialTransferMint.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeConfidentialTransferMintInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with confidential transfer', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a confidential transfer extension.
     const confidentialTransferExtension = extension('ConfidentialTransferMint', {
@@ -16,21 +16,13 @@ it('initializes a mint account with confidential transfer', async () => {
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [confidentialTransferExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeConfidentialTransferMintInstruction({
-            mint: mint.address,
-            ...confidentialTransferExtension,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [confidentialTransferExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following data.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/confidentialTransfer/updateConfidentialTransferMint.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/updateConfidentialTransferMint.test.ts
@@ -1,44 +1,46 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, none, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getUpdateConfidentialTransferMintInstruction } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates a mint account with confidential transfer', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, confidentialTransferAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, confidentialTransferAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with a confidential transfer extension.
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('ConfidentialTransferMint', {
-                authority: some(confidentialTransferAuthority.address),
-                autoApproveNewAccounts: true,
-                auditorElgamalPubkey: some(address('BTNEPmmWuj7Sg4Fo5i1FC5eiV2Aj4jiv9boarvE5XeaX')),
-            }),
-        ],
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('ConfidentialTransferMint', {
+                    authority: some(confidentialTransferAuthority.address),
+                    autoApproveNewAccounts: true,
+                    auditorElgamalPubkey: some(address('BTNEPmmWuj7Sg4Fo5i1FC5eiV2Aj4jiv9boarvE5XeaX')),
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the mint account with new confidential transfer configs.
-    await client.sendTransaction([
-        getUpdateConfidentialTransferMintInstruction({
-            mint,
+    await client.token2022.instructions
+        .updateConfidentialTransferMint({
+            mint: mint.address,
             authority: confidentialTransferAuthority,
             autoApproveNewAccounts: false,
             auditorElgamalPubkey: none(),
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to have the following updated data.
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
         data: {
             mintAuthority: some(authority.address),
             extensions: some([

--- a/clients/js/test/extensions/confidentialTransferFee/initializeConfidentialTransferFee.test.ts
+++ b/clients/js/test/extensions/confidentialTransferFee/initializeConfidentialTransferFee.test.ts
@@ -1,19 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import {
-    Mint,
-    extension,
-    fetchMint,
-    getInitializeConfidentialTransferFeeInstruction,
-    getInitializeTransferFeeConfigInstruction,
-    getInitializeConfidentialTransferMintInstruction,
-} from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint with confidential transfer fee', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And required extensions configuration
     const confidentialTransferAuthority = address('6sPR6MzvjMMP5LSZzEtTe4ZBVX9rhBmtM1dmfFtkNTbW');
@@ -52,40 +45,18 @@ it('initializes a mint with confidential transfer fee', async () => {
     });
 
     // When we create and initialize a mint account with these extensions.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [transferFeeConfigExtension, confidentialTransferMintExtension, confidentialTransferFeeExtension],
-        mint,
-        payer: authority,
-    });
-
-    await client.sendTransaction([
-        createMintInstruction,
-        // Initialize TransferFeeConfig first
-        getInitializeTransferFeeConfigInstruction({
-            mint: mint.address,
-            transferFeeConfigAuthority: confidentialTransferAuthority,
-            withdrawWithheldAuthority: confidentialTransferAuthority,
-            transferFeeBasisPoints: 0,
-            maximumFee: 0n,
-        }),
-        // Then initialize ConfidentialTransferMint
-        getInitializeConfidentialTransferMintInstruction({
-            mint: mint.address,
-            authority: some(confidentialTransferAuthority),
-            autoApproveNewAccounts: true,
-            auditorElgamalPubkey: some(elgamalPubkey),
-        }),
-        // Finally initialize ConfidentialTransferFee
-        getInitializeConfidentialTransferFeeInstruction({
-            mint: mint.address,
-            authority: some(confidentialTransferAuthority),
-            withdrawWithheldAuthorityElGamalPubkey: elgamalPubkey,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [
+                transferFeeConfigExtension,
+                confidentialTransferMintExtension,
+                confidentialTransferFeeExtension,
+            ],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have all extensions.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/cpiGuard/disableCpiGuard.test.ts
+++ b/clients/js/test/extensions/cpiGuard/disableCpiGuard.test.ts
@@ -1,46 +1,33 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Token, extension, fetchToken, getDisableCpiGuardInstruction } from '../../../src';
-import {
-    createTestClient,
-    createMint,
-    createToken,
-    generateKeyPairSignerWithSol,
-    getCreateTokenInstructions,
-} from '../../_setup';
+import { Token, extension, fetchToken } from '../../../src';
+import { createTestClient, createToken } from '../../_setup';
 
 it('initializes a token account with a disabled CPI guard extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, token, owner] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, token, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
 
     // When we create a token account and disable CPI guard.
     const cpiGuardExtension = extension('CpiGuard', {
         lockCpi: false,
     });
-    const [createTokenInstruction, initTokenInstruction] = await getCreateTokenInstructions({
-        client,
-        extensions: [cpiGuardExtension],
-        mint,
-        owner: owner.address,
-        payer: authority,
-        token,
-    });
-    await client.sendTransaction([
-        createTokenInstruction,
-        initTokenInstruction,
-        getDisableCpiGuardInstruction({
-            token: token.address,
+    await client.token2022.instructions
+        .createToken({
+            newToken: token,
+            mint: mint.address,
             owner,
-        }),
-    ]);
+            extensions: [cpiGuardExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the token account to exist and have the following extension.
     const tokenAccount = await fetchToken(client.rpc, token.address);
@@ -55,23 +42,24 @@ it('initializes a token account with a disabled CPI guard extension', async () =
 it('disables CPI guard on a token account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, owner] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
-        generateKeyPairSignerWithSol(client),
+    const [authority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
     ]);
 
     // And a token account with an enabled CPI guard extension.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
     const token = await createToken({
         client,
         extensions: [extension('CpiGuard', { lockCpi: true })],
-        mint,
+        mint: mint.address,
         owner,
-        payer: authority,
+        payer: client.payer,
     });
 
     // When we disable the CPI guard extension.
-    await client.sendTransaction([getDisableCpiGuardInstruction({ token, owner })]);
+    await client.token2022.instructions.disableCpiGuard({ token, owner }).sendTransaction();
 
     // Then we expect the token account to have CPI guard disabled.
     const tokenAccount = await fetchToken(client.rpc, token);

--- a/clients/js/test/extensions/cpiGuard/enableCpiGuard.test.ts
+++ b/clients/js/test/extensions/cpiGuard/enableCpiGuard.test.ts
@@ -1,46 +1,33 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Token, extension, fetchToken, getEnableCpiGuardInstruction } from '../../../src';
-import {
-    createTestClient,
-    createMint,
-    createToken,
-    generateKeyPairSignerWithSol,
-    getCreateTokenInstructions,
-} from '../../_setup';
+import { Token, extension, fetchToken } from '../../../src';
+import { createTestClient, createToken } from '../../_setup';
 
 it('initializes a token account with an enabled CPI guard extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, token, owner] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, token, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
 
     // When we create a token account and enable CPI guard.
     const cpiGuardExtension = extension('CpiGuard', {
         lockCpi: true,
     });
-    const [createTokenInstruction, initTokenInstruction] = await getCreateTokenInstructions({
-        client,
-        extensions: [cpiGuardExtension],
-        mint,
-        owner: owner.address,
-        payer: authority,
-        token,
-    });
-    await client.sendTransaction([
-        createTokenInstruction,
-        initTokenInstruction,
-        getEnableCpiGuardInstruction({
-            token: token.address,
+    await client.token2022.instructions
+        .createToken({
+            newToken: token,
+            mint: mint.address,
             owner,
-        }),
-    ]);
+            extensions: [cpiGuardExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the token account to exist and have the following extension.
     const tokenAccount = await fetchToken(client.rpc, token.address);
@@ -55,23 +42,24 @@ it('initializes a token account with an enabled CPI guard extension', async () =
 it('enables CPI guard on a token account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, owner] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
-        generateKeyPairSignerWithSol(client),
+    const [authority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
     ]);
 
     // And a token account with a disabled CPI guard extension.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
     const token = await createToken({
         client,
         extensions: [extension('CpiGuard', { lockCpi: false })],
-        mint,
+        mint: mint.address,
         owner,
-        payer: authority,
+        payer: client.payer,
     });
 
     // When we enable the CPI guard extension.
-    await client.sendTransaction([getEnableCpiGuardInstruction({ token, owner })]);
+    await client.token2022.instructions.enableCpiGuard({ token, owner }).sendTransaction();
 
     // Then we expect the token account to have CPI guard enabled.
     const tokenAccount = await fetchToken(client.rpc, token);

--- a/clients/js/test/extensions/defaultAccountState/initializeDefaultAccountState.test.ts
+++ b/clients/js/test/extensions/defaultAccountState/initializeDefaultAccountState.test.ts
@@ -1,26 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import {
-    AccountState,
-    Mint,
-    extension,
-    fetchMint,
-    fetchToken,
-    getInitializeDefaultAccountStateInstruction,
-} from '../../../src';
-import {
-    createTestClient,
-    createMint,
-    createToken,
-    generateKeyPairSignerWithSol,
-    getCreateMintInstructions,
-} from '../../_setup';
+import { AccountState, Mint, extension, fetchMint, fetchToken } from '../../../src';
+import { createTestClient, createToken, generateKeyPairSignerWithSol } from '../../_setup';
 
 it('initializes a mint account with a default account state extension', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
     const [authority, freezeAuthority, mint] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
@@ -31,22 +18,14 @@ it('initializes a mint account with a default account state extension', async ()
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [defaultAccountStateExtension],
-        freezeAuthority: freezeAuthority.address,
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeDefaultAccountStateInstruction({
-            mint: mint.address,
-            state: defaultAccountStateExtension.state,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            freezeAuthority: freezeAuthority.address,
+            extensions: [defaultAccountStateExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following data.
     const mintAccount = await fetchMint(client.rpc, mint.address);
@@ -63,23 +42,25 @@ it('initializes a mint account with a default account state extension', async ()
 it('initializes a token account with the default state defined on the mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, freezeAuthority, owner] = await Promise.all([
+    const [authority, freezeAuthority, owner, mint] = await Promise.all([
         generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with a default account state extension.
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [extension('DefaultAccountState', { state: AccountState.Frozen })],
-        freezeAuthority: freezeAuthority.address,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            freezeAuthority: freezeAuthority.address,
+            extensions: [extension('DefaultAccountState', { state: AccountState.Frozen })],
+        })
+        .sendTransaction();
 
     // When we create a new token account for the mint.
-    const token = await createToken({ client, mint, owner, payer: authority });
+    const token = await createToken({ client, mint: mint.address, owner, payer: authority });
 
     // Then we expect the token account to have the default state defined on the mint account.
     const tokenAccount = await fetchToken(client.rpc, token);

--- a/clients/js/test/extensions/defaultAccountState/updateDefaultAccountState.test.ts
+++ b/clients/js/test/extensions/defaultAccountState/updateDefaultAccountState.test.ts
@@ -1,38 +1,36 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { AccountState, Mint, extension, fetchMint, getUpdateDefaultAccountStateInstruction } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { AccountState, Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the default state account on a mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, freezeAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, freezeAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with a default account state extension.
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [extension('DefaultAccountState', { state: AccountState.Frozen })],
-        freezeAuthority: freezeAuthority.address,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            freezeAuthority: freezeAuthority.address,
+            extensions: [extension('DefaultAccountState', { state: AccountState.Frozen })],
+        })
+        .sendTransaction();
 
     // When we update the default account state on the mint account.
-    await client.sendTransaction([
-        getUpdateDefaultAccountStateInstruction({
-            mint,
-            freezeAuthority,
-            state: AccountState.Initialized,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateDefaultAccountState({ mint: mint.address, freezeAuthority, state: AccountState.Initialized })
+        .sendTransaction();
 
     // Then we expect the mint account to have the following updated data.
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
         data: {
             extensions: some([extension('DefaultAccountState', { state: AccountState.Initialized })]),
         },

--- a/clients/js/test/extensions/groupMemberPointer/initializeGroupMemberPointer.test.ts
+++ b/clients/js/test/extensions/groupMemberPointer/initializeGroupMemberPointer.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeGroupMemberPointerInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with a group member pointer extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, groupMember, groupMemberPointerAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
@@ -20,22 +20,13 @@ it('initializes a mint account with a group member pointer extension', async () 
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [groupMemberPointerExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeGroupMemberPointerInstruction({
-            mint: mint.address,
-            authority: groupMemberPointerExtension.authority,
-            memberAddress: groupMemberPointerExtension.memberAddress,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [groupMemberPointerExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/groupMemberPointer/updateGroupMemberPointer.test.ts
+++ b/clients/js/test/extensions/groupMemberPointer/updateGroupMemberPointer.test.ts
@@ -1,44 +1,42 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getUpdateGroupMemberPointerInstruction } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the group member pointer extension on a mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, groupMemberPointerAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, groupMemberPointerAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
     const oldMember = address('8dtp4b6tB8EhLpSG1jgg4swSQtUKRst2f7rJYSwE2Me3');
     const newMember = address('88F35KbnWKPeMnKFJDxZVjvEWmGms1FxW6wP52VABCVt');
 
     // And a mint account initialized with a group member pointer extension.
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('GroupMemberPointer', {
-                authority: groupMemberPointerAuthority.address,
-                memberAddress: oldMember,
-            }),
-        ],
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('GroupMemberPointer', {
+                    authority: groupMemberPointerAuthority.address,
+                    memberAddress: oldMember,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the group member pointer on the mint account.
-    await client.sendTransaction([
-        getUpdateGroupMemberPointerInstruction({
-            mint,
-            groupMemberPointerAuthority,
-            memberAddress: newMember,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateGroupMemberPointer({ mint: mint.address, groupMemberPointerAuthority, memberAddress: newMember })
+        .sendTransaction();
 
     // Then we expect the mint account to have the following updated data.
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
         data: {
             extensions: some([
                 extension('GroupMemberPointer', {

--- a/clients/js/test/extensions/groupPointer/initializeGroupPointer.test.ts
+++ b/clients/js/test/extensions/groupPointer/initializeGroupPointer.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeGroupPointerInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with a group pointer extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, group, groupPointerAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
@@ -20,22 +20,13 @@ it('initializes a mint account with a group pointer extension', async () => {
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [groupPointerExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeGroupPointerInstruction({
-            mint: mint.address,
-            authority: groupPointerExtension.authority,
-            groupAddress: groupPointerExtension.groupAddress,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [groupPointerExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/groupPointer/updateGroupPointer.test.ts
+++ b/clients/js/test/extensions/groupPointer/updateGroupPointer.test.ts
@@ -1,44 +1,42 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getUpdateGroupPointerInstruction } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the group pointer extension on a mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, groupPointerAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, groupPointerAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
     const oldGroup = address('8dtp4b6tB8EhLpSG1jgg4swSQtUKRst2f7rJYSwE2Me3');
     const newGroup = address('88F35KbnWKPeMnKFJDxZVjvEWmGms1FxW6wP52VABCVt');
 
     // And a mint account initialized with a group pointer extension.
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('GroupPointer', {
-                authority: groupPointerAuthority.address,
-                groupAddress: oldGroup,
-            }),
-        ],
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('GroupPointer', {
+                    authority: groupPointerAuthority.address,
+                    groupAddress: oldGroup,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the group pointer on the mint account.
-    await client.sendTransaction([
-        getUpdateGroupPointerInstruction({
-            mint,
-            groupPointerAuthority,
-            groupAddress: newGroup,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateGroupPointer({ mint: mint.address, groupPointerAuthority, groupAddress: newGroup })
+        .sendTransaction();
 
     // Then we expect the mint account to have the following updated data.
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
         data: {
             extensions: some([
                 extension('GroupPointer', {

--- a/clients/js/test/extensions/interestBearingMint/initializeInterestBearingMint.test.ts
+++ b/clients/js/test/extensions/interestBearingMint/initializeInterestBearingMint.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { createTestClient } from '../../_setup';
 import { Account, generateKeyPairSigner, isSome } from '@solana/kit';
-import { extension, fetchMint, getInitializeInterestBearingMintInstruction, Mint } from '../../../src';
+import { extension, fetchMint, Mint } from '../../../src';
 
 it('initialize a mint account with an interest bearing mint extension', async () => {
     // Given a fresh client with no state the test cares about.
     const client = await createTestClient();
-    const [rateAuthority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [rateAuthority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // in bips
     const rate = 10000;
@@ -21,22 +21,13 @@ it('initialize a mint account with an interest bearing mint extension', async ()
     });
 
     // When we initialize the mint account with the interest bearing mint extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: rateAuthority.address,
-        client,
-        extensions: [interestBearingMintExtension],
-        mint,
-        payer: rateAuthority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeInterestBearingMintInstruction({
-            rateAuthority: rateAuthority.address,
-            mint: mint.address,
-            rate: rate,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: rateAuthority,
+            extensions: [interestBearingMintExtension],
+        })
+        .sendTransaction();
 
     const mintAccount = await fetchMint(client.rpc, mint.address);
     // Then the mint account exists.

--- a/clients/js/test/extensions/interestBearingMint/updateInterestBearingMint.test.ts
+++ b/clients/js/test/extensions/interestBearingMint/updateInterestBearingMint.test.ts
@@ -1,44 +1,41 @@
 import { expect, it } from 'vitest';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
-import { Account, isSome } from '@solana/kit';
-import { extension, fetchMint, getUpdateRateInterestBearingMintInstruction, Mint } from '../../../src';
+import { createTestClient } from '../../_setup';
+import { Account, generateKeyPairSigner, isSome } from '@solana/kit';
+import { extension, fetchMint, Mint } from '../../../src';
 
 it('updates the interest bearing mint extension on a mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [rateAuthority] = await Promise.all([generateKeyPairSignerWithSol(client)]);
+    const [rateAuthority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     const oldRate = 10000;
     const newRate = 20000;
 
     // And a mint with an interest bearing mint extension.
-    const mint = await createMint({
-        authority: rateAuthority,
-        client,
-        extensions: [
-            extension('InterestBearingConfig', {
-                rateAuthority: rateAuthority.address,
-                initializationTimestamp: BigInt(Math.floor(new Date().getTime() / 1000)),
-                lastUpdateTimestamp: BigInt(Math.floor(new Date().getTime() / 1000)),
-                preUpdateAverageRate: oldRate,
-                currentRate: oldRate,
-            }),
-        ],
-        payer: rateAuthority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: rateAuthority,
+            extensions: [
+                extension('InterestBearingConfig', {
+                    rateAuthority: rateAuthority.address,
+                    initializationTimestamp: BigInt(Math.floor(new Date().getTime() / 1000)),
+                    lastUpdateTimestamp: BigInt(Math.floor(new Date().getTime() / 1000)),
+                    preUpdateAverageRate: oldRate,
+                    currentRate: oldRate,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the interest bearing mint extension on the mint account
-    await client.sendTransaction([
-        getUpdateRateInterestBearingMintInstruction({
-            rateAuthority: rateAuthority,
-            mint: mint,
-            rate: newRate,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateRateInterestBearingMint({ rateAuthority, mint: mint.address, rate: newRate })
+        .sendTransaction();
 
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
     });
 
     // Then the mint account has an interest bearing mint extension.

--- a/clients/js/test/extensions/memoTransfers/disableMemoTransfers.test.ts
+++ b/clients/js/test/extensions/memoTransfers/disableMemoTransfers.test.ts
@@ -1,43 +1,33 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Token, extension, fetchToken, getDisableMemoTransfersInstruction } from '../../../src';
-import {
-    createTestClient,
-    createMint,
-    createToken,
-    generateKeyPairSignerWithSol,
-    getCreateTokenInstructions,
-} from '../../_setup';
+import { Token, extension, fetchToken } from '../../../src';
+import { createTestClient, createToken } from '../../_setup';
 
 it('initializes a token account with a disabled memo transfers extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, token, owner] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, token, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
 
     // When we create a token account and disable memo transfers.
     const memoTransfersExtension = extension('MemoTransfer', {
         requireIncomingTransferMemos: false,
     });
-    const [createTokenInstruction, initTokenInstruction] = await getCreateTokenInstructions({
-        client,
-        extensions: [memoTransfersExtension],
-        mint,
-        owner: owner.address,
-        payer: authority,
-        token,
-    });
-    await client.sendTransaction([
-        createTokenInstruction,
-        initTokenInstruction,
-        getDisableMemoTransfersInstruction({ token: token.address, owner }),
-    ]);
+    await client.token2022.instructions
+        .createToken({
+            newToken: token,
+            mint: mint.address,
+            owner,
+            extensions: [memoTransfersExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the token account to exist and have the following extension.
     const tokenAccount = await fetchToken(client.rpc, token.address);
@@ -52,20 +42,24 @@ it('initializes a token account with a disabled memo transfers extension', async
 it('disables an active memo transfers extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, owner] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
 
     // And a token account with an active memo transfers extension.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
     const token = await createToken({
         client,
         extensions: [extension('MemoTransfer', { requireIncomingTransferMemos: true })],
-        mint,
+        mint: mint.address,
         owner,
-        payer: authority,
+        payer: client.payer,
     });
 
     // When we disable the memo transfers extension.
-    await client.sendTransaction([getDisableMemoTransfersInstruction({ token, owner })]);
+    await client.token2022.instructions.disableMemoTransfers({ token, owner }).sendTransaction();
 
     // Then we expect the token account to have the extension disabled.
     const tokenAccount = await fetchToken(client.rpc, token);

--- a/clients/js/test/extensions/memoTransfers/enableMemoTransfers.test.ts
+++ b/clients/js/test/extensions/memoTransfers/enableMemoTransfers.test.ts
@@ -1,43 +1,33 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Token, extension, fetchToken, getEnableMemoTransfersInstruction } from '../../../src';
-import {
-    createTestClient,
-    createMint,
-    createToken,
-    generateKeyPairSignerWithSol,
-    getCreateTokenInstructions,
-} from '../../_setup';
+import { Token, extension, fetchToken } from '../../../src';
+import { createTestClient, createToken } from '../../_setup';
 
 it('initializes a token account with an active memo transfers extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, token, owner] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, token, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
 
     // When we create a token account and enable memo transfers.
     const memoTransfersExtension = extension('MemoTransfer', {
         requireIncomingTransferMemos: true,
     });
-    const [createTokenInstruction, initTokenInstruction] = await getCreateTokenInstructions({
-        client,
-        extensions: [memoTransfersExtension],
-        mint,
-        owner: owner.address,
-        payer: authority,
-        token,
-    });
-    await client.sendTransaction([
-        createTokenInstruction,
-        initTokenInstruction,
-        getEnableMemoTransfersInstruction({ token: token.address, owner }),
-    ]);
+    await client.token2022.instructions
+        .createToken({
+            newToken: token,
+            mint: mint.address,
+            owner,
+            extensions: [memoTransfersExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the token account to exist and have the following extension.
     const tokenAccount = await fetchToken(client.rpc, token.address);
@@ -52,20 +42,24 @@ it('initializes a token account with an active memo transfers extension', async 
 it('enables an disabled memo transfers extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, owner] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
 
     // And a token account with a disabled memo transfers extension.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority: authority }).sendTransaction();
     const token = await createToken({
         client,
         extensions: [extension('MemoTransfer', { requireIncomingTransferMemos: false })],
-        mint,
+        mint: mint.address,
         owner,
-        payer: authority,
+        payer: client.payer,
     });
 
     // When we enable the memo transfers extension.
-    await client.sendTransaction([getEnableMemoTransfersInstruction({ token, owner })]);
+    await client.token2022.instructions.enableMemoTransfers({ token, owner }).sendTransaction();
 
     // Then we expect the token account to have the extension enabled.
     const tokenAccount = await fetchToken(client.rpc, token);

--- a/clients/js/test/extensions/metadataPointer/initializeMetadataPointer.test.ts
+++ b/clients/js/test/extensions/metadataPointer/initializeMetadataPointer.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeMetadataPointerInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with a metadata pointer extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, metadata, metadataPointerAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
@@ -20,22 +20,13 @@ it('initializes a mint account with a metadata pointer extension', async () => {
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [metadataPointerExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeMetadataPointerInstruction({
-            mint: mint.address,
-            authority: metadataPointerExtension.authority,
-            metadataAddress: metadataPointerExtension.metadataAddress,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [metadataPointerExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/metadataPointer/updateMetadataPointer.test.ts
+++ b/clients/js/test/extensions/metadataPointer/updateMetadataPointer.test.ts
@@ -1,44 +1,42 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getUpdateMetadataPointerInstruction } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the metadata pointer extension on a mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, metadataPointerAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, metadataPointerAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
     const oldMetadata = address('8dtp4b6tB8EhLpSG1jgg4swSQtUKRst2f7rJYSwE2Me3');
     const newMetadata = address('88F35KbnWKPeMnKFJDxZVjvEWmGms1FxW6wP52VABCVt');
 
     // And a mint account initialized with a metadata pointer extension.
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: metadataPointerAuthority.address,
-                metadataAddress: oldMetadata,
-            }),
-        ],
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: metadataPointerAuthority.address,
+                    metadataAddress: oldMetadata,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the metadata pointer on the mint account.
-    await client.sendTransaction([
-        getUpdateMetadataPointerInstruction({
-            mint,
-            metadataPointerAuthority,
-            metadataAddress: newMetadata,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateMetadataPointer({ mint: mint.address, metadataPointerAuthority, metadataAddress: newMetadata })
+        .sendTransaction();
 
     // Then we expect the mint account to have the following updated data.
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
         data: {
             extensions: some([
                 extension('MetadataPointer', {

--- a/clients/js/test/extensions/mintCloseAuthority.test.ts
+++ b/clients/js/test/extensions/mintCloseAuthority.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, none, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeMintCloseAuthorityInstruction } from '../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../_setup';
+import { Mint, extension, fetchMint } from '../../src';
+import { createTestClient } from '../_setup';
 
 it('initializes a mint account with a close authority', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a mint close authority extension.
     const mintCloseAuthorityExtension = extension('MintCloseAuthority', {
@@ -14,22 +14,14 @@ it('initializes a mint account with a close authority', async () => {
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [mintCloseAuthorityExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeMintCloseAuthorityInstruction({
-            mint: mint.address,
-            closeAuthority: mintCloseAuthorityExtension.closeAuthority,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [mintCloseAuthorityExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following data.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/nonTransfer/initializeNonTransferableMint.test.ts
+++ b/clients/js/test/extensions/nonTransfer/initializeNonTransferableMint.test.ts
@@ -1,29 +1,21 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeNonTransferableMintInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a non-transferable mint', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // When we create and initialize a mint account as non-transferable
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [extension('NonTransferable', {})],
-        mint,
-        payer: authority,
-    });
-
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeNonTransferableMintInstruction({
-            mint: mint.address,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [extension('NonTransferable', {})],
+        })
+        .sendTransaction();
 
     // Then we expect the mint to be initialized with the non-transferable extension
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/pausable/initializePausable.test.ts
+++ b/clients/js/test/extensions/pausable/initializePausable.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { getInitializePausableConfigInstruction, extension, fetchMint, Mint } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { extension, fetchMint, Mint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint with a pausable config', async () => {
     // Given a fresh client with no state the test cares about.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a pausable config extension.
     const pausableConfigExtension = extension('PausableConfig', {
@@ -15,22 +15,14 @@ it('initializes a mint with a pausable config', async () => {
     });
 
     // When we initialize the mint with the pausable config extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [pausableConfigExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializePausableConfigInstruction({
-            mint: mint.address,
-            authority: authority.address,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [pausableConfigExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following data.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/pausable/pause.test.ts
+++ b/clients/js/test/extensions/pausable/pause.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, isSome, some } from '@solana/kit';
-import { getInitializePausableConfigInstruction, extension, fetchMint, getPauseInstruction } from '../../../src';
-import { createTestClient, getCreateMintInstructions } from '../../_setup';
+import { extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('pauses a mint', async () => {
     // Given a fresh client with no state the test cares about.
@@ -16,29 +16,17 @@ it('pauses a mint', async () => {
     });
 
     // When we initialize the mint with the pausable config extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [pausableConfigExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializePausableConfigInstruction({
-            mint: mint.address,
-            authority: authority.address,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [pausableConfigExtension],
+        })
+        .sendTransaction();
 
     // And when pause the mint.
-    const pauseInstruction = getPauseInstruction({
-        mint: mint.address,
-        authority: authority.address,
-    });
-    await client.sendTransaction([pauseInstruction]);
+    await client.token2022.instructions.pause({ mint: mint.address, authority: authority.address }).sendTransaction();
 
     // Then we expect the mint account to exist and have the pausable config extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/pausable/resume.test.ts
+++ b/clients/js/test/extensions/pausable/resume.test.ts
@@ -1,13 +1,7 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, isSome, some } from '@solana/kit';
-import {
-    getInitializePausableConfigInstruction,
-    extension,
-    fetchMint,
-    getPauseInstruction,
-    getResumeInstruction,
-} from '../../../src';
-import { createTestClient, getCreateMintInstructions } from '../../_setup';
+import { extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('resumes a mint', async () => {
     // Given a fresh client with no state the test cares about.
@@ -22,36 +16,20 @@ it('resumes a mint', async () => {
     });
 
     // When we initialize the mint with the pausable config extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [pausableConfigExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializePausableConfigInstruction({
-            mint: mint.address,
-            authority: authority.address,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [pausableConfigExtension],
+        })
+        .sendTransaction();
 
     // And when pause the mint.
-    const pauseInstruction = getPauseInstruction({
-        mint: mint.address,
-        authority: authority.address,
-    });
-    await client.sendTransaction([pauseInstruction]);
+    await client.token2022.instructions.pause({ mint: mint.address, authority: authority.address }).sendTransaction();
 
     // And when resume the mint.
-    const resumeInstruction = getResumeInstruction({
-        mint: mint.address,
-        authority: authority.address,
-    });
-    await client.sendTransaction([resumeInstruction]);
+    await client.token2022.instructions.resume({ mint: mint.address, authority: authority.address }).sendTransaction();
 
     // Then we expect the mint account to exist and have the pausable config extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/permanentDelegate/initializePermanentDelegate.test.ts
+++ b/clients/js/test/extensions/permanentDelegate/initializePermanentDelegate.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializePermanentDelegateInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint with permanent delegate', async () => {
     // Given some signer accounts
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a permanent delegate extension
     const permanentDelegate = address('6sPR6MzvjMMP5LSZzEtTe4ZBVX9rhBmtM1dmfFtkNTbW');
@@ -15,22 +15,13 @@ it('initializes a mint with permanent delegate', async () => {
     });
 
     // When we create and initialize a mint account with this extension
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [permanentDelegateExtension],
-        mint,
-        payer: authority,
-    });
-
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializePermanentDelegateInstruction({
-            mint: mint.address,
-            delegate: permanentDelegate,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [permanentDelegateExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist with the permanent delegate
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/permissionedBurn/initializePermissionedBurn.test.ts
+++ b/clients/js/test/extensions/permissionedBurn/initializePermissionedBurn.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializePermissionedBurnInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint with permissioned burn', async () => {
     // Given a fresh client and signers
     const client = await createTestClient();
     const [authority, mint, permissionedBurnAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
@@ -18,22 +18,13 @@ it('initializes a mint with permissioned burn', async () => {
     });
 
     // When we create and initialize a mint account with this extension
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [permissionedBurnExtension],
-        mint,
-        payer: authority,
-    });
-
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializePermissionedBurnInstruction({
-            mint: mint.address,
-            authority: permissionedBurnAuthority.address,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [permissionedBurnExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist with the permissioned burn config
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/reallocate.test.ts
+++ b/clients/js/test/extensions/reallocate.test.ts
@@ -7,33 +7,34 @@ import {
     GetAccountInfoApi,
     Rpc,
 } from '@solana/kit';
-import { ExtensionType, getReallocateInstruction } from '../../src';
-import { createTestClient, createMint, createToken, generateKeyPairSignerWithSol } from '../_setup';
+import { ExtensionType } from '../../src';
+import { createTestClient, createToken, generateKeyPairSignerWithSol } from '../_setup';
 
 it('reallocates token accounts to fit the provided extensions', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, owner] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, owner, mint] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
 
     // And a token account with no extensions.
-    const mint = await createMint({ authority, client, payer: authority });
+    await client.token2022.instructions
+        .createMint({ payer: authority, newMint: mint, mintAuthority: authority })
+        .sendTransaction();
     const token = await createToken({
         client,
-        mint,
+        mint: mint.address,
         owner,
         payer: authority,
     });
     expect(await getAccountLength(client, token)).toBe(165);
 
     // When
-    await client.sendTransaction([
-        getReallocateInstruction({
-            token,
-            owner,
-            newExtensionTypes: [ExtensionType.MemoTransfer],
-            payer: authority,
-        }),
-    ]);
+    await client.token2022.instructions
+        .reallocate({ token, owner, newExtensionTypes: [ExtensionType.MemoTransfer], payer: authority })
+        .sendTransaction();
 
     // Then
     expect(await getAccountLength(client, token)).toBe(

--- a/clients/js/test/extensions/scaledUiAmountMint/initializeScaledUiAmountMint.test.ts
+++ b/clients/js/test/extensions/scaledUiAmountMint/initializeScaledUiAmountMint.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { createTestClient } from '../../_setup';
 import { Account, generateKeyPairSigner, isSome } from '@solana/kit';
-import { extension, fetchMint, getInitializeScaledUiAmountMintInstruction, Mint } from '../../../src';
+import { extension, fetchMint, Mint } from '../../../src';
 
 it('initialize a mint account with a scaled ui amount mint extension', async () => {
     // Given a fresh client with no state the test cares about.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     const multiplier = 1;
     const newMultiplier = 2;
@@ -20,23 +20,14 @@ it('initialize a mint account with a scaled ui amount mint extension', async () 
     });
 
     // When we initialize the mint account with the scaled ui amount mint extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [scaledUiAmountMintExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeScaledUiAmountMintInstruction({
-            mint: mint.address,
-            authority: authority.address,
-            multiplier,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [scaledUiAmountMintExtension],
+        })
+        .sendTransaction();
 
     const mintAccount = await fetchMint(client.rpc, mint.address);
     // Then the mint account exists.

--- a/clients/js/test/extensions/scaledUiAmountMint/updateScaledUiAmountMint.test.ts
+++ b/clients/js/test/extensions/scaledUiAmountMint/updateScaledUiAmountMint.test.ts
@@ -1,42 +1,44 @@
 import { expect, it } from 'vitest';
-import { createTestClient, createMint } from '../../_setup';
-import { isSome } from '@solana/kit';
-import { extension, fetchMint, getUpdateMultiplierScaledUiMintInstruction } from '../../../src';
+import { createTestClient } from '../../_setup';
+import { generateKeyPairSigner, isSome } from '@solana/kit';
+import { extension, fetchMint } from '../../../src';
 
 it('updates the multiplier of the scaled ui amount mint extension on a mint account', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const multiplierAuthority = client.payer;
+    const mint = await generateKeyPairSigner();
 
     const oldMultiplier = 1;
     const newMultiplier = 2;
 
     // And a mint with a scaled ui amount mint extension.
-    const mint = await createMint({
-        authority: multiplierAuthority,
-        client,
-        extensions: [
-            extension('ScaledUiAmountConfig', {
-                authority: multiplierAuthority.address,
-                multiplier: oldMultiplier,
-                newMultiplierEffectiveTimestamp: BigInt(Math.floor(new Date().getTime() * 2)),
-                newMultiplier: oldMultiplier,
-            }),
-        ],
-        payer: multiplierAuthority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: multiplierAuthority,
+            extensions: [
+                extension('ScaledUiAmountConfig', {
+                    authority: multiplierAuthority.address,
+                    multiplier: oldMultiplier,
+                    newMultiplierEffectiveTimestamp: BigInt(Math.floor(new Date().getTime() * 2)),
+                    newMultiplier: oldMultiplier,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the scaled ui amount mint extension on the mint account
-    await client.sendTransaction([
-        getUpdateMultiplierScaledUiMintInstruction({
-            mint,
+    await client.token2022.instructions
+        .updateMultiplierScaledUiMint({
+            mint: mint.address,
             authority: multiplierAuthority.address,
             multiplier: newMultiplier,
             effectiveTimestamp: BigInt(Math.floor(new Date().getTime() / 1000)),
-        }),
-    ]);
+        })
+        .sendTransaction();
 
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
 
     // Then the mint account has a scaled ui amount mint extension.
     const extensions = mintAccount.data.extensions;

--- a/clients/js/test/extensions/tokenGroup/initializeTokenGroup.test.ts
+++ b/clients/js/test/extensions/tokenGroup/initializeTokenGroup.test.ts
@@ -1,19 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import {
-    Mint,
-    extension,
-    fetchMint,
-    getInitializeGroupPointerInstruction,
-    getInitializeTokenGroupInstruction,
-} from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with a token group and group pointer extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
@@ -33,29 +27,13 @@ it('initializes a mint account with a token group and group pointer extension', 
     });
 
     // When we create and initialize a mint account with these extensions.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [groupPointerExtension, tokenGroupExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeGroupPointerInstruction({
-            mint: mint.address,
-            authority: authority.address,
-            groupAddress: mint.address,
-        }),
-        initMintInstruction,
-        getInitializeTokenGroupInstruction({
-            group: mint.address,
-            updateAuthority: updateAuthority.address,
-            mint: mint.address,
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
             mintAuthority: authority,
-            maxSize: tokenGroupExtension.maxSize,
-        }),
-    ]);
+            extensions: [groupPointerExtension, tokenGroupExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/tokenGroup/initializeTokenGroupMember.test.ts
+++ b/clients/js/test/extensions/tokenGroup/initializeTokenGroupMember.test.ts
@@ -1,37 +1,37 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, none, some, unwrapOption } from '@solana/kit';
-import { extension, fetchMint, getInitializeTokenGroupMemberInstruction, isExtension, Mint } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { extension, fetchMint, isExtension, Mint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('adds members to the token group extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, group, member, groupUpdateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a group mint account initialized with the token group and group pointer extensions.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('GroupPointer', {
-                authority: authority.address,
-                groupAddress: group.address,
-            }),
-            extension('TokenGroup', {
-                updateAuthority: groupUpdateAuthority.address,
-                mint: group.address,
-                size: 0n,
-                maxSize: 20_000n,
-            }),
-        ],
-        mint: group,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: group,
+            mintAuthority: authority,
+            extensions: [
+                extension('GroupPointer', {
+                    authority: authority.address,
+                    groupAddress: group.address,
+                }),
+                extension('TokenGroup', {
+                    updateAuthority: groupUpdateAuthority.address,
+                    mint: group.address,
+                    size: 0n,
+                    maxSize: 20_000n,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // And a member mint account with the group member pointer and the token group member extensions.
     const memberExtensions = [
@@ -45,24 +45,20 @@ it('adds members to the token group extension', async () => {
             memberNumber: 1n,
         }),
     ];
-    await createMint({
-        authority,
-        client,
-        extensions: memberExtensions,
-        mint: member,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({ newMint: member, mintAuthority: authority, extensions: memberExtensions })
+        .sendTransaction();
 
     // When we initialize the member mint account as a member of the group mint account.
-    await client.sendTransaction([
-        getInitializeTokenGroupMemberInstruction({
+    await client.token2022.instructions
+        .initializeTokenGroupMember({
             member: member.address,
             memberMint: member.address,
             memberMintAuthority: authority,
             group: group.address,
             groupUpdateAuthority,
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect the member mint account to have the following extensions
     const memberAccount = await fetchMint(client.rpc, member.address);

--- a/clients/js/test/extensions/tokenGroup/updateTokenGroupMaxSize.test.ts
+++ b/clients/js/test/extensions/tokenGroup/updateTokenGroupMaxSize.test.ts
@@ -1,45 +1,41 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, unwrapOption } from '@solana/kit';
-import { extension, fetchMint, getUpdateTokenGroupMaxSizeInstruction, isExtension } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { extension, fetchMint, isExtension } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the max size of the token group extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with the token group and group pointer extensions.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('GroupPointer', {
-                authority: authority.address,
-                groupAddress: mint.address,
-            }),
-            extension('TokenGroup', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                size: 0n,
-                maxSize: 20_000n,
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('GroupPointer', {
+                    authority: authority.address,
+                    groupAddress: mint.address,
+                }),
+                extension('TokenGroup', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    size: 0n,
+                    maxSize: 20_000n,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we change the max size of the token group extension.
-    await client.sendTransaction([
-        getUpdateTokenGroupMaxSizeInstruction({
-            group: mint.address,
-            updateAuthority,
-            maxSize: 30_000n,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateTokenGroupMaxSize({ group: mint.address, updateAuthority, maxSize: 30_000n })
+        .sendTransaction();
 
     // Then we expect the token group extension to have the new max size.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/tokenGroup/updateTokenGroupUpdateAuthority.test.ts
+++ b/clients/js/test/extensions/tokenGroup/updateTokenGroupUpdateAuthority.test.ts
@@ -1,46 +1,46 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, none, some, unwrapOption } from '@solana/kit';
-import { extension, fetchMint, getUpdateTokenGroupUpdateAuthorityInstruction, isExtension } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { extension, fetchMint, isExtension } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the update authority of the token group extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority, newUpdateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with the token group and group pointer extensions.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('GroupPointer', {
-                authority: authority.address,
-                groupAddress: mint.address,
-            }),
-            extension('TokenGroup', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                size: 0n,
-                maxSize: 20_000n,
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('GroupPointer', {
+                    authority: authority.address,
+                    groupAddress: mint.address,
+                }),
+                extension('TokenGroup', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    size: 0n,
+                    maxSize: 20_000n,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we change the update authority of the token group extension.
-    await client.sendTransaction([
-        getUpdateTokenGroupUpdateAuthorityInstruction({
+    await client.token2022.instructions
+        .updateTokenGroupUpdateAuthority({
             group: mint.address,
             updateAuthority,
             newUpdateAuthority: newUpdateAuthority.address,
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect the new update authority to be set on the token group extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);
@@ -52,39 +52,35 @@ it('removes the update authority of the token group extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with the token group and group pointer extensions.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('GroupPointer', {
-                authority: authority.address,
-                groupAddress: mint.address,
-            }),
-            extension('TokenGroup', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                size: 0n,
-                maxSize: 20_000n,
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('GroupPointer', {
+                    authority: authority.address,
+                    groupAddress: mint.address,
+                }),
+                extension('TokenGroup', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    size: 0n,
+                    maxSize: 20_000n,
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we remove the update authority of the token group extension.
-    await client.sendTransaction([
-        getUpdateTokenGroupUpdateAuthorityInstruction({
-            group: mint.address,
-            updateAuthority,
-            newUpdateAuthority: none(),
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateTokenGroupUpdateAuthority({ group: mint.address, updateAuthority, newUpdateAuthority: none() })
+        .sendTransaction();
 
     // Then we expect the token group extension to have no update authority.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/tokenMetadata/emitTokenMetadata.test.ts
+++ b/clients/js/test/extensions/tokenMetadata/emitTokenMetadata.test.ts
@@ -1,13 +1,13 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner } from '@solana/kit';
-import { extension, getEmitTokenMetadataInstruction, getExtensionEncoder } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol, getSingleTransactionContext } from '../../_setup';
+import { extension, getExtensionEncoder } from '../../../src';
+import { createTestClient, getSingleTransactionContext } from '../../_setup';
 
 it('emits the token metadata extension as return data', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
@@ -21,22 +21,22 @@ it('emits the token metadata extension as return data', async () => {
         uri: 'https://example.com/mst.json',
         additionalMetadata: new Map(),
     });
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: authority.address,
-                metadataAddress: mint.address,
-            }),
-            tokenMetadataExtension,
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: authority.address,
+                    metadataAddress: mint.address,
+                }),
+                tokenMetadataExtension,
+            ],
+        })
+        .sendTransaction();
 
     // When we emit the token metadata extension.
-    const result = await client.sendTransaction([getEmitTokenMetadataInstruction({ metadata: mint.address })]);
+    const result = await client.token2022.instructions.emitTokenMetadata({ metadata: mint.address }).sendTransaction();
 
     // Then we expect the token metadata extension to be emitted as return data.
     const returnData = getSingleTransactionContext(result).transactionMetadata.returnData().data();

--- a/clients/js/test/extensions/tokenMetadata/initializeTokenMetadata.test.ts
+++ b/clients/js/test/extensions/tokenMetadata/initializeTokenMetadata.test.ts
@@ -1,19 +1,13 @@
 import { expect, it } from 'vitest';
 import { Account, generateKeyPairSigner, some } from '@solana/kit';
-import {
-    Mint,
-    extension,
-    fetchMint,
-    getInitializeMetadataPointerInstruction,
-    getInitializeTokenMetadataInstruction,
-} from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with a token metadata and metadata pointer extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
@@ -35,31 +29,13 @@ it('initializes a mint account with a token metadata and metadata pointer extens
     });
 
     // When we create and initialize a mint account with these extensions.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [metadataPointerExtension, tokenMetadataExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeMetadataPointerInstruction({
-            mint: mint.address,
-            authority: authority.address,
-            metadataAddress: mint.address,
-        }),
-        initMintInstruction,
-        getInitializeTokenMetadataInstruction({
-            metadata: mint.address,
-            updateAuthority: updateAuthority.address,
-            mint: mint.address,
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
             mintAuthority: authority,
-            name: tokenMetadataExtension.name,
-            symbol: tokenMetadataExtension.symbol,
-            uri: tokenMetadataExtension.uri,
-        }),
-    ]);
+            extensions: [metadataPointerExtension, tokenMetadataExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/tokenMetadata/removeTokenMetadataKey.test.ts
+++ b/clients/js/test/extensions/tokenMetadata/removeTokenMetadataKey.test.ts
@@ -1,62 +1,51 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, unwrapOption } from '@solana/kit';
-import {
-    extension,
-    fetchMint,
-    getRemoveTokenMetadataKeyInstruction,
-    getUpdateTokenMetadataFieldInstruction,
-    isExtension,
-    tokenMetadataField,
-} from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { extension, fetchMint, isExtension, tokenMetadataField } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('removes a custom field on the token metadata extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with a token metadata extension that has a custom field.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: authority.address,
-                metadataAddress: mint.address,
-            }),
-            extension('TokenMetadata', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                name: 'My Super Token',
-                symbol: 'MST',
-                uri: 'https://example.com/mst.json',
-                additionalMetadata: new Map<string, string>([['CustomField', 'CustomValue']]),
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        getUpdateTokenMetadataFieldInstruction({
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: authority.address,
+                    metadataAddress: mint.address,
+                }),
+                extension('TokenMetadata', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    name: 'My Super Token',
+                    symbol: 'MST',
+                    uri: 'https://example.com/mst.json',
+                    additionalMetadata: new Map<string, string>([['CustomField', 'CustomValue']]),
+                }),
+            ],
+        })
+        .sendTransaction();
+    await client.token2022.instructions
+        .updateTokenMetadataField({
             metadata: mint.address,
-            updateAuthority: updateAuthority,
+            updateAuthority,
             field: tokenMetadataField('Key', ['CustomField']),
             value: 'CustomValue',
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // When we remove the custom field from the token metadata extension.
-    await client.sendTransaction([
-        getRemoveTokenMetadataKeyInstruction({
-            metadata: mint.address,
-            updateAuthority: updateAuthority,
-            key: 'CustomField',
-        }),
-    ]);
+    await client.token2022.instructions
+        .removeTokenMetadataKey({ metadata: mint.address, updateAuthority, key: 'CustomField' })
+        .sendTransaction();
 
     // Then we expect the token metadata extension to no longer have custom fields.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/tokenMetadata/updateTokenMetadataField.test.ts
+++ b/clients/js/test/extensions/tokenMetadata/updateTokenMetadataField.test.ts
@@ -1,54 +1,48 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, unwrapOption } from '@solana/kit';
-import {
-    extension,
-    fetchMint,
-    getUpdateTokenMetadataFieldInstruction,
-    isExtension,
-    tokenMetadataField,
-} from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { extension, fetchMint, isExtension, tokenMetadataField } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates a known field on the token metadata extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized with the token metadata and metadata pointer extensions.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: authority.address,
-                metadataAddress: mint.address,
-            }),
-            extension('TokenMetadata', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                name: 'My OLD Token Name',
-                symbol: 'MST',
-                uri: 'https://example.com/mst.json',
-                additionalMetadata: new Map<string, string>(),
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: authority.address,
+                    metadataAddress: mint.address,
+                }),
+                extension('TokenMetadata', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    name: 'My OLD Token Name',
+                    symbol: 'MST',
+                    uri: 'https://example.com/mst.json',
+                    additionalMetadata: new Map<string, string>(),
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we change the name of the token metadata extension.
-    await client.sendTransaction([
-        getUpdateTokenMetadataFieldInstruction({
+    await client.token2022.instructions
+        .updateTokenMetadataField({
             metadata: mint.address,
-            updateAuthority: updateAuthority,
+            updateAuthority,
             field: tokenMetadataField('Name'),
             value: 'My NEW Token Name',
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect the token metadata extension to have the new name.
     const mintAccount = await fetchMint(client.rpc, mint.address);
@@ -62,7 +56,7 @@ it('updates a custom field on the token metadata extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
@@ -70,39 +64,39 @@ it('updates a custom field on the token metadata extension', async () => {
     // And a mint account initialized with the token metadata and metadata pointer
     // extension such that the additional metadata field is set to a custom key/value
     // pair in order to know the size of mint account data before updating the field.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: authority.address,
-                metadataAddress: mint.address,
-            }),
-            extension('TokenMetadata', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                name: 'My Super Token',
-                symbol: 'MST',
-                uri: 'https://example.com/mst.json',
-                additionalMetadata: new Map<string, string>([
-                    // This is important to know how much rent to pay at this stage.
-                    ['CustomField', 'CustomValue'],
-                ]),
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: authority.address,
+                    metadataAddress: mint.address,
+                }),
+                extension('TokenMetadata', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    name: 'My Super Token',
+                    symbol: 'MST',
+                    uri: 'https://example.com/mst.json',
+                    additionalMetadata: new Map<string, string>([
+                        // This is important to know how much rent to pay at this stage.
+                        ['CustomField', 'CustomValue'],
+                    ]),
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we set the custom field on the token metadata extension.
-    await client.sendTransaction([
-        getUpdateTokenMetadataFieldInstruction({
+    await client.token2022.instructions
+        .updateTokenMetadataField({
             metadata: mint.address,
-            updateAuthority: updateAuthority,
+            updateAuthority,
             field: tokenMetadataField('Key', ['CustomField']),
             value: 'CustomValue',
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect the token metadata extension to have the new custom field.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/tokenMetadata/updateTokenMetadataUpdateAuthority.test.ts
+++ b/clients/js/test/extensions/tokenMetadata/updateTokenMetadataUpdateAuthority.test.ts
@@ -1,48 +1,48 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner, none, some, unwrapOption } from '@solana/kit';
-import { extension, fetchMint, getUpdateTokenMetadataUpdateAuthorityInstruction, isExtension } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol } from '../../_setup';
+import { extension, fetchMint, isExtension } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates the update authority of the token metadata extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority, newUpdateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized a token metadata extension.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: authority.address,
-                metadataAddress: mint.address,
-            }),
-            extension('TokenMetadata', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                name: 'My Super Token',
-                symbol: 'MST',
-                uri: 'https://example.com/mst.json',
-                additionalMetadata: new Map(),
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: authority.address,
+                    metadataAddress: mint.address,
+                }),
+                extension('TokenMetadata', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    name: 'My Super Token',
+                    symbol: 'MST',
+                    uri: 'https://example.com/mst.json',
+                    additionalMetadata: new Map(),
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we update the update authority of the token metadata extension.
-    await client.sendTransaction([
-        getUpdateTokenMetadataUpdateAuthorityInstruction({
+    await client.token2022.instructions
+        .updateTokenMetadataUpdateAuthority({
             metadata: mint.address,
-            updateAuthority: updateAuthority,
+            updateAuthority,
             newUpdateAuthority: newUpdateAuthority.address,
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect the new update authority to be set on the token metadata extension.
     const mintAccount = await fetchMint(client.rpc, mint.address);
@@ -56,42 +56,38 @@ it('removes the update authority of the token metadata extension', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
     const [authority, mint, updateAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
     // And a mint account initialized a token metadata extension.
-    await createMint({
-        authority,
-        client,
-        extensions: [
-            extension('MetadataPointer', {
-                authority: authority.address,
-                metadataAddress: mint.address,
-            }),
-            extension('TokenMetadata', {
-                updateAuthority: updateAuthority.address,
-                mint: mint.address,
-                name: 'My Super Token',
-                symbol: 'MST',
-                uri: 'https://example.com/mst.json',
-                additionalMetadata: new Map(),
-            }),
-        ],
-        mint,
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [
+                extension('MetadataPointer', {
+                    authority: authority.address,
+                    metadataAddress: mint.address,
+                }),
+                extension('TokenMetadata', {
+                    updateAuthority: updateAuthority.address,
+                    mint: mint.address,
+                    name: 'My Super Token',
+                    symbol: 'MST',
+                    uri: 'https://example.com/mst.json',
+                    additionalMetadata: new Map(),
+                }),
+            ],
+        })
+        .sendTransaction();
 
     // When we remove the update authority of the token metadata extension.
-    await client.sendTransaction([
-        getUpdateTokenMetadataUpdateAuthorityInstruction({
-            metadata: mint.address,
-            updateAuthority: updateAuthority,
-            newUpdateAuthority: null,
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateTokenMetadataUpdateAuthority({ metadata: mint.address, updateAuthority, newUpdateAuthority: null })
+        .sendTransaction();
 
     // Then we expect token metadata extension to no longer have an update authority.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/transferFee/initializeTransferFeeConfig.test.ts
+++ b/clients/js/test/extensions/transferFee/initializeTransferFeeConfig.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, none, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeTransferFeeConfigInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint account with transfer fee configurations', async () => {
     // Given an authority and a mint account.
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a transfer fee config extension.
     const transferFees = {
@@ -24,25 +24,14 @@ it('initializes a mint account with transfer fee configurations', async () => {
     });
 
     // When we create and initialize a mint account with this extension.
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        decimals: 2,
-        extensions: [transferFeeConfigExtension],
-        mint,
-        payer: authority,
-    });
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeTransferFeeConfigInstruction({
-            mint: mint.address,
-            transferFeeConfigAuthority: transferFeeConfigExtension.transferFeeConfigAuthority,
-            withdrawWithheldAuthority: transferFeeConfigExtension.withdrawWithheldAuthority,
-            transferFeeBasisPoints: transferFeeConfigExtension.newerTransferFee.transferFeeBasisPoints,
-            maximumFee: transferFeeConfigExtension.newerTransferFee.maximumFee,
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [transferFeeConfigExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist and have the following data.
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/transferFee/transferCheckedWithFee.test.ts
+++ b/clients/js/test/extensions/transferFee/transferCheckedWithFee.test.ts
@@ -1,13 +1,14 @@
 import { expect, it } from 'vitest';
-import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Token, extension, fetchToken, getMintToInstruction, getTransferCheckedWithFeeInstruction } from '../../../src';
-import { createTestClient, createMint, generateKeyPairSignerWithSol, getCreateTokenInstructions } from '../../_setup';
+import { Account, address, generateKeyPairSigner, sequentialInstructionPlan, some } from '@solana/kit';
+import { Token, extension, fetchToken, getCreateTokenInstructionPlan, getMintToInstruction } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('transfers tokens with pre-configured fees', async () => {
     // Given some signer accounts.
     const client = await createTestClient();
-    const [authority, ownerA, tokenA, ownerB, tokenB] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, ownerA, tokenA, ownerB, tokenB, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
@@ -28,65 +29,63 @@ it('transfers tokens with pre-configured fees', async () => {
         // Used for transitioning configs. Starts by being the same as newerTransferFee.
         olderTransferFee: transferFees,
     });
-    const mint = await createMint({
-        authority,
-        client,
-        decimals: 2,
-        extensions: [transferFeeConfigExtension],
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            decimals: 2,
+            mintAuthority: authority,
+            extensions: [transferFeeConfigExtension],
+        })
+        .sendTransaction();
 
     // And two token accounts with 10.00 and 0.00 tokens respectively.
     const transferFeeAmount = extension('TransferFeeAmount', {
         withheldAmount: 0n,
     });
-    const createTokensInstructions = await Promise.all([
-        getCreateTokenInstructions({
-            client,
-            extensions: [transferFeeAmount],
-            mint,
-            owner: ownerA.address,
-            payer: authority,
-            token: tokenA,
-        }),
-        getCreateTokenInstructions({
-            client,
-            extensions: [transferFeeAmount],
-            mint,
-            owner: ownerB.address,
-            payer: authority,
-            token: tokenB,
-        }),
-    ]);
-    await client.sendTransaction([
-        ...createTokensInstructions.flat(),
-        getMintToInstruction({
-            mint,
-            token: tokenA.address,
-            mintAuthority: authority,
-            amount: 1000n,
-        }),
-    ]);
+    await client.sendTransaction(
+        sequentialInstructionPlan([
+            getCreateTokenInstructionPlan({
+                payer: client.payer,
+                newToken: tokenA,
+                mint: mint.address,
+                owner: ownerA.address,
+                extensions: [transferFeeAmount],
+            }),
+            getCreateTokenInstructionPlan({
+                payer: client.payer,
+                newToken: tokenB,
+                mint: mint.address,
+                owner: ownerB.address,
+                extensions: [transferFeeAmount],
+            }),
+            getMintToInstruction({
+                mint: mint.address,
+                token: tokenA.address,
+                mintAuthority: authority,
+                amount: 1000n,
+            }),
+        ]),
+    );
 
     // When we transfer 2.00 tokens from owner A to owner B with fees.
-    await client.sendTransaction([
-        getTransferCheckedWithFeeInstruction({
+    await client.token2022.instructions
+        .transferCheckedWithFee({
             source: tokenA.address,
-            mint,
+            mint: mint.address,
             destination: tokenB.address,
             authority: ownerA,
             amount: 200n,
             decimals: 2,
             fee: 3n, // 1.5% of 2.00 is 0.03.
-        }),
-    ]);
+        })
+        .sendTransaction();
 
     // Then we expect token A to have 8.00 tokens and no fees withheld.
     const tokenAccountA = await fetchToken(client.rpc, tokenA.address);
     expect(tokenAccountA).toMatchObject(<Account<Token>>{
         address: tokenA.address,
         data: {
-            mint,
+            mint: mint.address,
             owner: ownerA.address,
             amount: 800n,
             extensions: some([extension('TransferFeeAmount', { withheldAmount: 0n })]),
@@ -98,7 +97,7 @@ it('transfers tokens with pre-configured fees', async () => {
     expect(tokenAccountB).toMatchObject(<Account<Token>>{
         address: tokenB.address,
         data: {
-            mint,
+            mint: mint.address,
             owner: ownerB.address,
             amount: 197n,
             extensions: some([extension('TransferFeeAmount', { withheldAmount: 3n })]),

--- a/clients/js/test/extensions/transferHook/initializeTransferHook.test.ts
+++ b/clients/js/test/extensions/transferHook/initializeTransferHook.test.ts
@@ -1,12 +1,12 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getInitializeTransferHookInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, getCreateMintInstructions } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('initializes a mint with transfer hook extension', async () => {
     // Given some signer accounts
     const client = await createTestClient();
-    const [authority, mint] = await Promise.all([generateKeyPairSignerWithSol(client), generateKeyPairSigner()]);
+    const [authority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
     // And a transfer hook extension
     const transferHookAuthority = address('6sPR6MzvjMMP5LSZzEtTe4ZBVX9rhBmtM1dmfFtkNTbW');
@@ -17,23 +17,13 @@ it('initializes a mint with transfer hook extension', async () => {
     });
 
     // When we create and initialize a mint account with this extension
-    const [createMintInstruction, initMintInstruction] = await getCreateMintInstructions({
-        authority: authority.address,
-        client,
-        extensions: [transferHookExtension],
-        mint,
-        payer: authority,
-    });
-
-    await client.sendTransaction([
-        createMintInstruction,
-        getInitializeTransferHookInstruction({
-            mint: mint.address,
-            authority: some(transferHookAuthority),
-            programId: some(transferHookProgramId),
-        }),
-        initMintInstruction,
-    ]);
+    await client.token2022.instructions
+        .createMint({
+            newMint: mint,
+            mintAuthority: authority,
+            extensions: [transferHookExtension],
+        })
+        .sendTransaction();
 
     // Then we expect the mint account to exist with the transfer hook extension
     const mintAccount = await fetchMint(client.rpc, mint.address);

--- a/clients/js/test/extensions/transferHook/updateTransferHook.test.ts
+++ b/clients/js/test/extensions/transferHook/updateTransferHook.test.ts
@@ -1,13 +1,14 @@
 import { expect, it } from 'vitest';
 import { Account, address, generateKeyPairSigner, some } from '@solana/kit';
-import { Mint, extension, fetchMint, getUpdateTransferHookInstruction } from '../../../src';
-import { createTestClient, generateKeyPairSignerWithSol, createMint } from '../../_setup';
+import { Mint, extension, fetchMint } from '../../../src';
+import { createTestClient } from '../../_setup';
 
 it('updates transfer hook program ID on a mint', async () => {
     // Given some signer accounts and client
     const client = await createTestClient();
-    const [authority, hookAuthority] = await Promise.all([
-        generateKeyPairSignerWithSol(client),
+    const [authority, hookAuthority, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
 
@@ -18,27 +19,20 @@ it('updates transfer hook program ID on a mint', async () => {
         programId: oldProgramId,
     });
 
-    const mint = await createMint({
-        authority,
-        client,
-        extensions: [transferHookExtension],
-        payer: authority,
-    });
+    await client.token2022.instructions
+        .createMint({ newMint: mint, mintAuthority: authority, extensions: [transferHookExtension] })
+        .sendTransaction();
 
     // When we update the program ID
     const newProgramId = address('6sPR6MzvjMMP5LSZzEtTe4ZBVX9rhBmtM1dmfFtkNTbW');
-    await client.sendTransaction([
-        getUpdateTransferHookInstruction({
-            mint,
-            authority: hookAuthority,
-            programId: some(newProgramId),
-        }),
-    ]);
+    await client.token2022.instructions
+        .updateTransferHook({ mint: mint.address, authority: hookAuthority, programId: some(newProgramId) })
+        .sendTransaction();
 
     // Then we expect the mint to have the updated program ID
-    const mintAccount = await fetchMint(client.rpc, mint);
+    const mintAccount = await fetchMint(client.rpc, mint.address);
     expect(mintAccount).toMatchObject(<Account<Mint>>{
-        address: mint,
+        address: mint.address,
         data: {
             extensions: some([
                 extension('TransferHook', {

--- a/clients/js/test/initializeAccount.test.ts
+++ b/clients/js/test/initializeAccount.test.ts
@@ -9,18 +9,19 @@ import {
     getInitializeAccountInstruction,
     getTokenSize,
 } from '../src';
-import { createTestClient, createMint } from './_setup';
+import { createTestClient } from './_setup';
 
 it('creates and initializes a new token account', async () => {
     // Given a mint account, its mint authority and two generated keypairs
     // for the token to be created and its owner.
     const client = await createTestClient();
-    const [mintAuthority, token, owner] = await Promise.all([
+    const [mintAuthority, token, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
-    const mint = await createMint({ client, payer: client.payer, authority: mintAuthority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
 
     // When we create and initialize a token account at this address.
     const space = BigInt(getTokenSize());
@@ -35,7 +36,7 @@ it('creates and initializes a new token account', async () => {
         }),
         getInitializeAccountInstruction({
             account: token.address,
-            mint,
+            mint: mint.address,
             owner: owner.address,
         }),
     ];
@@ -46,7 +47,7 @@ it('creates and initializes a new token account', async () => {
     expect(tokenAccount).toMatchObject(<Account<Token>>{
         address: token.address,
         data: {
-            mint,
+            mint: mint.address,
             owner: owner.address,
             amount: 0n,
             delegate: none(),

--- a/clients/js/test/mintTo.test.ts
+++ b/clients/js/test/mintTo.test.ts
@@ -1,27 +1,27 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner } from '@solana/kit';
-import { Mint, Token, fetchMint, fetchToken, getMintToInstruction } from '../src';
-import { createTestClient, createMint, createToken } from './_setup';
+import { Mint, Token, fetchMint, fetchToken } from '../src';
+import { createTestClient, createToken } from './_setup';
 
 it('mints tokens to a token account', async () => {
     // Given a mint account and a token account.
     const client = await createTestClient();
-    const [mintAuthority, owner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const mint = await createMint({ client, payer: client.payer, authority: mintAuthority });
-    const token = await createToken({ client, payer: client.payer, mint, owner });
+    const [mintAuthority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
+    const token = await createToken({ client, payer: client.payer, mint: mint.address, owner });
 
     // When the mint authority mints tokens to the token account.
-    const mintTo = getMintToInstruction({
-        mint,
-        token,
-        mintAuthority,
-        amount: 100n,
-    });
-    await client.sendTransaction([mintTo]);
+    await client.token2022.instructions
+        .mintTo({ mint: mint.address, token, mintAuthority, amount: 100n })
+        .sendTransaction();
 
     // Then we expect the mint and token accounts to have the following updated data.
     const [{ data: mintData }, { data: tokenData }] = await Promise.all([
-        fetchMint(client.rpc, mint),
+        fetchMint(client.rpc, mint.address),
         fetchToken(client.rpc, token),
     ]);
     expect(mintData).toMatchObject(<Mint>{ supply: 100n });

--- a/clients/js/test/mintToATA.test.ts
+++ b/clients/js/test/mintToATA.test.ts
@@ -1,0 +1,114 @@
+import { Account, generateKeyPairSigner, none } from '@solana/kit';
+import { expect, it } from 'vitest';
+import { AccountState, TOKEN_2022_PROGRAM_ADDRESS, Token, fetchToken, findAssociatedTokenPda } from '../src';
+import { createTestClient } from './_setup';
+
+it('mints to an associated token account at an explicit address', async () => {
+    // Given a mint account, its mint authority, a token owner and the ATA.
+    const client = await createTestClient();
+    const [mintAuthority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const decimals = 2;
+    await client.token2022.instructions.createMint({ newMint: mint, decimals, mintAuthority }).sendTransaction();
+    const [ata] = await findAssociatedTokenPda({
+        mint: mint.address,
+        owner: owner.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+
+    // When we mint to the explicit ATA.
+    await client.token2022.instructions
+        .mintToATA({ ata, mint: mint.address, owner: owner.address, mintAuthority, amount: 1_000n, decimals })
+        .sendTransaction();
+
+    // Then we expect the token account to exist and have the following data.
+    expect(await fetchToken(client.rpc, ata)).toMatchObject(<Account<Token>>{
+        address: ata,
+        data: {
+            mint: mint.address,
+            owner: owner.address,
+            amount: 1000n,
+            delegate: none(),
+            state: AccountState.Initialized,
+            isNative: none(),
+            delegatedAmount: 0n,
+            closeAuthority: none(),
+        },
+    });
+});
+
+it('mints to an associated token account that it auto-derives', async () => {
+    // Given a mint account, its mint authority and a token owner.
+    const client = await createTestClient();
+    const [mintAuthority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const decimals = 2;
+    await client.token2022.instructions.createMint({ newMint: mint, decimals, mintAuthority }).sendTransaction();
+
+    // When we mint to the owner, with the ATA auto-derived.
+    await client.token2022.instructions
+        .mintToATA({ mint: mint.address, owner: owner.address, mintAuthority, amount: 1_000n, decimals })
+        .sendTransaction();
+
+    // Then we expect the derived ATA to exist and have the following data.
+    const [ata] = await findAssociatedTokenPda({
+        mint: mint.address,
+        owner: owner.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+    expect(await fetchToken(client.rpc, ata)).toMatchObject(<Account<Token>>{
+        address: ata,
+        data: {
+            mint: mint.address,
+            owner: owner.address,
+            amount: 1000n,
+        },
+    });
+});
+
+it('also mints to an existing associated token account', async () => {
+    // Given a mint account, its mint authority, a token owner and the ATA.
+    const client = await createTestClient();
+    const [mintAuthority, owner, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const decimals = 2;
+    await client.token2022.instructions.createMint({ newMint: mint, decimals, mintAuthority }).sendTransaction();
+    const [ata] = await findAssociatedTokenPda({
+        mint: mint.address,
+        owner: owner.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+
+    // When we mint to the ATA a first time.
+    await client.token2022.instructions
+        .mintToATA({ ata, mint: mint.address, owner: owner.address, mintAuthority, amount: 1_000n, decimals })
+        .sendTransaction();
+
+    // Expire the blockhash so the next (otherwise identical) transaction has a
+    // distinct signature in LiteSVM, which has no passage of time of its own.
+    client.svm.expireBlockhash();
+
+    // And then we mint additional tokens to the same account.
+    await client.token2022.instructions
+        .mintToATA({ ata, mint: mint.address, owner: owner.address, mintAuthority, amount: 1_000n, decimals })
+        .sendTransaction();
+
+    // Then we expect the token account to have the accumulated amount.
+    expect(await fetchToken(client.rpc, ata)).toMatchObject(<Account<Token>>{
+        address: ata,
+        data: {
+            mint: mint.address,
+            owner: owner.address,
+            amount: 2000n,
+        },
+    });
+});

--- a/clients/js/test/transfer.test.ts
+++ b/clients/js/test/transfer.test.ts
@@ -1,42 +1,39 @@
 import { expect, it } from 'vitest';
 import { generateKeyPairSigner } from '@solana/kit';
-import { Mint, Token, fetchMint, fetchToken, getTransferInstruction } from '../src';
-import { createTestClient, createMint, createToken, createTokenWithAmount } from './_setup';
+import { Mint, Token, fetchMint, fetchToken } from '../src';
+import { createTestClient, createToken, createTokenWithAmount } from './_setup';
 
 it('transfers tokens from one account to another', async () => {
     // Given a mint account and two token accounts.
     // One with 100 tokens and the other with 0 tokens.
     const client = await createTestClient();
-    const [mintAuthority, ownerA, ownerB] = await Promise.all([
+    const [mintAuthority, ownerA, ownerB, mint] = await Promise.all([
+        generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
         generateKeyPairSigner(),
     ]);
-    const mint = await createMint({ client, payer: client.payer, authority: mintAuthority });
+    await client.token2022.instructions.createMint({ newMint: mint, mintAuthority }).sendTransaction();
     const [tokenA, tokenB] = await Promise.all([
         createTokenWithAmount({
             client,
             payer: client.payer,
             mintAuthority,
-            mint,
+            mint: mint.address,
             owner: ownerA,
             amount: 100n,
         }),
-        createToken({ client, payer: client.payer, mint, owner: ownerB }),
+        createToken({ client, payer: client.payer, mint: mint.address, owner: ownerB }),
     ]);
 
     // When owner A transfers 50 tokens to owner B.
-    const transfer = getTransferInstruction({
-        source: tokenA,
-        destination: tokenB,
-        authority: ownerA,
-        amount: 50n,
-    });
-    await client.sendTransaction([transfer]);
+    await client.token2022.instructions
+        .transfer({ source: tokenA, destination: tokenB, authority: ownerA, amount: 50n })
+        .sendTransaction();
 
     // Then we expect the mint and token accounts to have the following updated data.
     const [{ data: mintData }, { data: tokenDataA }, { data: tokenDataB }] = await Promise.all([
-        fetchMint(client.rpc, mint),
+        fetchMint(client.rpc, mint.address),
         fetchToken(client.rpc, tokenA),
         fetchToken(client.rpc, tokenB),
     ]);

--- a/clients/js/test/transferToATA.test.ts
+++ b/clients/js/test/transferToATA.test.ts
@@ -1,0 +1,142 @@
+import { generateKeyPairSigner } from '@solana/kit';
+import { expect, it } from 'vitest';
+import { Mint, TOKEN_2022_PROGRAM_ADDRESS, Token, fetchMint, fetchToken, findAssociatedTokenPda } from '../src';
+import { createTestClient, createTokenPdaWithAmount, createTokenWithAmount } from './_setup';
+
+it('transfers tokens from an explicit source to an explicit destination ATA', async () => {
+    // Given a mint account, one token account with 100 tokens, and a second owner.
+    const client = await createTestClient();
+    const [mintAuthority, ownerA, ownerB, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const decimals = 2;
+    await client.token2022.instructions.createMint({ newMint: mint, decimals, mintAuthority }).sendTransaction();
+    const tokenA = await createTokenWithAmount({
+        client,
+        payer: client.payer,
+        mint: mint.address,
+        owner: ownerA,
+        mintAuthority,
+        amount: 100n,
+    });
+    const [tokenB] = await findAssociatedTokenPda({
+        owner: ownerB.address,
+        mint: mint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+
+    // When owner A transfers 50 tokens to owner B.
+    await client.token2022.instructions
+        .transferToATA({
+            mint: mint.address,
+            source: tokenA,
+            authority: ownerA,
+            destination: tokenB,
+            recipient: ownerB.address,
+            amount: 50n,
+            decimals,
+        })
+        .sendTransaction();
+
+    // Then we expect the mint and token accounts to have the following updated data.
+    const [{ data: mintData }, { data: tokenDataA }, { data: tokenDataB }] = await Promise.all([
+        fetchMint(client.rpc, mint.address),
+        fetchToken(client.rpc, tokenA),
+        fetchToken(client.rpc, tokenB),
+    ]);
+    expect(mintData).toMatchObject(<Mint>{ supply: 100n });
+    expect(tokenDataA).toMatchObject(<Token>{ amount: 50n });
+    expect(tokenDataB).toMatchObject(<Token>{ amount: 50n });
+});
+
+it('derives a new destination ATA and transfers tokens to it', async () => {
+    // Given a mint account, one token account with 100 tokens, and a second owner.
+    const client = await createTestClient();
+    const [mintAuthority, ownerA, ownerB, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const decimals = 2;
+    await client.token2022.instructions.createMint({ newMint: mint, decimals, mintAuthority }).sendTransaction();
+    const tokenA = await createTokenWithAmount({
+        client,
+        payer: client.payer,
+        mint: mint.address,
+        owner: ownerA,
+        mintAuthority,
+        amount: 100n,
+    });
+
+    // When owner A transfers 50 tokens to owner B, with the destination derived.
+    await client.token2022.instructions
+        .transferToATA({
+            mint: mint.address,
+            source: tokenA,
+            authority: ownerA,
+            recipient: ownerB.address,
+            amount: 50n,
+            decimals,
+        })
+        .sendTransaction();
+
+    // Then we expect the mint and token accounts to have the following updated data.
+    const [tokenB] = await findAssociatedTokenPda({
+        owner: ownerB.address,
+        mint: mint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+    const [{ data: mintData }, { data: tokenDataA }, { data: tokenDataB }] = await Promise.all([
+        fetchMint(client.rpc, mint.address),
+        fetchToken(client.rpc, tokenA),
+        fetchToken(client.rpc, tokenB),
+    ]);
+    expect(mintData).toMatchObject(<Mint>{ supply: 100n });
+    expect(tokenDataA).toMatchObject(<Token>{ amount: 50n });
+    expect(tokenDataB).toMatchObject(<Token>{ amount: 50n });
+});
+
+it('derives both source and destination ATAs and transfers tokens', async () => {
+    // Given a mint account and ownerA's ATA with 100 tokens.
+    const client = await createTestClient();
+    const [mintAuthority, ownerA, ownerB, mint] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const decimals = 2;
+    await client.token2022.instructions.createMint({ newMint: mint, decimals, mintAuthority }).sendTransaction();
+    const tokenA = await createTokenPdaWithAmount({
+        client,
+        mint: mint.address,
+        mintAuthority,
+        owner: ownerA.address,
+        amount: 100n,
+        decimals,
+    });
+
+    // When owner A transfers 50 tokens to owner B without specifying source or destination.
+    await client.token2022.instructions
+        .transferToATA({ mint: mint.address, authority: ownerA, recipient: ownerB.address, amount: 50n, decimals })
+        .sendTransaction();
+
+    // Then we expect both ATAs to have the correct balances.
+    const [tokenB] = await findAssociatedTokenPda({
+        owner: ownerB.address,
+        mint: mint.address,
+        tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+    });
+    const [{ data: mintData }, { data: tokenDataA }, { data: tokenDataB }] = await Promise.all([
+        fetchMint(client.rpc, mint.address),
+        fetchToken(client.rpc, tokenA),
+        fetchToken(client.rpc, tokenB),
+    ]);
+    expect(mintData).toMatchObject(<Mint>{ supply: 100n });
+    expect(tokenDataA).toMatchObject(<Token>{ amount: 50n });
+    expect(tokenDataB).toMatchObject(<Token>{ amount: 50n });
+});

--- a/clients/js/test/withdrawExcess.test.ts
+++ b/clients/js/test/withdrawExcess.test.ts
@@ -5,10 +5,8 @@ import {
     fetchToken,
     findAssociatedTokenPda,
     getCreateAssociatedTokenInstructionAsync,
-    getMintToInstruction,
-    getWithdrawExcessLamportsInstruction,
 } from '../src';
-import { createTestClient, createMint, createToken, generateKeyPairSignerWithSol } from './_setup';
+import { createTestClient, createToken, generateKeyPairSignerWithSol } from './_setup';
 import { getTransferSolInstruction } from '@solana-program/system';
 import { generateKeyPairSigner } from '@solana/kit';
 
@@ -23,33 +21,27 @@ it('withdraws excess lamports from an associated token account', async () => {
     ]);
 
     // And a mint and token are created
-    const mint = await createMint({
-        client,
-        payer,
-        authority: mintAuthority,
-        decimals: 9,
-    });
-    const token = await createToken({ client, payer, mint, owner });
+    const mint = await generateKeyPairSigner();
+    await client.token2022.instructions
+        .createMint({ payer, newMint: mint, mintAuthority, decimals: 9 })
+        .sendTransaction();
+    const token = await createToken({ client, payer, mint: mint.address, owner });
 
     // And tokens are minted to the token account
-    const mintToInstruction = getMintToInstruction({
-        mint,
-        token,
-        mintAuthority,
-        amount: 100_000n,
-    });
-    await client.sendTransaction([mintToInstruction]);
+    await client.token2022.instructions
+        .mintTo({ mint: mint.address, token, mintAuthority, amount: 100_000n })
+        .sendTransaction();
 
     // And an associated token account (ATA) is created for the owner
     const createAtaInstruction = await getCreateAssociatedTokenInstructionAsync({
         payer,
-        mint,
+        mint: mint.address,
         owner: owner.address,
     });
     await client.sendTransaction([createAtaInstruction]);
 
     const [ata] = await findAssociatedTokenPda({
-        mint,
+        mint: mint.address,
         owner: owner.address,
         tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     });
@@ -71,12 +63,9 @@ it('withdraws excess lamports from an associated token account', async () => {
     const ataLamportsBefore = await client.rpc.getBalance(ata).send();
 
     // And we initiate withdrawal of excess lamports from the ATA to the destination
-    const withdrawInstruction = await getWithdrawExcessLamportsInstruction({
-        source: ata,
-        destination: destination.address,
-        authority: owner,
-    });
-    await client.sendTransaction([withdrawInstruction]);
+    await client.token2022.instructions
+        .withdrawExcessLamports({ source: ata, destination: destination.address, authority: owner })
+        .sendTransaction();
 
     // Then: Verify that lamports were successfully withdrawn to the destination
     const lamportsAfter = await client.rpc.getBalance(destination.address).send();


### PR DESCRIPTION
This PR adds a Kit-plugin client to the token-2022 JS package, to align with the token repo and the other repos in the solana-program org. It introduces a token2022Program() plugin that augments the generated program with extension-aware createMint and createToken helpers (which build the full create-account, extension-initialize and account-initialize instruction plan from an extensions array), along with mintToATA and transferToATA helpers. The test suite is updated to install the plugin and exercise instructions through the client (client.token2022.instructions.X().sendTransaction()), and dedicated tests are added for the new helpers.