### PR TITLE
[token-cli] Add support for confidential mint burn extension (Initialize, Mint, Burn, ApplyPendingBurn)

### DIFF
--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -32,7 +32,6 @@ solana-sdk = "3.0.0"
 solana-system-interface = "3.2.0"
 solana-zk-elgamal-proof-interface = "0.1.3"
 solana-zk-sdk = "7.0.1"
-solana-zk-elgamal-proof-interface = "0.1.3"
 solana-zk-sdk-pod = "0.1.2"
 spl-associated-token-account-interface = { version = "2.0.0" }
 spl-memo-interface = "2.1.0"

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -30,6 +30,7 @@ solana-logger = "3.0.0"
 solana-remote-wallet = { version = "3.1.0", features = ["agave-unstable-api"] }
 solana-sdk = "3.0.0"
 solana-system-interface = "3.2.0"
+solana-zk-elgamal-proof-interface = "0.1.3"
 solana-zk-sdk = "7.0.1"
 solana-zk-elgamal-proof-interface = "0.1.3"
 solana-zk-sdk-pod = "0.1.2"

--- a/clients/cli/src/bench.rs
+++ b/clients/cli/src/bench.rs
@@ -247,7 +247,7 @@ async fn command_deposit_into_or_withdraw_from(
     println!("Scanning accounts...");
     let program_id = get_valid_mint_program_id(rpc_client, token).await?;
 
-    let mint_info = config.get_mint_info(token, None).await?;
+    let mint_info = config.get_mint_info(token, None, None).await?;
     let from_or_to = from_or_to
         .unwrap_or_else(|| get_associated_token_address_with_program_id(owner, token, &program_id));
     config.check_account(&from_or_to, Some(*token)).await?;

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -167,6 +167,7 @@ pub enum CommandName {
     DepositConfidentialTokens,
     WithdrawConfidentialTokens,
     ApplyPendingBalance,
+    ApplyPendingBurn,
     UpdateGroupAddress,
     UpdateMemberAddress,
     UpdateUiAmountMultiplier,
@@ -943,6 +944,16 @@ pub fn app<'a>(
                         .conflicts_with("enable_permissioned_burn")
                         .help("Specify a permissioned burn authority for the mint. Defaults to the mint authority.")
                 )
+                .arg(
+                    Arg::with_name("enable_confidential_mint_burn")
+                        .long("enable-confidential-mint-burn")
+                        .takes_value(false)
+                        .requires("enable_confidential_transfers")
+                        .help(
+                            "Enable the confidential mint and burn extension. \
+                            Requires confidential transfers to be enabled."
+                        ),
+                )
                 .arg(multisig_signer_arg())
                 .nonce_args(true)
                 .arg(memo_arg())
@@ -1552,6 +1563,12 @@ pub fn app<'a>(
                              This may be a keypair file or the ASK keyword."
                         ),
                 )
+                .arg(
+                    Arg::with_name("confidential")
+                    .long("confidential")
+                    .takes_value(false)
+                    .help("Burn tokens confidentially."),
+                )
                 .arg(multisig_signer_arg())
                 .mint_args()
                 .nonce_args(true)
@@ -1610,6 +1627,12 @@ pub fn app<'a>(
                              This may be a keypair file or the ASK keyword. \
                              Defaults to the client keypair."
                         ),
+                )
+                .arg(
+                    Arg::with_name("confidential")
+                        .long("confidential")
+                        .takes_value(false)
+                        .help("Mint tokens confidentially."),
                 )
                 .arg(mint_decimals_arg())
                 .arg(multisig_signer_arg())
@@ -2801,6 +2824,29 @@ pub fn app<'a>(
                 )
                 .arg(
                     owner_address_arg()
+                )
+                .arg(multisig_signer_arg())
+                .nonce_args(true)
+        )
+        .subcommand(
+            SubCommand::with_name(CommandName::ApplyPendingBurn.into())
+                .about("Apply pending burn amount to the confidential supply")
+                .arg(
+                    Arg::with_name("token")
+                        .validator(|s| is_valid_pubkey(s))
+                        .value_name("TOKEN_MINT_ADDRESS")
+                        .takes_value(true)
+                        .index(1)
+                        .required(true)
+                        .help("The token mint address"),
+                )
+                .arg(
+                    owner_keypair_arg_with_value_name("MINT_AUTHORITY_KEYPAIR")
+                        .help(
+                            "Specify the mint authority keypair. \
+                            This may be a keypair file or the ASK keyword. \
+                            Defaults to the client keypair."
+                        )
                 )
                 .arg(multisig_signer_arg())
                 .nonce_args(true)

--- a/clients/cli/src/clap_app.rs
+++ b/clients/cli/src/clap_app.rs
@@ -1567,7 +1567,8 @@ pub fn app<'a>(
                     Arg::with_name("confidential")
                     .long("confidential")
                     .takes_value(false)
-                    .help("Burn tokens confidentially."),
+                    .help("Burn tokens confidentially. Required for \
+                            offline signing on confidential mints."),
                 )
                 .arg(multisig_signer_arg())
                 .mint_args()
@@ -1632,7 +1633,8 @@ pub fn app<'a>(
                     Arg::with_name("confidential")
                         .long("confidential")
                         .takes_value(false)
