### PR TITLE
Export the legacy token program address

### DIFF
--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -15,5 +15,6 @@ export * from './createToken';
 export * from './getInitializeInstructionsForExtensions';
 export * from './getTokenSize';
 export * from './getMintSize';
+export * from './legacyToken';
 export * from './mintToATA';
 export * from './transferToATA';

--- a/clients/js/src/legacyToken.ts
+++ b/clients/js/src/legacyToken.ts
@@ -1,0 +1,12 @@
+import { Address } from '@solana/kit';
+
+/**
+ * The address of the legacy SPL Token program.
+ *
+ * The Token-2022 client is backwards-compatible with the legacy SPL Token
+ * program, so this address is re-exported here for convenience — pass it as the
+ * `programAddress` of an instruction (or the `tokenProgram` of an
+ * associated-token helper) to target the legacy program from this client.
+ */
+export const TOKEN_PROGRAM_ADDRESS =
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address<'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'>;


### PR DESCRIPTION
This PR exports the legacy SPL Token program address from the token-2022 JS client as TOKEN_PROGRAM_ADDRESS, to align with the other repos in the solana-program org. Since the Token-2022 client is backwards-compatible with the legacy SPL Token program, exposing the address lets developers target the legacy program from this single package without hardcoding it. Closes #510.