-                        .help("Mint tokens confidentially."),
+                        .help("Mint tokens confidentially. Required for \
+                            offline signing on confidential mints."),
                 )
                 .arg(mint_decimals_arg())
                 .arg(multisig_signer_arg())

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -1313,7 +1313,9 @@ async fn command_transfer(
     transfer_hook_accounts: Option<Vec<AccountMeta>>,
     confidential_transfer_args: Option<&ConfidentialTransferArgs>,
 ) -> CommandResult {
-    let mint_info = config.get_mint_info(&token_pubkey, mint_decimals).await?;
+    let mint_info = config
+        .get_mint_info(&token_pubkey, mint_decimals, None)
+        .await?;
 
     // if the user got the decimals wrong, they may well have calculated the
     // transfer amount wrong we only check in online mode, because in offline,
@@ -2084,7 +2086,9 @@ async fn command_burn(
     confidential: bool,
 ) -> CommandResult {
     let mint_address = config.check_account(&account, mint_address).await?;
-    let mint_info = config.get_mint_info(&mint_address, mint_decimals).await?;
+    let mint_info = config
+        .get_mint_info(&mint_address, mint_decimals, Some(confidential))
+        .await?;
     let decimals = if use_unchecked_instruction {
         None
     } else {
@@ -2094,13 +2098,6 @@ async fn command_burn(
     let token = token_client_from_config(config, &mint_info.address, decimals)?;
 
     let use_confidential = confidential || mint_info.has_confidential_mint_burn;
-
-    if use_confidential && config.sign_only && !confidential {
-        return Err("Confidential mints require the --confidential \
-            flag for offline signing"
-            .to_string()
-            .into());
-    }
 
     let confidential_burn_args = if use_confidential {
         Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
@@ -2368,14 +2365,6 @@ async fn command_mint(
     );
 
     let use_confidential = confidential || mint_info.has_confidential_mint_burn;
-
-    if use_confidential && config.sign_only && !confidential {
-        return Err("Confidential mints require the --confidential \
-            flag for offline signing"
-            .to_string()
-            .into());
-    }
-
     let confidential_mint_args = if use_confidential {
         Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
     } else {
@@ -2583,7 +2572,7 @@ async fn command_freeze(
     bulk_signers: BulkSigners,
 ) -> CommandResult {
     let mint_address = config.check_account(&account, mint_address).await?;
-    let mint_info = config.get_mint_info(&mint_address, None).await?;
+    let mint_info = config.get_mint_info(&mint_address, None, None).await?;
 
     println_display(
         config,
@@ -2619,7 +2608,7 @@ async fn command_thaw(
     bulk_signers: BulkSigners,
 ) -> CommandResult {
     let mint_address = config.check_account(&account, mint_address).await?;
-    let mint_info = config.get_mint_info(&mint_address, None).await?;
+    let mint_info = config.get_mint_info(&mint_address, None, None).await?;
 
     println_display(
         config,
@@ -2888,7 +2877,9 @@ async fn command_approve(
     bulk_signers: BulkSigners,
 ) -> CommandResult {
     let mint_address = config.check_account(&account, mint_address).await?;
-    let mint_info = config.get_mint_info(&mint_address, mint_decimals).await?;
+    let mint_info = config
+        .get_mint_info(&mint_address, mint_decimals, None)
+        .await?;
     let amount = amount_to_raw_amount(ui_amount, mint_info.decimals, None, "TOKEN_AMOUNT");
     let decimals = if use_unchecked_instruction {
         None
@@ -3115,7 +3106,7 @@ async fn command_accounts(
     print_addresses_only: bool,
 ) -> CommandResult {
     let filters = if let Some(token_pubkey) = maybe_token {
-        let _ = config.get_mint_info(&token_pubkey, None).await?;
+        let _ = config.get_mint_info(&token_pubkey, None, None).await?;
         vec![TokenAccountsFilter::Mint(token_pubkey)]
     } else if config.restrict_to_program_id {
         vec![TokenAccountsFilter::ProgramId(config.program_id)]
@@ -3163,7 +3154,7 @@ async fn command_address(
         ..CliWalletAddress::default()
     };
     if let Some(token) = token {
-        config.get_mint_info(&token, None).await?;
+        config.get_mint_info(&token, None, None).await?;
         let associated_token_address =
             get_associated_token_address_with_program_id(&owner, &token, &config.program_id);
         cli_address.associated_token_address = Some(associated_token_address.to_string());
@@ -4117,7 +4108,9 @@ async fn command_deposit_withdraw_confidential_tokens(
     }
 
     // check if mint decimals provided is consistent
-    let mint_info = config.get_mint_info(&token_pubkey, mint_decimals).await?;
+    let mint_info = config
+        .get_mint_info(&token_pubkey, mint_decimals, None)
+        .await?;
 
     if let Some(decimals) = mint_decimals {
         if !config.sign_only && decimals != mint_info.decimals {
@@ -4994,7 +4987,10 @@ pub async fn process_command(
                 .unwrap();
             let amount = *arg_matches.get_one::<Amount>("amount").unwrap();
             let mint_decimals = arg_matches.get_one::<u8>(MINT_DECIMALS_ARG.name).copied();
-            let mint_info = config.get_mint_info(&token, mint_decimals).await?;
+            let confidential = arg_matches.is_present("confidential");
+            let mint_info = config
+                .get_mint_info(&token, mint_decimals, Some(confidential))
+                .await?;
             let recipient = if let Some(address) =
                 pubkey_of_signer(arg_matches, "recipient", &mut wallet_manager).unwrap()
             {
@@ -5014,7 +5010,6 @@ pub async fn process_command(
             config.check_account(&recipient, Some(token)).await?;
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let memo = value_t!(arg_matches, "memo", String).ok();
-            let confidential = arg_matches.is_present("confidential");
             command_mint(
                 config,
                 token,

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -79,8 +79,8 @@ use {
         },
     },
     spl_token_confidential_transfer_proof_generation::{
-        transfer::TransferProofData, transfer_with_fee::TransferWithFeeProofData,
-        withdraw::WithdrawProofData, burn::BurnProofData, mint::MintProofData,
+        burn::BurnProofData, mint::MintProofData, transfer::TransferProofData,
+        transfer_with_fee::TransferWithFeeProofData, withdraw::WithdrawProofData,
     },
     spl_token_group_interface::state::TokenGroup,
     spl_token_metadata_interface::state::{Field, TokenMetadata},

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -2081,7 +2081,7 @@ async fn command_burn(
     permissioned_burn_authority: Option<Pubkey>,
     memo: Option<String>,
     bulk_signers: BulkSigners,
-    confidential_burn_args: Option<(ElGamalKeypair, AeKey)>,
+    confidential: bool,
 ) -> CommandResult {
     let mint_address = config.check_account(&account, mint_address).await?;
     let mint_info = config.get_mint_info(&mint_address, mint_decimals).await?;
@@ -2092,6 +2092,21 @@ async fn command_burn(
     };
 
     let token = token_client_from_config(config, &mint_info.address, decimals)?;
+
+    let use_confidential = confidential || mint_info.has_confidential_mint_burn;
+
+    if use_confidential && config.sign_only && !confidential {
+        return Err("Confidential mints require the --confidential \
+            flag for offline signing"
+            .to_string()
+            .into());
+    }
+
+    let confidential_burn_args = if use_confidential {
+        Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
+    } else {
+        None
+    };
 
     let amount = match ui_amount {
         Amount::Raw(ui_amount) => ui_amount,
@@ -2194,6 +2209,10 @@ async fn command_burn(
             &[&ciphertext_validity_proof_context_state_account];
         let create_range_proof_context_signer = &[&range_proof_context_state_account];
 
+        // Upload range proof via record account
+        let range_proof_record_account = Keypair::new();
+        let range_proof_record_pubkey = range_proof_record_account.pubkey();
+
         let _ = try_join!(
             token.confidential_transfer_create_context_state_account(
                 &equality_proof_pubkey,
@@ -2208,29 +2227,27 @@ async fn command_burn(
                 &ciphertext_validity_proof_data_with_ciphertext.proof_data,
                 false,
                 create_ciphertext_validity_proof_context_signer
-            )
+            ),
+            // Range proof too large, so we must explicitly send them in chunks
+            async {
+                token
+                    .confidential_transfer_create_record_account(
+                        &range_proof_record_pubkey,
+                        &context_state_authority_pubkey,
+                        &range_proof_data,
+                        &range_proof_record_account,
+                        &context_state_authority,
+                    )
+                    .await?;
+
+                token.confidential_transfer_create_context_state_account_from_record::<_, BatchedRangeProofU128Data, BatchedRangeProofContext>(
+                    &range_proof_pubkey,
+                    &context_state_authority_pubkey,
+                    &range_proof_record_pubkey,
+                    create_range_proof_context_signer,
+                ).await
+            }
         )?;
-
-        // Upload range proof via record account
-        let range_proof_record_account = Keypair::new();
-        let range_proof_record_pubkey = range_proof_record_account.pubkey();
-
-        token
-            .confidential_transfer_create_record_account(
-                &range_proof_record_pubkey,
-                &context_state_authority_pubkey,
-                &range_proof_data,
-                &range_proof_record_account,
-                &context_state_authority,
-            )
-            .await?;
-
-        token.confidential_transfer_create_context_state_account_from_record::<_, BatchedRangeProofU128Data, BatchedRangeProofContext>(
-            &range_proof_pubkey,
-            &context_state_authority_pubkey,
-            &range_proof_record_pubkey,
-            create_range_proof_context_signer,
-        ).await?;
 
         let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
             context_state_account: ciphertext_validity_proof_pubkey,
@@ -2306,14 +2323,12 @@ async fn command_burn(
         )?;
 
         burn_result?
+    } else if let Some(authority) = permissioned_burn_authority {
+        token
+            .permissioned_burn(&account, &authority, &owner, amount, &bulk_signers)
+            .await?
     } else {
-        if let Some(authority) = permissioned_burn_authority {
-            token
-                .permissioned_burn(&account, &authority, &owner, amount, &bulk_signers)
-                .await?
-        } else {
-            token.burn(&account, &owner, amount, &bulk_signers).await?
-        }
+        token.burn(&account, &owner, amount, &bulk_signers).await?
     };
 
     let tx_return = finish_tx(config, &res, false).await?;
@@ -2338,7 +2353,7 @@ async fn command_mint(
     use_unchecked_instruction: bool,
     memo: Option<String>,
     bulk_signers: BulkSigners,
-    confidential_mint_args: Option<(ElGamalKeypair, AeKey)>,
+    confidential: bool,
 ) -> CommandResult {
     let amount = amount_to_raw_amount(ui_amount, mint_info.decimals, None, "TOKEN_AMOUNT");
 
@@ -2351,6 +2366,21 @@ async fn command_mint(
             recipient
         ),
     );
+
+    let use_confidential = confidential || mint_info.has_confidential_mint_burn;
+
+    if use_confidential && config.sign_only && !confidential {
+        return Err("Confidential mints require the --confidential \
+            flag for offline signing"
+            .to_string()
+            .into());
+    }
+
+    let confidential_mint_args = if use_confidential {
+        Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
+    } else {
+        None
+    };
 
     let res = if let Some((supply_elgamal_keypair, supply_aes_key)) = confidential_mint_args {
         // Fetch mint info to get auditor pubkey and supply extension
@@ -2421,6 +2451,10 @@ async fn command_mint(
             &[&ciphertext_validity_proof_context_state_account];
         let create_range_proof_context_signer = &[&range_proof_context_state_account];
 
+        // Upload range proof via record account
+        let range_proof_record_account = Keypair::new();
+        let range_proof_record_pubkey = range_proof_record_account.pubkey();
+
         let token = token_client_from_config(config, &mint_info.address, None)?;
 
         let _ = try_join!(
@@ -2437,29 +2471,27 @@ async fn command_mint(
                 &ciphertext_validity_proof_data_with_ciphertext.proof_data,
                 false,
                 create_ciphertext_validity_proof_context_signer
-            )
+            ),
+            // Range proof too large, so we must explicitly send them in chunks
+            async {
+                token
+                    .confidential_transfer_create_record_account(
+                        &range_proof_record_pubkey,
+                        &context_state_authority_pubkey,
+                        &range_proof_data,
+                        &range_proof_record_account,
+                        &context_state_authority,
+                    )
+                    .await?;
+
+                token.confidential_transfer_create_context_state_account_from_record::<_, BatchedRangeProofU128Data, BatchedRangeProofContext>(
+                    &range_proof_pubkey,
+                    &context_state_authority_pubkey,
+                    &range_proof_record_pubkey,
+                    create_range_proof_context_signer,
+                ).await
+            }
         )?;
-
-        // Upload range proof via record account
-        let range_proof_record_account = Keypair::new();
-        let range_proof_record_pubkey = range_proof_record_account.pubkey();
-
-        token
-            .confidential_transfer_create_record_account(
-                &range_proof_record_pubkey,
-                &context_state_authority_pubkey,
-                &range_proof_data,
-                &range_proof_record_account,
-                &context_state_authority,
-            )
-            .await?;
-
-        token.confidential_transfer_create_context_state_account_from_record::<_, BatchedRangeProofU128Data, BatchedRangeProofContext>(
-            &range_proof_pubkey,
-            &context_state_authority_pubkey,
-            &range_proof_record_pubkey,
-            create_range_proof_context_signer,
-        ).await?;
 
         let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
             context_state_account: ciphertext_validity_proof_pubkey,
@@ -4935,11 +4967,6 @@ pub async fn process_command(
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let memo = value_t!(arg_matches, "memo", String).ok();
             let confidential = arg_matches.is_present("confidential");
-            let confidential_burn_args = if confidential {
-                Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
-            } else {
-                None
-            };
             command_burn(
                 config,
                 account,
@@ -4951,7 +4978,7 @@ pub async fn process_command(
                 permissioned_burn_authority,
                 memo,
                 bulk_signers,
-                confidential_burn_args,
+                confidential,
             )
             .await
         }
@@ -4988,11 +5015,6 @@ pub async fn process_command(
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let memo = value_t!(arg_matches, "memo", String).ok();
             let confidential = arg_matches.is_present("confidential");
-            let confidential_mint_args = if confidential {
-                Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
-            } else {
-                None
-            };
             command_mint(
                 config,
                 token,
@@ -5003,7 +5025,7 @@ pub async fn process_command(
                 use_unchecked_instruction,
                 memo,
                 bulk_signers,
-                confidential_mint_args,
+                confidential,
             )
             .await
         }

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -45,6 +45,7 @@ use {
     spl_associated_token_account_interface::address::get_associated_token_address_with_program_id,
     spl_token_2022_interface::{
         extension::{
+            confidential_mint_burn::ConfidentialMintBurn,
             confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
             confidential_transfer_fee::ConfidentialTransferFeeConfig,
             cpi_guard::CpiGuard,
@@ -70,13 +71,16 @@ use {
         token::{
             ComputeUnitLimit, ExtensionInitializationParams, ProofAccountWithCiphertext, Token,
         },
-        zk_proofs::confidential_transfer::{
-            ApplyPendingBalanceAccountInfo, TransferAccountInfo, WithdrawAccountInfo,
+        zk_proofs::{
+            confidential_mint_burn::{BurnAccountInfo, SupplyAccountInfo},
+            confidential_transfer::{
+                ApplyPendingBalanceAccountInfo, TransferAccountInfo, WithdrawAccountInfo,
+            },
         },
     },
     spl_token_confidential_transfer_proof_generation::{
         transfer::TransferProofData, transfer_with_fee::TransferWithFeeProofData,
-        withdraw::WithdrawProofData,
+        withdraw::WithdrawProofData, burn::BurnProofData, mint::MintProofData,
     },
     spl_token_group_interface::state::TokenGroup,
     spl_token_metadata_interface::state::{Field, TokenMetadata},
@@ -266,6 +270,7 @@ async fn command_create_token(
     default_account_state: Option<AccountState>,
     transfer_fee: Option<(u16, u64)>,
     confidential_transfer_auto_approve: Option<bool>,
+    enable_confidential_mint_burn: bool,
     transfer_hook_program_id: Option<Pubkey>,
     enable_metadata: bool,
     enable_group: bool,
@@ -328,6 +333,18 @@ async fn command_create_token(
             withdraw_withheld_authority: Some(authority),
             transfer_fee_basis_points,
             maximum_fee,
+        });
+    }
+
+    if enable_confidential_mint_burn {
+        let (supply_elgamal_keypair, supply_aes_key) =
+            derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap();
+        // encrypt the initial 0 supply
+        let decryptable_supply = supply_aes_key.encrypt(0).into();
+
+        extensions.push(ExtensionInitializationParams::ConfidentialMintBurn {
+            supply_elgamal_pubkey: (*supply_elgamal_keypair.pubkey()).into(),
+            decryptable_supply,
         });
     }
 
@@ -2064,6 +2081,7 @@ async fn command_burn(
     permissioned_burn_authority: Option<Pubkey>,
     memo: Option<String>,
     bulk_signers: BulkSigners,
+    confidential_burn_args: Option<(ElGamalKeypair, AeKey)>,
 ) -> CommandResult {
     let mint_address = config.check_account(&account, mint_address).await?;
     let mint_info = config.get_mint_info(&mint_address, mint_decimals).await?;
@@ -2103,12 +2121,199 @@ async fn command_burn(
         token.with_memo(text, vec![config.default_signer()?.pubkey()]);
     }
 
-    let res = if let Some(authority) = permissioned_burn_authority {
+    let res = if let Some((source_elgamal_keypair, source_aes_key)) = confidential_burn_args {
+        // Fetch mint info to get auditor and supply pubkeys
+        let mint_account = config.get_account_checked(&mint_info.address).await?;
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(mint_account.data)
+            .map_err(|_| format!("Could not deserialize token mint {}", mint_info.address))?;
+
+        let auditor_elgamal_pubkey = mint_state
+            .get_extension::<ConfidentialTransferMint>()
+            .ok()
+            .and_then(|ext| Option::<PodElGamalPubkey>::from(ext.auditor_elgamal_pubkey))
+            .map(|pod| {
+                let pubkey: elgamal::ElGamalPubkey =
+                    pod.try_into().expect("Invalid auditor ElGamal pubkey");
+                pubkey
+            });
+
+        let supply_elgamal_pubkey: elgamal::ElGamalPubkey = mint_state
+            .get_extension::<ConfidentialMintBurn>()
+            .unwrap()
+            .supply_elgamal_pubkey
+            .try_into()
+            .expect("Invalid supply ElGamal pubkey");
+
+        // Fetch source account to setup burn info
+        let source_account_data = config.get_account_checked(&account).await?;
+        let source_state =
+            StateWithExtensionsOwned::<Account>::unpack(source_account_data.data).unwrap();
+        let burn_account_info = BurnAccountInfo::new(
+            source_state
+                .get_extension::<ConfidentialTransferAccount>()
+                .unwrap(),
+        );
+
+        // Generate split proofs
+        let BurnProofData {
+            equality_proof_data,
+            ciphertext_validity_proof_data_with_ciphertext,
+            range_proof_data,
+        } = burn_account_info
+            .generate_split_burn_proof_data(
+                amount,
+                &source_elgamal_keypair,
+                &source_aes_key,
+                &supply_elgamal_pubkey,
+                auditor_elgamal_pubkey.as_ref(),
+            )
+            .unwrap();
+
+        let burn_amount_auditor_ciphertext_lo =
+            ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo;
+        let burn_amount_auditor_ciphertext_hi =
+            ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi;
+
+        // Setup context state accounts
+        let context_state_authority = config.fee_payer()?;
+        let context_state_authority_pubkey = context_state_authority.pubkey();
+        let payer_pubkey = config.fee_payer()?.pubkey();
+
+        let equality_proof_context_state_account = Keypair::new();
+        let equality_proof_pubkey = equality_proof_context_state_account.pubkey();
+
+        let ciphertext_validity_proof_context_state_account = Keypair::new();
+        let ciphertext_validity_proof_pubkey =
+            ciphertext_validity_proof_context_state_account.pubkey();
+
+        let range_proof_context_state_account = Keypair::new();
+        let range_proof_pubkey = range_proof_context_state_account.pubkey();
+
+        let create_equality_proof_context_signer = &[&equality_proof_context_state_account];
+        let create_ciphertext_validity_proof_context_signer =
+            &[&ciphertext_validity_proof_context_state_account];
+        let create_range_proof_context_signer = &[&range_proof_context_state_account];
+
+        let _ = try_join!(
+            token.confidential_transfer_create_context_state_account(
+                &equality_proof_pubkey,
+                &context_state_authority_pubkey,
+                &equality_proof_data,
+                false,
+                create_equality_proof_context_signer
+            ),
+            token.confidential_transfer_create_context_state_account(
+                &ciphertext_validity_proof_pubkey,
+                &context_state_authority_pubkey,
+                &ciphertext_validity_proof_data_with_ciphertext.proof_data,
+                false,
+                create_ciphertext_validity_proof_context_signer
+            )
+        )?;
+
+        // Upload range proof via record account
+        let range_proof_record_account = Keypair::new();
+        let range_proof_record_pubkey = range_proof_record_account.pubkey();
+
         token
-            .permissioned_burn(&account, &authority, &owner, amount, &bulk_signers)
-            .await?
+            .confidential_transfer_create_record_account(
+                &range_proof_record_pubkey,
+                &context_state_authority_pubkey,
+                &range_proof_data,
+                &range_proof_record_account,
+                &context_state_authority,
+            )
+            .await?;
+
+        token.confidential_transfer_create_context_state_account_from_record::<_, BatchedRangeProofU128Data, BatchedRangeProofContext>(
+            &range_proof_pubkey,
+            &context_state_authority_pubkey,
+            &range_proof_record_pubkey,
+            create_range_proof_context_signer,
+        ).await?;
+
+        let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
+            context_state_account: ciphertext_validity_proof_pubkey,
+            ciphertext_lo: burn_amount_auditor_ciphertext_lo,
+            ciphertext_hi: burn_amount_auditor_ciphertext_hi,
+        };
+
+        // Execute burn
+        let burn_result = if let Some(permissioned_auth) = permissioned_burn_authority {
+            token
+                .confidential_transfer_permissioned_burn(
+                    &owner,
+                    &account,
+                    &permissioned_auth,
+                    Some(&equality_proof_pubkey),
+                    Some(&ciphertext_validity_proof_account_with_ciphertext),
+                    Some(&range_proof_pubkey),
+                    amount,
+                    &source_elgamal_keypair,
+                    &supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey.as_ref(),
+                    &source_aes_key,
+                    Some(burn_account_info),
+                    &bulk_signers,
+                )
+                .await
+        } else {
+            token
+                .confidential_transfer_burn(
+                    &owner,
+                    &account,
+                    Some(&equality_proof_pubkey),
+                    Some(&ciphertext_validity_proof_account_with_ciphertext),
+                    Some(&range_proof_pubkey),
+                    amount,
+                    &source_elgamal_keypair,
+                    &supply_elgamal_pubkey,
+                    auditor_elgamal_pubkey.as_ref(),
+                    &source_aes_key,
+                    Some(burn_account_info),
+                    &bulk_signers,
+                )
+                .await
+        };
+
+        // Cleanup context state accounts
+        let close_context_state_signer = &[&context_state_authority];
+        let _ = try_join!(
+            token.confidential_transfer_close_context_state_account(
+                &equality_proof_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+            token.confidential_transfer_close_context_state_account(
+                &ciphertext_validity_proof_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+            token.confidential_transfer_close_context_state_account(
+                &range_proof_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+            token.confidential_transfer_close_record_account(
+                &range_proof_record_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+        )?;
+
+        burn_result?
     } else {
-        token.burn(&account, &owner, amount, &bulk_signers).await?
+        if let Some(authority) = permissioned_burn_authority {
+            token
+                .permissioned_burn(&account, &authority, &owner, amount, &bulk_signers)
+                .await?
+        } else {
+            token.burn(&account, &owner, amount, &bulk_signers).await?
+        }
     };
 
     let tx_return = finish_tx(config, &res, false).await?;
@@ -2133,6 +2338,7 @@ async fn command_mint(
     use_unchecked_instruction: bool,
     memo: Option<String>,
     bulk_signers: BulkSigners,
+    confidential_mint_args: Option<(ElGamalKeypair, AeKey)>,
 ) -> CommandResult {
     let amount = amount_to_raw_amount(ui_amount, mint_info.decimals, None, "TOKEN_AMOUNT");
 
@@ -2146,20 +2352,185 @@ async fn command_mint(
         ),
     );
 
-    let decimals = if use_unchecked_instruction {
-        None
+    let res = if let Some((supply_elgamal_keypair, supply_aes_key)) = confidential_mint_args {
+        // Fetch mint info to get auditor pubkey and supply extension
+        let mint_account = config.get_account_checked(&mint_info.address).await?;
+        let mint_state = StateWithExtensionsOwned::<Mint>::unpack(mint_account.data)
+            .map_err(|_| format!("Could not deserialize token mint {}", mint_info.address))?;
+
+        let auditor_elgamal_pubkey = mint_state
+            .get_extension::<ConfidentialTransferMint>()
+            .ok()
+            .and_then(|ext| Option::<PodElGamalPubkey>::from(ext.auditor_elgamal_pubkey))
+            .map(|pod| {
+                let pubkey: elgamal::ElGamalPubkey =
+                    pod.try_into().expect("Invalid auditor ElGamal pubkey");
+                pubkey
+            });
+
+        let supply_account_info =
+            SupplyAccountInfo::new(mint_state.get_extension::<ConfidentialMintBurn>().unwrap());
+
+        // Fetch destination account to get destination ElGamal pubkey
+        let dest_account = config.get_account_checked(&recipient).await?;
+        let dest_state = StateWithExtensionsOwned::<Account>::unpack(dest_account.data).unwrap();
+        let destination_elgamal_pubkey: elgamal::ElGamalPubkey = dest_state
+            .get_extension::<ConfidentialTransferAccount>()
+            .unwrap()
+            .elgamal_pubkey
+            .try_into()
+            .expect("Invalid destination ElGamal pubkey");
+
+        // Generate split proofs
+        let MintProofData {
+            equality_proof_data,
+            ciphertext_validity_proof_data_with_ciphertext,
+            range_proof_data,
+        } = supply_account_info
+            .generate_split_mint_proof_data(
+                amount,
+                &supply_elgamal_keypair,
+                &supply_aes_key,
+                &destination_elgamal_pubkey,
+                auditor_elgamal_pubkey.as_ref(),
+            )
+            .unwrap();
+
+        let mint_amount_auditor_ciphertext_lo =
+            ciphertext_validity_proof_data_with_ciphertext.ciphertext_lo;
+        let mint_amount_auditor_ciphertext_hi =
+            ciphertext_validity_proof_data_with_ciphertext.ciphertext_hi;
+
+        // Setup context state accounts
+        let context_state_authority = config.fee_payer()?;
+        let context_state_authority_pubkey = context_state_authority.pubkey();
+        let payer_pubkey = config.fee_payer()?.pubkey();
+
+        let equality_proof_context_state_account = Keypair::new();
+        let equality_proof_pubkey = equality_proof_context_state_account.pubkey();
+
+        let ciphertext_validity_proof_context_state_account = Keypair::new();
+        let ciphertext_validity_proof_pubkey =
+            ciphertext_validity_proof_context_state_account.pubkey();
+
+        let range_proof_context_state_account = Keypair::new();
+        let range_proof_pubkey = range_proof_context_state_account.pubkey();
+
+        let create_equality_proof_context_signer = &[&equality_proof_context_state_account];
+        let create_ciphertext_validity_proof_context_signer =
+            &[&ciphertext_validity_proof_context_state_account];
+        let create_range_proof_context_signer = &[&range_proof_context_state_account];
+
+        let token = token_client_from_config(config, &mint_info.address, None)?;
+
+        let _ = try_join!(
+            token.confidential_transfer_create_context_state_account(
+                &equality_proof_pubkey,
+                &context_state_authority_pubkey,
+                &equality_proof_data,
+                false,
+                create_equality_proof_context_signer
+            ),
+            token.confidential_transfer_create_context_state_account(
+                &ciphertext_validity_proof_pubkey,
+                &context_state_authority_pubkey,
+                &ciphertext_validity_proof_data_with_ciphertext.proof_data,
+                false,
+                create_ciphertext_validity_proof_context_signer
+            )
+        )?;
+
+        // Upload range proof via record account
+        let range_proof_record_account = Keypair::new();
+        let range_proof_record_pubkey = range_proof_record_account.pubkey();
+
+        token
+            .confidential_transfer_create_record_account(
+                &range_proof_record_pubkey,
+                &context_state_authority_pubkey,
+                &range_proof_data,
+                &range_proof_record_account,
+                &context_state_authority,
+            )
+            .await?;
+
+        token.confidential_transfer_create_context_state_account_from_record::<_, BatchedRangeProofU128Data, BatchedRangeProofContext>(
+            &range_proof_pubkey,
+            &context_state_authority_pubkey,
+            &range_proof_record_pubkey,
+            create_range_proof_context_signer,
+        ).await?;
+
+        let ciphertext_validity_proof_account_with_ciphertext = ProofAccountWithCiphertext {
+            context_state_account: ciphertext_validity_proof_pubkey,
+            ciphertext_lo: mint_amount_auditor_ciphertext_lo,
+            ciphertext_hi: mint_amount_auditor_ciphertext_hi,
+        };
+
+        // Execute confidential mint
+        let mint_result = token
+            .confidential_transfer_mint(
+                &mint_authority,
+                &recipient,
+                Some(&equality_proof_pubkey),
+                Some(&ciphertext_validity_proof_account_with_ciphertext),
+                Some(&range_proof_pubkey),
+                amount,
+                &supply_elgamal_keypair,
+                &destination_elgamal_pubkey,
+                auditor_elgamal_pubkey.as_ref(),
+                &supply_aes_key,
+                Some(supply_account_info),
+                &bulk_signers,
+            )
+            .await;
+
+        // Cleanup context state accounts
+        let close_context_state_signer = &[&context_state_authority];
+        let _ = try_join!(
+            token.confidential_transfer_close_context_state_account(
+                &equality_proof_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+            token.confidential_transfer_close_context_state_account(
+                &ciphertext_validity_proof_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+            token.confidential_transfer_close_context_state_account(
+                &range_proof_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+            token.confidential_transfer_close_record_account(
+                &range_proof_record_pubkey,
+                &payer_pubkey,
+                &context_state_authority_pubkey,
+                close_context_state_signer
+            ),
+        )?;
+
+        mint_result?
     } else {
-        Some(mint_info.decimals)
+        let decimals = if use_unchecked_instruction {
+            None
+        } else {
+            Some(mint_info.decimals)
+        };
+
+        let token = token_client_from_config(config, &mint_info.address, decimals)?;
+        if let Some(text) = memo {
+            token.with_memo(text, vec![config.default_signer()?.pubkey()]);
+        }
+
+        token
+            .mint_to(&recipient, &mint_authority, amount, &bulk_signers)
+            .await?
     };
-
-    let token = token_client_from_config(config, &mint_info.address, decimals)?;
-    if let Some(text) = memo {
-        token.with_memo(text, vec![config.default_signer()?.pubkey()]);
-    }
-
-    let res = token
-        .mint_to(&recipient, &mint_authority, amount, &bulk_signers)
-        .await?;
 
     let tx_return = finish_tx(config, &res, false).await?;
     Ok(match tx_return {
@@ -3953,6 +4324,37 @@ async fn command_apply_pending_balance(
     })
 }
 
+async fn command_apply_pending_burn(
+    config: &Config<'_>,
+    token_pubkey: Pubkey,
+    mint_authority: Pubkey,
+    bulk_signers: BulkSigners,
+) -> CommandResult {
+    let token = token_client_from_config(config, &token_pubkey, None)?;
+
+    println_display(
+        config,
+        format!(
+            "Applying pending burn for confidential mint: {}",
+            token_pubkey
+        ),
+    );
+
+    let res = token
+        .confidential_transfer_apply_pending_burn(&mint_authority, &bulk_signers)
+        .await?;
+
+    let tx_return = finish_tx(config, &res, false).await?;
+    Ok(match tx_return {
+        TransactionReturnData::CliSignature(signature) => {
+            config.output_format.formatted_string(&signature)
+        }
+        TransactionReturnData::CliSignOnlyData(sign_only_data) => {
+            config.output_format.formatted_string(&sign_only_data)
+        }
+    })
+}
+
 async fn command_update_multiplier(
     config: &Config<'_>,
     token_pubkey: Pubkey,
@@ -4158,6 +4560,9 @@ pub async fn process_command(
                 .value_of("enable_confidential_transfers")
                 .map(|b| b == "auto");
 
+            let enable_confidential_mint_burn =
+                arg_matches.is_present("enable_confidential_mint_burn");
+
             command_create_token(
                 config,
                 decimals,
@@ -4175,6 +4580,7 @@ pub async fn process_command(
                 default_account_state,
                 transfer_fee,
                 confidential_transfer_auto_approve,
+                enable_confidential_mint_burn,
                 transfer_hook_program_id,
                 arg_matches.is_present("enable_metadata"),
                 arg_matches.is_present("enable_group"),
@@ -4528,6 +4934,12 @@ pub async fn process_command(
                 .map(|v: &String| v.parse::<u8>().unwrap());
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let memo = value_t!(arg_matches, "memo", String).ok();
+            let confidential = arg_matches.is_present("confidential");
+            let confidential_burn_args = if confidential {
+                Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
+            } else {
+                None
+            };
             command_burn(
                 config,
                 account,
@@ -4539,6 +4951,7 @@ pub async fn process_command(
                 permissioned_burn_authority,
                 memo,
                 bulk_signers,
+                confidential_burn_args,
             )
             .await
         }
@@ -4574,6 +4987,12 @@ pub async fn process_command(
             config.check_account(&recipient, Some(token)).await?;
             let use_unchecked_instruction = arg_matches.is_present("use_unchecked_instruction");
             let memo = value_t!(arg_matches, "memo", String).ok();
+            let confidential = arg_matches.is_present("confidential");
+            let confidential_mint_args = if confidential {
+                Some(derive_confidential_keys(config.default_signer()?.as_ref(), b"").unwrap())
+            } else {
+                None
+            };
             command_mint(
                 config,
                 token,
@@ -4584,6 +5003,7 @@ pub async fn process_command(
                 use_unchecked_instruction,
                 memo,
                 bulk_signers,
+                confidential_mint_args,
             )
             .await
         }
@@ -5257,6 +5677,18 @@ pub async fn process_command(
                 &aes_key,
             )
             .await
+        }
+        (CommandName::ApplyPendingBurn, arg_matches) => {
+            let token = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)
+                .unwrap()
+                .unwrap();
+            let (mint_authority_signer, mint_authority) =
+                config.signer_or_default(arg_matches, "owner", &mut wallet_manager);
+            if config.multisigner_pubkeys.is_empty() {
+                push_signer_with_dedup(mint_authority_signer, &mut bulk_signers);
+            }
+
+            command_apply_pending_burn(config, token, mint_authority, bulk_signers).await
         }
         (CommandName::UpdateUiAmountMultiplier, arg_matches) => {
             let token_pubkey = pubkey_of_signer(arg_matches, "token", &mut wallet_manager)

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -427,7 +427,7 @@ impl<'a> Config<'a> {
         }
 
         let token = token.unwrap();
-        let program_id = self.get_mint_info(&token, None).await?.program_id;
+        let program_id = self.get_mint_info(&token, None, None).await?.program_id;
         let owner = self.pubkey_or_default(arg_matches, "owner", wallet_manager)?;
         self.associated_token_address_for_token_and_program(&token, &owner, &program_id)
     }
@@ -523,13 +523,14 @@ impl<'a> Config<'a> {
         &self,
         mint: &Pubkey,
         mint_decimals: Option<u8>,
+        has_confidential_mint_burn: Option<bool>,
     ) -> Result<MintInfo, Error> {
         if self.sign_only {
             Ok(MintInfo {
                 program_id: self.program_id,
                 address: *mint,
                 decimals: mint_decimals.unwrap_or_default(),
-                has_confidential_mint_burn: false,
+                has_confidential_mint_burn: has_confidential_mint_burn.unwrap_or(false),
             })
         } else {
             let account = self.get_account_checked(mint).await?;

--- a/clients/cli/src/config.rs
+++ b/clients/cli/src/config.rs
@@ -18,7 +18,10 @@ use {
     },
     spl_associated_token_account_interface::address::get_associated_token_address_with_program_id,
     spl_token_2022_interface::{
-        extension::StateWithExtensionsOwned,
+        extension::{
+            confidential_mint_burn::ConfidentialMintBurn, BaseStateWithExtensions,
+            StateWithExtensionsOwned,
+        },
         state::{Account, Mint},
     },
     spl_token_client::{
@@ -67,6 +70,7 @@ pub(crate) struct MintInfo {
     pub program_id: Pubkey,
     pub address: Pubkey,
     pub decimals: u8,
+    pub has_confidential_mint_burn: bool,
 }
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(30);
@@ -525,6 +529,7 @@ impl<'a> Config<'a> {
                 program_id: self.program_id,
                 address: *mint,
                 decimals: mint_decimals.unwrap_or_default(),
+                has_confidential_mint_burn: false,
             })
         } else {
             let account = self.get_account_checked(mint).await?;
@@ -539,10 +544,15 @@ impl<'a> Config<'a> {
                     .into());
                 }
             }
+
+            let has_confidential_mint_burn =
+                mint_account.get_extension::<ConfidentialMintBurn>().is_ok();
+
             Ok(MintInfo {
                 program_id: account.owner,
                 address: *mint,
                 decimals: mint_account.base.decimals,
+                has_confidential_mint_burn,
             })
         }
     }

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -5037,7 +5037,6 @@ async fn confidential_mint_burn(test_validator: &TestValidator, payer: &Keypair)
             &token_pubkey.to_string(),
             &mint_amount.to_string(),
             &account.to_string(),
-            "--confidential",
         ],
     )
     .await
@@ -5066,7 +5065,6 @@ async fn confidential_mint_burn(test_validator: &TestValidator, payer: &Keypair)
             CommandName::Burn.into(),
             &account.to_string(),
             &burn_amount.to_string(),
-            "--confidential",
         ],
     )
     .await

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -158,6 +158,7 @@ async fn main() {
         async_trial!(scaled_ui_amount, test_validator, payer),
         async_trial!(pause, test_validator, payer),
         async_trial!(permissioned_burn, test_validator, payer),
+        async_trial!(confidential_mint_burn, test_validator, payer),
         // GC messes with every other test, so have it on its own test validator
         async_trial!(gc, gc_test_validator, gc_payer),
     ];
@@ -4978,6 +4979,107 @@ async fn permissioned_burn(test_validator: &TestValidator, payer: &Keypair) {
             "10",
             "--permissioned-burn-authority",
             burn_authority_keypair_file.path().to_str().unwrap(),
+        ],
+    )
+    .await
+    .unwrap();
+}
+
+async fn confidential_mint_burn(test_validator: &TestValidator, payer: &Keypair) {
+    let config =
+        test_config_with_default_signer(test_validator, payer, &spl_token_2022_interface::id());
+
+    // Create a token with both confidential transfers and confidential
+    // mint/burn enabled
+    let token = Keypair::new();
+    let token_keypair_file = NamedTempFile::new().unwrap();
+    write_keypair_file(&token, &token_keypair_file).unwrap();
+    let token_pubkey = token.pubkey();
+
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::CreateToken.into(),
+            token_keypair_file.path().to_str().unwrap(),
+            "--enable-confidential-transfers",
+            "auto",
+            "--enable-confidential-mint-burn",
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Create and configure an associated token account
+    let account = create_associated_account(&config, payer, &token_pubkey, &payer.pubkey()).await;
+
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::ConfigureConfidentialTransferAccount.into(),
+            &token_pubkey.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Mint confidentially
+    let mint_amount = 100.0;
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Mint.into(),
+            &token_pubkey.to_string(),
+            &mint_amount.to_string(),
+            &account.to_string(),
+            "--confidential",
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Apply the pending balance so we can burn it
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::ApplyPendingBalance.into(),
+            &token_pubkey.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Burn confidentially
+    let burn_amount = 50.0;
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Burn.into(),
+            &account.to_string(),
+            &burn_amount.to_string(),
+            "--confidential",
+        ],
+    )
+    .await
+    .unwrap();
+
+    // Apply pending burn to the mint's supply
+    process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::ApplyPendingBurn.into(),
+            &token_pubkey.to_string(),
         ],
     )
     .await


### PR DESCRIPTION
#### Problem

The token-cli does not yet have support for the confidential mint burn extension.

The confidential mint burn extension contain six instructions:
- InitializeMint
- RotateSupplyElGamalPubkey
- UpdateDecryptableSupply
- Mint
- Burn
- ApplyPendingBurn

#### Summary of Changes

I added support for the `InitializeMint`, `Mint`, `Burn`, and `ApplyPendingBurn` instructions. If this PR looks good, I'll add support for the `RotateSupplyElGamalPubkey` and `UpdateDecryptableSupply` in an immediate follow-up PR.