### PR TITLE
feat(clients/js): add confidential transfer with fee helper

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -50,7 +50,7 @@
     },
     "dependencies": {
         "@noble/curves": "^1.9.7",
-        "@solana-program/record": "^0.1.0",
+        "@solana-program/record": "^0.3.0",
         "@solana-program/zk-elgamal-proof": "^0.3.2"
     },
     "devDependencies": {

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "@noble/curves": "^1.9.7",
+        "@solana-program/record": "^0.1.0",
         "@solana-program/zk-elgamal-proof": "^0.3.2"
     },
     "devDependencies": {

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@noble/curves':
         specifier: ^1.9.7
         version: 1.9.7
+      '@solana-program/record':
+        specifier: ^0.1.0
+        version: 0.1.0(@solana/kit@6.10.0(typescript@5.9.3))
       '@solana-program/zk-elgamal-proof':
         specifier: ^0.3.2
         version: 0.3.2(@solana/kit@7.0.0(typescript@6.0.3))
@@ -770,6 +773,11 @@ packages:
         optional: true
       oxlint:
         optional: true
+
+  '@solana-program/record@0.1.0':
+    resolution: {integrity: sha512-g7Ub3wYnzU9+Q/srLxhxMMfiDpt2lKjkG2XPGoXHToM7eOhGWY7fKfMaK8rv1mhpzoKEJwAC+HuK6pcnHVIciQ==}
+    peerDependencies:
+      '@solana/kit': ^5.0
 
   '@solana-program/system@0.12.2':
     resolution: {integrity: sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==}

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.9.7
         version: 1.9.7
       '@solana-program/record':
-        specifier: ^0.1.0
-        version: 0.1.0(@solana/kit@6.10.0(typescript@5.9.3))
+        specifier: ^0.3.0
+        version: 0.3.0(@solana/kit@7.0.0(typescript@6.0.3))
       '@solana-program/zk-elgamal-proof':
         specifier: ^0.3.2
         version: 0.3.2(@solana/kit@7.0.0(typescript@6.0.3))
@@ -320,48 +320,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.61.0':
     resolution: {integrity: sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
     resolution: {integrity: sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
     resolution: {integrity: sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.61.0':
     resolution: {integrity: sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.61.0':
     resolution: {integrity: sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.61.0':
     resolution: {integrity: sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.61.0':
     resolution: {integrity: sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.61.0':
     resolution: {integrity: sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==}
@@ -464,48 +472,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.75.0':
     resolution: {integrity: sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.75.0':
     resolution: {integrity: sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.75.0':
     resolution: {integrity: sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.75.0':
     resolution: {integrity: sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.75.0':
     resolution: {integrity: sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.75.0':
     resolution: {integrity: sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.75.0':
     resolution: {integrity: sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.75.0':
     resolution: {integrity: sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==}
@@ -566,36 +582,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -657,66 +679,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -774,10 +809,11 @@ packages:
       oxlint:
         optional: true
 
-  '@solana-program/record@0.1.0':
-    resolution: {integrity: sha512-g7Ub3wYnzU9+Q/srLxhxMMfiDpt2lKjkG2XPGoXHToM7eOhGWY7fKfMaK8rv1mhpzoKEJwAC+HuK6pcnHVIciQ==}
+  '@solana-program/record@0.3.0':
+    resolution: {integrity: sha512-q8z86INfXRQ5357qgVBrw05vC+u3xg8Vb4E1gEwnYUvAkL3cbJSjWVfTlGRiGWYmPNq/FYIWbsFrhsxXyhaJ+w==}
+    engines: {node: '>=24.0.0'}
     peerDependencies:
-      '@solana/kit': ^5.0
+      '@solana/kit': ^7.0.0
 
   '@solana-program/system@0.12.2':
     resolution: {integrity: sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==}
@@ -1804,24 +1840,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1866,24 +1906,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-arm64-musl@1.3.0:
     resolution: {integrity: sha512-FO9p6rx+/3h7R3CU7lkOebL+jy8UEDngSrENHu7pj9EOr78QVyE3Fm0O+WMnwXpMoCSgW0XLhu1cI9NHAbzCTA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   litesvm-linux-x64-gnu@1.3.0:
     resolution: {integrity: sha512-yXC8ZAdIei9JQ2xw5/BocOTu/7EqZuFPyhgENQ1mYDhjNpoyUbIuGCWnqtria14mDda0aV9yVev8plGUrUpjUw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-x64-musl@1.3.0:
     resolution: {integrity: sha512-oedromp1gTjShXmKmxZ1FYtnfM824vRcrPSPvGM0CrqJqKK61m1+tFwNRAVsDlpmWKvO/zsz90ctbgAUo/3TXg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   litesvm@1.3.0:
     resolution: {integrity: sha512-tMu9sBIqSbF1gQluXEUtGmXPfZlMc10tOoBVeDokgK77nl/CcuC506sEoFKM5Rq58Dkb070lBMVBLc43TbMUzQ==}
@@ -2668,6 +2712,10 @@ snapshots:
     optionalDependencies:
       oxfmt: 0.61.0
       oxlint: 1.75.0(oxlint-tsgolint@7.0.2001)
+
+  '@solana-program/record@0.3.0(@solana/kit@7.0.0(typescript@6.0.3))':
+    dependencies:
+      '@solana/kit': 7.0.0(typescript@6.0.3)
 
   '@solana-program/system@0.12.2(@solana/kit@6.10.0(typescript@6.0.3))':
     dependencies:

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -97,6 +97,8 @@ const NET_TRANSFER_AMOUNT_BIT_LENGTH = 64;
 const COMPUTE_BUDGET_PROGRAM_ADDRESS =
     'ComputeBudget111111111111111111111111111111' as Address<'ComputeBudget111111111111111111111111111111'>;
 const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
+const PEDERSEN_ARITHMETIC_ERROR =
+    'Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment and opening arithmetic.';
 
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
@@ -257,8 +259,12 @@ type GetConfidentialTransferWithFeeInstructionPlanBaseInput = GetConfidentialTra
     currentEpoch: number | bigint;
 };
 
+type RecordBackedContextStateProofMode = Omit<ContextStateProofMode, 'payer'> & {
+    payer: KeyPairSigner;
+};
+
 export type GetConfidentialTransferWithFeeInstructionPlanInput =
-    GetConfidentialTransferWithFeeInstructionPlanBaseInput & ContextStateProofMode;
+    GetConfidentialTransferWithFeeInstructionPlanBaseInput & RecordBackedContextStateProofMode;
 
 function getTokenProgramAddress(programAddress?: Address) {
     return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
@@ -399,13 +405,6 @@ function assertCreateHelperOwnerMatchesAuthority(
     }
 }
 
-/**
- * Builds the setup-and-cleanup instruction plans for a single proof's
- * context-state account. The setup plan creates the context-state account
- * and verifies the proof into it (these two instructions must share a
- * transaction). The cleanup plan closes the context-state account to recover
- * its rent.
- */
 function assertNonNegativeAmount(amount: bigint): void {
     if (amount < 0n) {
         throw new Error('Amount must be non-negative.');
@@ -413,6 +412,9 @@ function assertNonNegativeAmount(amount: bigint): void {
 }
 
 function assertU64Amount(amount: bigint, name: string): void {
+    if (amount < 0n) {
+        throw new Error(`${name} must be non-negative.`);
+    }
     if (amount > (1n << 64n) - 1n) {
         throw new Error(`${name} must fit in a u64.`);
     }
@@ -454,60 +456,57 @@ function calculateTransferWithFeeAmounts(transferAmount: bigint, transferFeeBasi
     return { feeAmount, claimedDeltaFee, netTransferAmount };
 }
 
+function assertPedersenArithmeticAvailable(): void {
+    const commitmentConstructor = PedersenCommitment as unknown as PedersenCommitmentConstructorWithArithmetic;
+    const openingConstructor = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
+    const commitment = PedersenCommitment.from(0n, new PedersenOpening()) as PedersenCommitmentWithArithmetic;
+    const opening = new PedersenOpening() as PedersenOpeningWithArithmetic;
+    if (
+        typeof commitmentConstructor.combineLoHi !== 'function' ||
+        typeof openingConstructor.combineLoHi !== 'function' ||
+        typeof openingConstructor.zero !== 'function' ||
+        typeof commitment.subtract !== 'function' ||
+        typeof commitment.multiplyByU64 !== 'function' ||
+        typeof opening.subtract !== 'function' ||
+        typeof opening.multiplyByU64 !== 'function'
+    ) {
+        throw new Error(PEDERSEN_ARITHMETIC_ERROR);
+    }
+}
+
 function combineLoHiCommitments(lo: PedersenCommitment, hi: PedersenCommitment, bitLength: bigint): PedersenCommitment {
     const PedersenCommitmentWithArithmetic =
         PedersenCommitment as unknown as PedersenCommitmentConstructorWithArithmetic;
-    if (typeof PedersenCommitmentWithArithmetic.combineLoHi !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.');
-    }
     return PedersenCommitmentWithArithmetic.combineLoHi(lo, hi, Number(bitLength));
 }
 
 function combineLoHiOpenings(lo: PedersenOpening, hi: PedersenOpening, bitLength: bigint): PedersenOpening {
     const PedersenOpeningWithArithmetic = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
-    if (typeof PedersenOpeningWithArithmetic.combineLoHi !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
-    }
     return PedersenOpeningWithArithmetic.combineLoHi(lo, hi, Number(bitLength));
 }
 
 function getZeroOpening(): PedersenOpening {
     const PedersenOpeningWithArithmetic = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
-    if (typeof PedersenOpeningWithArithmetic.zero !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
-    }
     return PedersenOpeningWithArithmetic.zero();
 }
 
 function subtractCommitments(left: PedersenCommitment, right: PedersenCommitment): PedersenCommitment {
     const leftWithArithmetic = left as PedersenCommitmentWithArithmetic;
-    if (typeof leftWithArithmetic.subtract !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.');
-    }
     return leftWithArithmetic.subtract(right);
 }
 
 function subtractOpenings(left: PedersenOpening, right: PedersenOpening): PedersenOpening {
     const leftWithArithmetic = left as PedersenOpeningWithArithmetic;
-    if (typeof leftWithArithmetic.subtract !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
-    }
     return leftWithArithmetic.subtract(right);
 }
 
 function multiplyCommitment(commitment: PedersenCommitment, scalar: bigint): PedersenCommitment {
     const commitmentWithArithmetic = commitment as PedersenCommitmentWithArithmetic;
-    if (typeof commitmentWithArithmetic.multiplyByU64 !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.');
-    }
     return commitmentWithArithmetic.multiplyByU64(scalar);
 }
 
 function multiplyOpening(opening: PedersenOpening, scalar: bigint): PedersenOpening {
     const openingWithArithmetic = opening as PedersenOpeningWithArithmetic;
-    if (typeof openingWithArithmetic.multiplyByU64 !== 'function') {
-        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
-    }
     return openingWithArithmetic.multiplyByU64(scalar);
 }
 
@@ -537,6 +536,13 @@ function getSetComputeUnitLimitInstruction(units: number): Instruction {
     return { programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS, data };
 }
 
+/**
+ * Builds the setup-and-cleanup instruction plans for a single proof's
+ * context-state account. The setup plan creates the context-state account
+ * and verifies the proof into it (these two instructions must share a
+ * transaction). The cleanup plan closes the context-state account to recover
+ * its rent.
+ */
 async function buildContextStateProofPlan(
     proofData: ReadonlyUint8Array,
     verifyAction: (args: {
@@ -548,15 +554,15 @@ async function buildContextStateProofPlan(
     payer: TransactionSigner,
     rpc: Rpc<GetMinimumBalanceForRentExemptionApi>,
     contextStateAuthority: TransactionSigner = payer,
-    useRecordAccount = false,
+    recordPayer?: KeyPairSigner,
 ): Promise<ContextStateProofPlan> {
     const contextAccount = await generateKeyPairSigner();
     const proofDataBytes = new Uint8Array(proofData);
-    if (useRecordAccount) {
+    if (recordPayer) {
         const recordAuthority = await generateKeyPairSigner();
         const { recordKeypair, ixs: createRecordInstructions } = await createRecord({
             rpc,
-            payer: payer as KeyPairSigner,
+            payer: recordPayer,
             authority: recordAuthority.address,
             dataLength: BigInt(proofDataBytes.length),
         });
@@ -1015,6 +1021,7 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
     assertU64Amount(feeAmount, 'Fee amount');
     assertU64Amount(claimedDeltaFee, 'Claimed delta fee');
     assertU64Amount(netTransferAmount, 'Net transfer amount');
+    assertPedersenArithmeticAvailable();
 
     const [transferAmountLo, transferAmountHi] = splitAmount(amount, TRANSFER_AMOUNT_LO_BIT_LENGTH);
     const [feeAmountLo, feeAmountHi] = splitAmount(feeAmount, FEE_AMOUNT_LO_BIT_LENGTH);
@@ -1230,32 +1237,24 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
             verifyCiphertextCommitmentEquality,
             input.payer,
             input.rpc,
-            input.payer,
-            true,
         ),
         buildContextStateProofPlan(
             transferAmountCiphertextValidityProofData.toBytes(),
             verifyBatchedGroupedCiphertext3HandlesValidity,
             input.payer,
             input.rpc,
-            input.payer,
-            true,
         ),
         buildContextStateProofPlan(
             percentageWithCapProofData.toBytes(),
             verifyPercentageWithCap,
             input.payer,
             input.rpc,
-            input.payer,
-            true,
         ),
         buildContextStateProofPlan(
             feeCiphertextValidityProofData.toBytes(),
             verifyBatchedGroupedCiphertext2HandlesValidity,
             input.payer,
             input.rpc,
-            input.payer,
-            true,
         ),
         buildContextStateProofPlan(
             rangeProofData.toBytes(),
@@ -1263,7 +1262,7 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
             input.payer,
             input.rpc,
             input.payer,
-            true,
+            input.payer,
         ),
     ]);
 

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -1,9 +1,8 @@
 import {
-    RECORD_CHUNK_SIZE_POST_INITIALIZE,
     RECORD_META_DATA_SIZE,
-    createCloseRecordInstruction,
-    createRecord,
-    createWriteInstruction,
+    getCloseAccountInstruction,
+    getCreateRecordInstructionPlan,
+    getWriteInstructionPlan,
 } from '@solana-program/record';
 import {
     closeContextStateProof,
@@ -259,7 +258,7 @@ type GetConfidentialTransferWithFeeInstructionPlanBaseInput = GetConfidentialTra
     currentEpoch: number | bigint;
 };
 
-type RecordBackedContextStateProofMode = Omit<ContextStateProofMode, 'payer'> & {
+type RecordBackedContextStateProofMode = Omit<ConfidentialTransferContextStateProofMode, 'payer'> & {
     payer: KeyPairSigner;
 };
 
@@ -510,25 +509,6 @@ function multiplyOpening(opening: PedersenOpening, scalar: bigint): PedersenOpen
     return openingWithArithmetic.multiplyByU64(scalar);
 }
 
-function getRecordWriteInstructions(
-    recordAccount: Address,
-    authority: TransactionSigner,
-    proofData: Uint8Array,
-): Instruction[] {
-    const instructions: Instruction[] = [];
-    for (let offset = 0; offset < proofData.length; offset += RECORD_CHUNK_SIZE_POST_INITIALIZE) {
-        instructions.push(
-            createWriteInstruction({
-                recordAccount,
-                authority,
-                offset: BigInt(offset),
-                data: proofData.slice(offset, offset + RECORD_CHUNK_SIZE_POST_INITIALIZE),
-            }),
-        );
-    }
-    return instructions;
-}
-
 function getSetComputeUnitLimitInstruction(units: number): Instruction {
     const data = new Uint8Array(5);
     data[0] = 2;
@@ -560,9 +540,13 @@ async function buildContextStateProofPlan(
     const proofDataBytes = new Uint8Array(proofData);
     if (recordPayer) {
         const recordAuthority = await generateKeyPairSigner();
-        const { recordKeypair, ixs: createRecordInstructions } = await createRecord({
-            rpc,
+        const recordKeypair = await generateKeyPairSigner();
+        const recordClient = {
+            getMinimumBalance: (space: number) => rpc.getMinimumBalanceForRentExemption(BigInt(space)).send(),
+        };
+        const createRecordPlan = await getCreateRecordInstructionPlan(recordClient, {
             payer: recordPayer,
+            newRecord: recordKeypair,
             authority: recordAuthority.address,
             dataLength: BigInt(proofDataBytes.length),
         });
@@ -578,8 +562,12 @@ async function buildContextStateProofPlan(
         return {
             address: contextAccount.address,
             setup: sequentialInstructionPlan([
-                ...createRecordInstructions,
-                ...getRecordWriteInstructions(recordKeypair.address, recordAuthority, proofDataBytes),
+                createRecordPlan,
+                getWriteInstructionPlan({
+                    recordAccount: recordKeypair.address,
+                    authority: recordAuthority,
+                    data: proofDataBytes,
+                }),
                 nonDivisibleSequentialInstructionPlan([
                     getSetComputeUnitLimitInstruction(MAX_COMPUTE_UNIT_LIMIT),
                     ...verifyInstructions,
@@ -591,7 +579,7 @@ async function buildContextStateProofPlan(
                     authority: contextStateAuthority,
                     destination: payer.address,
                 }),
-                createCloseRecordInstruction({
+                getCloseAccountInstruction({
                     recordAccount: recordKeypair.address,
                     authority: recordAuthority,
                     receiver: payer.address,

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -1,9 +1,12 @@
 import {
     closeContextStateProof,
+    verifyBatchedGroupedCiphertext2HandlesValidity,
     verifyBatchedGroupedCiphertext3HandlesValidity,
     verifyBatchedRangeProofU128,
+    verifyBatchedRangeProofU256,
     verifyBatchedRangeProofU64,
     verifyCiphertextCommitmentEquality,
+    verifyPercentageWithCap,
     verifyPubkeyValidity,
     verifyZeroCiphertext,
 } from '@solana-program/zk-elgamal-proof';
@@ -27,17 +30,21 @@ import {
 import {
     AeCiphertext,
     AeKey,
+    BatchedGroupedCiphertext2HandlesValidityProofData,
     BatchedGroupedCiphertext3HandlesValidityProofData,
     BatchedRangeProofU128Data,
+    BatchedRangeProofU256Data,
     BatchedRangeProofU64Data,
     CiphertextCommitmentEqualityProofData,
     ElGamalCiphertext,
     ElGamalKeypair,
     ElGamalPubkey,
     ElGamalSecretKey,
+    GroupedElGamalCiphertext2Handles,
     GroupedElGamalCiphertext3Handles,
     PedersenCommitment,
     PedersenOpening,
+    PercentageWithCapProofData,
     PubkeyValidityProofData,
     ZeroCiphertextProofData,
 } from '@solana/zk-sdk/bundler';
@@ -57,6 +64,7 @@ import {
     findAssociatedTokenPda,
     getApplyConfidentialPendingBalanceInstruction,
     getConfidentialTransferInstruction,
+    getConfidentialTransferWithFeeInstruction,
     getConfidentialWithdrawInstruction,
     getConfigureConfidentialTransferAccountInstruction,
     getCreateAssociatedTokenIdempotentInstruction,
@@ -69,11 +77,34 @@ const DEFAULT_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER = 1n << 16n;
 const PENDING_BALANCE_LO_BIT_LENGTH = 16n;
 const TRANSFER_AMOUNT_LO_BIT_LENGTH = 16n;
 const TRANSFER_AMOUNT_HI_BIT_LENGTH = 32n;
+const FEE_AMOUNT_LO_BIT_LENGTH = 16n;
+const FEE_AMOUNT_HI_BIT_LENGTH = 32n;
 const REMAINING_BALANCE_BIT_LENGTH = 64;
 const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
+const MAX_FEE_BASIS_POINTS_SUB_ONE = 9_999n;
+const MAX_FEE_BASIS_POINTS = 10_000n;
+const DELTA_BIT_LENGTH = 16;
+const NET_TRANSFER_AMOUNT_BIT_LENGTH = 64;
 
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
+type TransferFeeConfigExtension = Extract<Extension, { __kind: 'TransferFeeConfig' }>;
+type TransferFee = TransferFeeConfigExtension['olderTransferFee'];
+type PedersenCommitmentWithArithmetic = PedersenCommitment & {
+    subtract(other: PedersenCommitment): PedersenCommitment;
+    multiplyByU64(scalar: bigint): PedersenCommitment;
+};
+type PedersenCommitmentConstructorWithArithmetic = typeof PedersenCommitment & {
+    combineLoHi(lo: PedersenCommitment, hi: PedersenCommitment, bitLength: number): PedersenCommitment;
+};
+type PedersenOpeningWithArithmetic = PedersenOpening & {
+    subtract(other: PedersenOpening): PedersenOpening;
+    multiplyByU64(scalar: bigint): PedersenOpening;
+};
+type PedersenOpeningConstructorWithArithmetic = typeof PedersenOpening & {
+    zero(): PedersenOpening;
+    combineLoHi(lo: PedersenOpening, hi: PedersenOpening, bitLength: number): PedersenOpening;
+};
 
 type ContextStateProofMode = {
     /**
@@ -206,6 +237,14 @@ type GetConfidentialTransferInstructionPlanBaseInput = {
 export type GetConfidentialTransferInstructionPlanInput = GetConfidentialTransferInstructionPlanBaseInput &
     ConfidentialTransferContextStateProofMode;
 
+type GetConfidentialTransferWithFeeInstructionPlanBaseInput = GetConfidentialTransferInstructionPlanBaseInput & {
+    mintAccount: Mint;
+    currentEpoch: number | bigint;
+};
+
+export type GetConfidentialTransferWithFeeInstructionPlanInput =
+    GetConfidentialTransferWithFeeInstructionPlanBaseInput & ContextStateProofMode;
+
 function getTokenProgramAddress(programAddress?: Address) {
     return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
 }
@@ -243,6 +282,24 @@ function getRequiredConfidentialTransferMintExtension(mint: Mint): ConfidentialT
         | undefined;
     if (!extension) {
         throw new Error('Mint account is missing the ConfidentialTransferMint extension.');
+    }
+
+    return extension;
+}
+
+function getRequiredMintExtension<TKind extends Extension['__kind']>(
+    mintAccount: Mint,
+    kind: TKind,
+): Extract<Extension, { __kind: TKind }> {
+    if (!isSome(mintAccount.extensions)) {
+        throw new Error('Mint account is missing extensions.');
+    }
+
+    const extension = mintAccount.extensions.value.find(candidate => candidate.__kind === kind) as
+        | Extract<Extension, { __kind: TKind }>
+        | undefined;
+    if (!extension) {
+        throw new Error(`Mint account is missing the ${kind} extension.`);
     }
 
     return extension;
@@ -340,6 +397,12 @@ function assertNonNegativeAmount(amount: bigint): void {
     }
 }
 
+function assertU64Amount(amount: bigint, name: string): void {
+    if (amount > (1n << 64n) - 1n) {
+        throw new Error(`${name} must fit in a u64.`);
+    }
+}
+
 function computeNewAvailableBalance(currentBalance: bigint, amount: bigint): bigint {
     assertNonNegativeAmount(amount);
     const newBalance = currentBalance - amount;
@@ -347,6 +410,90 @@ function computeNewAvailableBalance(currentBalance: bigint, amount: bigint): big
         throw new Error('Insufficient funds.');
     }
     return newBalance;
+}
+
+function getEpochTransferFee(
+    transferFeeConfig: TransferFeeConfigExtension,
+    currentEpoch: number | bigint,
+): TransferFee {
+    return BigInt(currentEpoch) >= transferFeeConfig.newerTransferFee.epoch
+        ? transferFeeConfig.newerTransferFee
+        : transferFeeConfig.olderTransferFee;
+}
+
+function calculateFee(transferAmount: bigint, transferFeeBasisPoints: number): [bigint, bigint] {
+    const numerator = transferAmount * BigInt(transferFeeBasisPoints);
+    const fee = (numerator + MAX_FEE_BASIS_POINTS - 1n) / MAX_FEE_BASIS_POINTS;
+    const deltaFee = fee * MAX_FEE_BASIS_POINTS - numerator;
+    return [fee, deltaFee];
+}
+
+function calculateTransferWithFeeAmounts(transferAmount: bigint, transferFeeBasisPoints: number, maximumFee: bigint) {
+    const [rawFeeAmount, rawDeltaFee] = calculateFee(transferAmount, transferFeeBasisPoints);
+    const [feeAmount, claimedDeltaFee] = maximumFee < rawFeeAmount ? [maximumFee, 0n] : [rawFeeAmount, rawDeltaFee];
+    const netTransferAmount = transferAmount - feeAmount;
+    if (netTransferAmount < 0n) {
+        throw new Error('Fee exceeds transfer amount.');
+    }
+
+    return { feeAmount, claimedDeltaFee, netTransferAmount };
+}
+
+function combineLoHiCommitments(lo: PedersenCommitment, hi: PedersenCommitment, bitLength: bigint): PedersenCommitment {
+    const PedersenCommitmentWithArithmetic =
+        PedersenCommitment as unknown as PedersenCommitmentConstructorWithArithmetic;
+    if (typeof PedersenCommitmentWithArithmetic.combineLoHi !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.');
+    }
+    return PedersenCommitmentWithArithmetic.combineLoHi(lo, hi, Number(bitLength));
+}
+
+function combineLoHiOpenings(lo: PedersenOpening, hi: PedersenOpening, bitLength: bigint): PedersenOpening {
+    const PedersenOpeningWithArithmetic = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
+    if (typeof PedersenOpeningWithArithmetic.combineLoHi !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
+    }
+    return PedersenOpeningWithArithmetic.combineLoHi(lo, hi, Number(bitLength));
+}
+
+function getZeroOpening(): PedersenOpening {
+    const PedersenOpeningWithArithmetic = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
+    if (typeof PedersenOpeningWithArithmetic.zero !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
+    }
+    return PedersenOpeningWithArithmetic.zero();
+}
+
+function subtractCommitments(left: PedersenCommitment, right: PedersenCommitment): PedersenCommitment {
+    const leftWithArithmetic = left as PedersenCommitmentWithArithmetic;
+    if (typeof leftWithArithmetic.subtract !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.');
+    }
+    return leftWithArithmetic.subtract(right);
+}
+
+function subtractOpenings(left: PedersenOpening, right: PedersenOpening): PedersenOpening {
+    const leftWithArithmetic = left as PedersenOpeningWithArithmetic;
+    if (typeof leftWithArithmetic.subtract !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
+    }
+    return leftWithArithmetic.subtract(right);
+}
+
+function multiplyCommitment(commitment: PedersenCommitment, scalar: bigint): PedersenCommitment {
+    const commitmentWithArithmetic = commitment as PedersenCommitmentWithArithmetic;
+    if (typeof commitmentWithArithmetic.multiplyByU64 !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.');
+    }
+    return commitmentWithArithmetic.multiplyByU64(scalar);
+}
+
+function multiplyOpening(opening: PedersenOpening, scalar: bigint): PedersenOpening {
+    const openingWithArithmetic = opening as PedersenOpeningWithArithmetic;
+    if (typeof openingWithArithmetic.multiplyByU64 !== 'function') {
+        throw new Error('Confidential transfer with fee requires @solana/zk-sdk Pedersen opening arithmetic.');
+    }
+    return openingWithArithmetic.multiplyByU64(scalar);
 }
 
 async function buildContextStateProofPlan(
@@ -741,6 +888,314 @@ export async function getConfidentialTransferInstructionPlan(
         parallelInstructionPlan([
             equalityProofPlan.cleanup,
             ciphertextValidityProofPlan.cleanup,
+            rangeProofPlan.cleanup,
+        ]),
+    ]);
+}
+
+/**
+ * Returns an instruction plan that confidentially transfers tokens between
+ * two accounts when the mint is configured for confidential transfer fees.
+ * Builds and verifies the five proofs required by `TransferWithFee` via
+ * context-state accounts.
+ *
+ * This helper requires the Pedersen arithmetic helpers added to
+ * `@solana/zk-sdk` after v0.4.2.
+ */
+export async function getConfidentialTransferWithFeeInstructionPlan(
+    input: GetConfidentialTransferWithFeeInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const sourceAccount = getRequiredConfidentialTransferAccountExtension(input.sourceTokenAccount);
+    const amount = BigInt(input.amount);
+    assertNonNegativeAmount(amount);
+    assertU64Amount(amount, 'Amount');
+
+    const transferFeeConfig = getRequiredMintExtension(input.mintAccount, 'TransferFeeConfig');
+    const confidentialTransferFee = getRequiredMintExtension(input.mintAccount, 'ConfidentialTransferFee');
+    const transferFee = getEpochTransferFee(transferFeeConfig, input.currentEpoch);
+    const maximumFee = BigInt(transferFee.maximumFee);
+    const { feeAmount, claimedDeltaFee, netTransferAmount } = calculateTransferWithFeeAmounts(
+        amount,
+        transferFee.transferFeeBasisPoints,
+        maximumFee,
+    );
+
+    assertU64Amount(feeAmount, 'Fee amount');
+    assertU64Amount(claimedDeltaFee, 'Claimed delta fee');
+    assertU64Amount(netTransferAmount, 'Net transfer amount');
+
+    const [transferAmountLo, transferAmountHi] = splitAmount(amount, TRANSFER_AMOUNT_LO_BIT_LENGTH);
+    const [feeAmountLo, feeAmountHi] = splitAmount(feeAmount, FEE_AMOUNT_LO_BIT_LENGTH);
+
+    const sourcePubkey = input.sourceElgamalKeypair.pubkey();
+    const destinationPubkey = getDestinationElGamalPubkey(input);
+    const auditorPubkey = await getAuditorElGamalPubkey(input);
+    const withdrawWithheldAuthorityPubkey = getElGamalPubkeyFromAddress(confidentialTransferFee.elgamalPubkey);
+
+    const transferAmountOpeningLo = new PedersenOpening();
+    const transferAmountOpeningHi = new PedersenOpening();
+    const transferAmountGroupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        destinationPubkey,
+        auditorPubkey,
+        transferAmountLo,
+        transferAmountOpeningLo,
+    );
+    const transferAmountGroupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        destinationPubkey,
+        auditorPubkey,
+        transferAmountHi,
+        transferAmountOpeningHi,
+    );
+
+    const transferAmountGroupedCiphertextLoBytes = transferAmountGroupedCiphertextLo.toBytes();
+    const transferAmountGroupedCiphertextHiBytes = transferAmountGroupedCiphertextHi.toBytes();
+    const transferAmountSourceCiphertextLo = extractCiphertextFromGroupedBytes(
+        transferAmountGroupedCiphertextLoBytes,
+        0,
+    );
+    const transferAmountSourceCiphertextHi = extractCiphertextFromGroupedBytes(
+        transferAmountGroupedCiphertextHiBytes,
+        0,
+    );
+    const transferAmountAuditorCiphertextLo = extractCiphertextFromGroupedBytes(
+        transferAmountGroupedCiphertextLoBytes,
+        2,
+    );
+    const transferAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(
+        transferAmountGroupedCiphertextHiBytes,
+        2,
+    );
+
+    const currentAvailableBalance = decryptAvailableBalance(sourceAccount, input.aesKey);
+    const newAvailableBalance = computeNewAvailableBalance(currentAvailableBalance, amount);
+    assertU64Amount(newAvailableBalance, 'New available balance');
+
+    const newAvailableBalanceOpening = new PedersenOpening();
+    const newAvailableBalanceCommitment = PedersenCommitment.from(newAvailableBalance, newAvailableBalanceOpening);
+    const newAvailableBalanceCiphertext = parseElGamalCiphertext(
+        subtractWithLoHiCiphertexts(
+            sourceAccount.availableBalance,
+            transferAmountSourceCiphertextLo,
+            transferAmountSourceCiphertextHi,
+            TRANSFER_AMOUNT_LO_BIT_LENGTH,
+        ),
+    );
+
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
+        input.sourceElgamalKeypair,
+        newAvailableBalanceCiphertext,
+        newAvailableBalanceCommitment,
+        newAvailableBalanceOpening,
+        newAvailableBalance,
+    );
+    const transferAmountCiphertextValidityProofData = new BatchedGroupedCiphertext3HandlesValidityProofData(
+        sourcePubkey,
+        destinationPubkey,
+        auditorPubkey,
+        transferAmountGroupedCiphertextLo,
+        transferAmountGroupedCiphertextHi,
+        transferAmountLo,
+        transferAmountHi,
+        transferAmountOpeningLo,
+        transferAmountOpeningHi,
+    );
+
+    const transferAmountCommitmentLo = PedersenCommitment.fromBytes(
+        transferAmountGroupedCiphertextLoBytes.slice(0, 32),
+    );
+    const transferAmountCommitmentHi = PedersenCommitment.fromBytes(
+        transferAmountGroupedCiphertextHiBytes.slice(0, 32),
+    );
+    const combinedTransferAmountCommitment = combineLoHiCommitments(
+        transferAmountCommitmentLo,
+        transferAmountCommitmentHi,
+        TRANSFER_AMOUNT_LO_BIT_LENGTH,
+    );
+    const combinedTransferAmountOpening = combineLoHiOpenings(
+        transferAmountOpeningLo,
+        transferAmountOpeningHi,
+        TRANSFER_AMOUNT_LO_BIT_LENGTH,
+    );
+
+    const feeOpeningLo = new PedersenOpening();
+    const feeOpeningHi = new PedersenOpening();
+    const feeGroupedCiphertextLo = GroupedElGamalCiphertext2Handles.encryptWith(
+        destinationPubkey,
+        withdrawWithheldAuthorityPubkey,
+        feeAmountLo,
+        feeOpeningLo,
+    );
+    const feeGroupedCiphertextHi = GroupedElGamalCiphertext2Handles.encryptWith(
+        destinationPubkey,
+        withdrawWithheldAuthorityPubkey,
+        feeAmountHi,
+        feeOpeningHi,
+    );
+    const feeGroupedCiphertextLoBytes = feeGroupedCiphertextLo.toBytes();
+    const feeGroupedCiphertextHiBytes = feeGroupedCiphertextHi.toBytes();
+    const feeCommitmentLo = PedersenCommitment.fromBytes(feeGroupedCiphertextLoBytes.slice(0, 32));
+    const feeCommitmentHi = PedersenCommitment.fromBytes(feeGroupedCiphertextHiBytes.slice(0, 32));
+    const combinedFeeCommitment = combineLoHiCommitments(feeCommitmentLo, feeCommitmentHi, FEE_AMOUNT_LO_BIT_LENGTH);
+    const combinedFeeOpening = combineLoHiOpenings(feeOpeningLo, feeOpeningHi, FEE_AMOUNT_LO_BIT_LENGTH);
+
+    const netTransferAmountCommitment = subtractCommitments(combinedTransferAmountCommitment, combinedFeeCommitment);
+    const netTransferAmountOpening = subtractOpenings(combinedTransferAmountOpening, combinedFeeOpening);
+    const claimedOpening = new PedersenOpening();
+    const claimedCommitment = PedersenCommitment.from(claimedDeltaFee, claimedOpening);
+    const deltaCommitment = subtractCommitments(
+        multiplyCommitment(combinedFeeCommitment, MAX_FEE_BASIS_POINTS),
+        multiplyCommitment(combinedTransferAmountCommitment, BigInt(transferFee.transferFeeBasisPoints)),
+    );
+    const deltaOpening = subtractOpenings(
+        multiplyOpening(combinedFeeOpening, MAX_FEE_BASIS_POINTS),
+        multiplyOpening(combinedTransferAmountOpening, BigInt(transferFee.transferFeeBasisPoints)),
+    );
+    const percentageWithCapProofData = new PercentageWithCapProofData(
+        combinedFeeCommitment,
+        combinedFeeOpening,
+        feeAmount,
+        deltaCommitment,
+        deltaOpening,
+        claimedDeltaFee,
+        claimedCommitment,
+        claimedOpening,
+        maximumFee,
+    );
+    const feeCiphertextValidityProofData = new BatchedGroupedCiphertext2HandlesValidityProofData(
+        destinationPubkey,
+        withdrawWithheldAuthorityPubkey,
+        feeGroupedCiphertextLo,
+        feeGroupedCiphertextHi,
+        feeAmountLo,
+        feeAmountHi,
+        feeOpeningLo,
+        feeOpeningHi,
+    );
+
+    const zeroOpening = getZeroOpening();
+    const maxFeeBasisPointsSubOneCommitment = PedersenCommitment.from(MAX_FEE_BASIS_POINTS_SUB_ONE, zeroOpening);
+    const claimedComplementCommitment = subtractCommitments(maxFeeBasisPointsSubOneCommitment, claimedCommitment);
+    const claimedComplementOpening = subtractOpenings(zeroOpening, claimedOpening);
+    const deltaFeeComplement = MAX_FEE_BASIS_POINTS_SUB_ONE - claimedDeltaFee;
+    if (deltaFeeComplement < 0n) {
+        throw new Error('Claimed delta fee exceeds maximum range.');
+    }
+
+    const rangeProofData = new BatchedRangeProofU256Data(
+        [
+            newAvailableBalanceCommitment,
+            transferAmountCommitmentLo,
+            transferAmountCommitmentHi,
+            claimedCommitment,
+            claimedComplementCommitment,
+            feeCommitmentLo,
+            feeCommitmentHi,
+            netTransferAmountCommitment,
+        ],
+        new BigUint64Array([
+            newAvailableBalance,
+            transferAmountLo,
+            transferAmountHi,
+            claimedDeltaFee,
+            deltaFeeComplement,
+            feeAmountLo,
+            feeAmountHi,
+            netTransferAmount,
+        ]),
+        Uint8Array.from([
+            REMAINING_BALANCE_BIT_LENGTH,
+            Number(TRANSFER_AMOUNT_LO_BIT_LENGTH),
+            Number(TRANSFER_AMOUNT_HI_BIT_LENGTH),
+            DELTA_BIT_LENGTH,
+            DELTA_BIT_LENGTH,
+            Number(FEE_AMOUNT_LO_BIT_LENGTH),
+            Number(FEE_AMOUNT_HI_BIT_LENGTH),
+            NET_TRANSFER_AMOUNT_BIT_LENGTH,
+        ]),
+        [
+            newAvailableBalanceOpening,
+            transferAmountOpeningLo,
+            transferAmountOpeningHi,
+            claimedOpening,
+            claimedComplementOpening,
+            feeOpeningLo,
+            feeOpeningHi,
+            netTransferAmountOpening,
+        ],
+    );
+
+    const [
+        equalityProofPlan,
+        transferAmountCiphertextValidityProofPlan,
+        percentageWithCapProofPlan,
+        feeCiphertextValidityProofPlan,
+        rangeProofPlan,
+    ] = await Promise.all([
+        buildContextStateProofPlan(
+            equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            transferAmountCiphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            percentageWithCapProofData.toBytes(),
+            verifyPercentageWithCap,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            feeCiphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext2HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU256, input.payer, input.rpc),
+    ]);
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([
+            equalityProofPlan.setup,
+            transferAmountCiphertextValidityProofPlan.setup,
+            percentageWithCapProofPlan.setup,
+            feeCiphertextValidityProofPlan.setup,
+            rangeProofPlan.setup,
+        ]),
+        getConfidentialTransferWithFeeInstruction(
+            {
+                sourceToken: input.sourceToken,
+                mint: input.mint,
+                destinationToken: input.destinationToken,
+                equalityRecord: equalityProofPlan.address,
+                transferAmountCiphertextValidityRecord: transferAmountCiphertextValidityProofPlan.address,
+                feeSigmaRecord: percentageWithCapProofPlan.address,
+                feeCiphertextValidityRecord: feeCiphertextValidityProofPlan.address,
+                rangeRecord: rangeProofPlan.address,
+                authority: input.authority,
+                newSourceDecryptableAvailableBalance: input.aesKey.encrypt(newAvailableBalance).toBytes(),
+                transferAmountAuditorCiphertextLo,
+                transferAmountAuditorCiphertextHi,
+                equalityProofInstructionOffset: 0,
+                transferAmountCiphertextValidityProofInstructionOffset: 0,
+                feeSigmaProofInstructionOffset: 0,
+                feeCiphertextValidityProofInstructionOffset: 0,
+                rangeProofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: input.programAddress ?? TOKEN_2022_PROGRAM_ADDRESS },
+        ),
+        parallelInstructionPlan([
+            equalityProofPlan.cleanup,
+            transferAmountCiphertextValidityProofPlan.cleanup,
+            percentageWithCapProofPlan.cleanup,
+            feeCiphertextValidityProofPlan.cleanup,
             rangeProofPlan.cleanup,
         ]),
     ]);

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -1,4 +1,11 @@
 import {
+    RECORD_CHUNK_SIZE_POST_INITIALIZE,
+    RECORD_META_DATA_SIZE,
+    createCloseRecordInstruction,
+    createRecord,
+    createWriteInstruction,
+} from '@solana-program/record';
+import {
     closeContextStateProof,
     verifyBatchedGroupedCiphertext2HandlesValidity,
     verifyBatchedGroupedCiphertext3HandlesValidity,
@@ -10,13 +17,6 @@ import {
     verifyPubkeyValidity,
     verifyZeroCiphertext,
 } from '@solana-program/zk-elgamal-proof';
-import {
-    RECORD_CHUNK_SIZE_POST_INITIALIZE,
-    RECORD_META_DATA_SIZE,
-    createCloseRecordInstruction,
-    createRecord,
-    createWriteInstruction,
-} from '@solana-program/record';
 import {
     Address,
     Instruction,
@@ -1257,7 +1257,14 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
             input.payer,
             true,
         ),
-        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU256, input.payer, input.rpc, input.payer, true),
+        buildContextStateProofPlan(
+            rangeProofData.toBytes(),
+            verifyBatchedRangeProofU256,
+            input.payer,
+            input.rpc,
+            input.payer,
+            true,
+        ),
     ]);
 
     return sequentialInstructionPlan([

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -11,8 +11,16 @@ import {
     verifyZeroCiphertext,
 } from '@solana-program/zk-elgamal-proof';
 import {
+    RECORD_CHUNK_SIZE_POST_INITIALIZE,
+    RECORD_META_DATA_SIZE,
+    createCloseRecordInstruction,
+    createRecord,
+    createWriteInstruction,
+} from '@solana-program/record';
+import {
     Address,
     Instruction,
+    KeyPairSigner,
     TransactionSigner,
     generateKeyPairSigner,
     getAddressEncoder,
@@ -20,6 +28,7 @@ import {
     nonDivisibleSequentialInstructionPlan,
     parallelInstructionPlan,
     sequentialInstructionPlan,
+    singleInstructionPlan,
     type GetAccountInfoApi,
     type GetMinimumBalanceForRentExemptionApi,
     type FetchAccountConfig,
@@ -85,6 +94,9 @@ const MAX_FEE_BASIS_POINTS_SUB_ONE = 9_999n;
 const MAX_FEE_BASIS_POINTS = 10_000n;
 const DELTA_BIT_LENGTH = 16;
 const NET_TRANSFER_AMOUNT_BIT_LENGTH = 64;
+const COMPUTE_BUDGET_PROGRAM_ADDRESS =
+    'ComputeBudget111111111111111111111111111111' as Address<'ComputeBudget111111111111111111111111111111'>;
+const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
@@ -105,6 +117,8 @@ type PedersenOpeningConstructorWithArithmetic = typeof PedersenOpening & {
     zero(): PedersenOpening;
     combineLoHi(lo: PedersenOpening, hi: PedersenOpening, bitLength: number): PedersenOpening;
 };
+type ProofDataInput = Uint8Array | { account: Address; offset: number };
+type ContextStateProofPlan = Readonly<{ address: Address; setup: InstructionPlan; cleanup: InstructionPlan }>;
 
 type ContextStateProofMode = {
     /**
@@ -144,6 +158,7 @@ export type GetCreateConfidentialTransferAccountInstructionPlanInput = {
     elgamalKeypair: ElGamalKeypair;
     aesKey: AeKey;
     maximumPendingBalanceCreditCounter?: number | bigint;
+    includeConfidentialTransferFeeAmount?: boolean;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
 };
@@ -496,23 +511,93 @@ function multiplyOpening(opening: PedersenOpening, scalar: bigint): PedersenOpen
     return openingWithArithmetic.multiplyByU64(scalar);
 }
 
+function getRecordWriteInstructions(
+    recordAccount: Address,
+    authority: TransactionSigner,
+    proofData: Uint8Array,
+): Instruction[] {
+    const instructions: Instruction[] = [];
+    for (let offset = 0; offset < proofData.length; offset += RECORD_CHUNK_SIZE_POST_INITIALIZE) {
+        instructions.push(
+            createWriteInstruction({
+                recordAccount,
+                authority,
+                offset: BigInt(offset),
+                data: proofData.slice(offset, offset + RECORD_CHUNK_SIZE_POST_INITIALIZE),
+            }),
+        );
+    }
+    return instructions;
+}
+
+function getSetComputeUnitLimitInstruction(units: number): Instruction {
+    const data = new Uint8Array(5);
+    data[0] = 2;
+    new DataView(data.buffer).setUint32(1, units, true);
+    return { programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS, data };
+}
+
 async function buildContextStateProofPlan(
     proofData: ReadonlyUint8Array,
     verifyAction: (args: {
         rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
         payer: TransactionSigner;
-        proofData: Uint8Array;
+        proofData: ProofDataInput;
         contextState: { contextAccount: Awaited<ReturnType<typeof generateKeyPairSigner>>; authority: Address };
     }) => Promise<Instruction[]>,
     payer: TransactionSigner,
     rpc: Rpc<GetMinimumBalanceForRentExemptionApi>,
     contextStateAuthority: TransactionSigner = payer,
-): Promise<{ address: Address; setup: InstructionPlan; cleanup: Instruction }> {
+    useRecordAccount = false,
+): Promise<ContextStateProofPlan> {
     const contextAccount = await generateKeyPairSigner();
+    const proofDataBytes = new Uint8Array(proofData);
+    if (useRecordAccount) {
+        const recordAuthority = await generateKeyPairSigner();
+        const { recordKeypair, ixs: createRecordInstructions } = await createRecord({
+            rpc,
+            payer: payer as KeyPairSigner,
+            authority: recordAuthority.address,
+            dataLength: BigInt(proofDataBytes.length),
+        });
+        const verifyInstructions = await verifyAction({
+            rpc,
+            payer,
+            proofData: {
+                account: recordKeypair.address,
+                offset: Number(RECORD_META_DATA_SIZE),
+            },
+            contextState: { contextAccount, authority: contextStateAuthority.address },
+        });
+        return {
+            address: contextAccount.address,
+            setup: sequentialInstructionPlan([
+                ...createRecordInstructions,
+                ...getRecordWriteInstructions(recordKeypair.address, recordAuthority, proofDataBytes),
+                nonDivisibleSequentialInstructionPlan([
+                    getSetComputeUnitLimitInstruction(MAX_COMPUTE_UNIT_LIMIT),
+                    ...verifyInstructions,
+                ]),
+            ]),
+            cleanup: sequentialInstructionPlan([
+                closeContextStateProof({
+                    contextState: contextAccount.address,
+                    authority: contextStateAuthority,
+                    destination: payer.address,
+                }),
+                createCloseRecordInstruction({
+                    recordAccount: recordKeypair.address,
+                    authority: recordAuthority,
+                    receiver: payer.address,
+                }),
+            ]),
+        };
+    }
+
     const setupInstructions = await verifyAction({
         rpc,
         payer,
-        proofData: new Uint8Array(proofData),
+        proofData: proofDataBytes,
         contextState: { contextAccount, authority: contextStateAuthority.address },
     });
     return {
@@ -523,11 +608,13 @@ async function buildContextStateProofPlan(
         // transaction planner decides how to pack them; the verify only needs
         // the account to exist, which is true once create-account is confirmed.
         setup: sequentialInstructionPlan(setupInstructions),
-        cleanup: closeContextStateProof({
-            contextState: contextAccount.address,
-            authority: contextStateAuthority,
-            destination: payer.address,
-        }),
+        cleanup: singleInstructionPlan(
+            closeContextStateProof({
+                contextState: contextAccount.address,
+                authority: contextStateAuthority,
+                destination: payer.address,
+            }),
+        ),
     };
 }
 
@@ -535,6 +622,9 @@ async function buildContextStateProofPlan(
  * Returns a single-transaction plan that creates the ATA, reallocates it
  * for the confidential-transfer extension, configures the account, and
  * verifies the ZK pubkey-validity proof.
+ *
+ * Set `includeConfidentialTransferFeeAmount` when configuring accounts for
+ * mints that also include confidential transfer fees.
  */
 export async function getCreateConfidentialTransferAccountInstructionPlan(
     input: GetCreateConfidentialTransferAccountInstructionPlanInput,
@@ -574,7 +664,9 @@ export async function getCreateConfidentialTransferAccountInstructionPlan(
                 token,
                 payer: input.payer,
                 owner: authority,
-                newExtensionTypes: [ExtensionType.ConfidentialTransferAccount],
+                newExtensionTypes: input.includeConfidentialTransferFeeAmount
+                    ? [ExtensionType.ConfidentialTransferAccount, ExtensionType.ConfidentialTransferFeeAmount]
+                    : [ExtensionType.ConfidentialTransferAccount],
                 multiSigners: input.multiSigners,
             },
             { programAddress },
@@ -1138,26 +1230,34 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
             verifyCiphertextCommitmentEquality,
             input.payer,
             input.rpc,
+            input.payer,
+            true,
         ),
         buildContextStateProofPlan(
             transferAmountCiphertextValidityProofData.toBytes(),
             verifyBatchedGroupedCiphertext3HandlesValidity,
             input.payer,
             input.rpc,
+            input.payer,
+            true,
         ),
         buildContextStateProofPlan(
             percentageWithCapProofData.toBytes(),
             verifyPercentageWithCap,
             input.payer,
             input.rpc,
+            input.payer,
+            true,
         ),
         buildContextStateProofPlan(
             feeCiphertextValidityProofData.toBytes(),
             verifyBatchedGroupedCiphertext2HandlesValidity,
             input.payer,
             input.rpc,
+            input.payer,
+            true,
         ),
-        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU256, input.payer, input.rpc),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU256, input.payer, input.rpc, input.payer, true),
     ]);
 
     return sequentialInstructionPlan([

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -8,6 +8,7 @@ import {
     type ReadonlyUint8Array,
 } from '@solana/kit';
 import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
+import * as ZkSdk from '@solana/zk-sdk/bundler';
 
 export type DerivedElGamalKeypair = Readonly<{
     elgamalPubkey: Address;
@@ -21,6 +22,29 @@ async function signDerivationMessage(signer: MessagePartialSigner, message: Uint
         throw new Error(`Signer ${signer.address} did not return a signature`);
     }
     return new Uint8Array(signature);
+}
+
+type ConfidentialKeysInstance = Readonly<{
+    ae(): AeKey;
+    elgamal(): ElGamalKeypair;
+}>;
+type ConfidentialKeysConstructor = Readonly<{
+    fromSignature(signature: Uint8Array): ConfidentialKeysInstance;
+    signerMessage(publicSeed: Uint8Array): Uint8Array;
+}>;
+type LegacyAeKeyConstructor = typeof AeKey &
+    Readonly<{
+        fromSignature?: (signature: Uint8Array) => AeKey;
+        signerMessage?: (publicSeed: Uint8Array) => Uint8Array;
+    }>;
+type LegacyElGamalKeypairConstructor = typeof ElGamalKeypair &
+    Readonly<{
+        fromSignature?: (signature: Uint8Array) => ElGamalKeypair;
+        signerMessage?: (publicSeed: Uint8Array) => Uint8Array;
+    }>;
+
+function getConfidentialKeysConstructor(): ConfidentialKeysConstructor | undefined {
+    return (ZkSdk as unknown as { ConfidentialKeys?: ConfidentialKeysConstructor }).ConfidentialKeys;
 }
 
 function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
@@ -38,9 +62,19 @@ export async function deriveElGamalKeypair({
     signer: MessagePartialSigner;
     publicSeed?: ReadonlyUint8Array;
 }): Promise<DerivedElGamalKeypair> {
-    const message = ElGamalKeypair.signerMessage(new Uint8Array(publicSeed));
+    const confidentialKeys = getConfidentialKeysConstructor();
+    const legacyElGamal = ElGamalKeypair as LegacyElGamalKeypairConstructor;
+    const message =
+        confidentialKeys?.signerMessage(new Uint8Array(publicSeed)) ??
+        legacyElGamal.signerMessage?.(new Uint8Array(publicSeed));
+    if (message == null) {
+        throw new Error('The installed @solana/zk-sdk does not expose confidential key derivation.');
+    }
     const signature = await signDerivationMessage(signer, message);
-    const keypair = ElGamalKeypair.fromSignature(signature);
+    const keypair = confidentialKeys?.fromSignature(signature).elgamal() ?? legacyElGamal.fromSignature?.(signature);
+    if (keypair == null) {
+        throw new Error('The installed @solana/zk-sdk does not expose ElGamal key derivation.');
+    }
     const secretKey = new Uint8Array(keypair.secret().toBytes());
     const elgamalPubkey = getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
     return { elgamalPubkey, secretKey };
@@ -75,9 +109,19 @@ export async function deriveAeKey({
     signer: MessagePartialSigner;
     publicSeed?: ReadonlyUint8Array;
 }): Promise<Uint8Array> {
-    const message = AeKey.signerMessage(new Uint8Array(publicSeed));
+    const confidentialKeys = getConfidentialKeysConstructor();
+    const legacyAeKey = AeKey as LegacyAeKeyConstructor;
+    const message =
+        confidentialKeys?.signerMessage(new Uint8Array(publicSeed)) ??
+        legacyAeKey.signerMessage?.(new Uint8Array(publicSeed));
+    if (message == null) {
+        throw new Error('The installed @solana/zk-sdk does not expose confidential key derivation.');
+    }
     const signature = await signDerivationMessage(signer, message);
-    const aeKey = AeKey.fromSignature(signature);
+    const aeKey = confidentialKeys?.fromSignature(signature).ae() ?? legacyAeKey.fromSignature?.(signature);
+    if (aeKey == null) {
+        throw new Error('The installed @solana/zk-sdk does not expose AES key derivation.');
+    }
     return new Uint8Array(aeKey.toBytes());
 }
 

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -293,6 +293,7 @@ export const createConfidentialTokenAccount = async (input: {
     payer: TransactionSigner;
     owner: TransactionSigner;
     mint: Address;
+    includeConfidentialTransferFeeAmount?: boolean;
 }): Promise<ConfidentialTokenAccount> => {
     const elgamalKeypair = new ElGamalKeypair();
     const aesKey = new AeKey();
@@ -309,6 +310,7 @@ export const createConfidentialTokenAccount = async (input: {
             rpc: input.client.rpc,
             elgamalKeypair,
             aesKey,
+            includeConfidentialTransferFeeAmount: input.includeConfidentialTransferFeeAmount,
         }),
     );
     return { token, elgamalKeypair, aesKey };
@@ -324,6 +326,7 @@ export const createConfidentialTokenAccountWithBalance = async (input: {
     mintAuthority: TransactionSigner;
     decimals: number;
     amount: bigint;
+    includeConfidentialTransferFeeAmount?: boolean;
 }): Promise<ConfidentialTokenAccount> => {
     const account = await createConfidentialTokenAccount(input);
 

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
@@ -7,7 +7,14 @@ import {
     some,
     type ReadonlyUint8Array,
 } from '@solana/kit';
-import { AeCiphertext, AeKey, ElGamalCiphertext, ElGamalKeypair } from '@solana/zk-sdk/bundler';
+import {
+    AeCiphertext,
+    AeKey,
+    ElGamalCiphertext,
+    ElGamalKeypair,
+    PedersenCommitment,
+    PedersenOpening,
+} from '@solana/zk-sdk/bundler';
 import { expect, it } from 'vitest';
 
 import { ExtensionArgs, Token, extension, fetchMint, fetchToken } from '../../../src';
@@ -57,6 +64,23 @@ function decryptWithheldAmount(tokenAccount: Token, withdrawWithheldAuthorityElG
     const confidentialTransferFeeAmount = getTokenExtension(tokenAccount, 'ConfidentialTransferFeeAmount');
     const ciphertext = parseElGamalCiphertext(confidentialTransferFeeAmount.withheldAmount);
     return withdrawWithheldAuthorityElGamalKeypair.secret().decrypt(ciphertext);
+}
+
+function hasPedersenArithmetic() {
+    const opening = new PedersenOpening() as PedersenOpening & Record<string, unknown>;
+    const commitment = PedersenCommitment.from(0n, new PedersenOpening()) as PedersenCommitment &
+        Record<string, unknown>;
+    const PedersenOpeningConstructor = PedersenOpening as unknown as Record<string, unknown>;
+    const PedersenCommitmentConstructor = PedersenCommitment as unknown as Record<string, unknown>;
+    return (
+        typeof PedersenOpeningConstructor.zero === 'function' &&
+        typeof PedersenOpeningConstructor.combineLoHi === 'function' &&
+        typeof opening.subtract === 'function' &&
+        typeof opening.multiplyByU64 === 'function' &&
+        typeof PedersenCommitmentConstructor.combineLoHi === 'function' &&
+        typeof commitment.subtract === 'function' &&
+        typeof commitment.multiplyByU64 === 'function'
+    );
 }
 
 async function createConfidentialTransferFeeMint(input: {
@@ -158,23 +182,28 @@ it('transfers tokens confidentially with fees', async () => {
             fetchMint(client.rpc, mint),
             client.rpc.getEpochInfo().send(),
         ]);
-    await client.sendTransactions(
-        await getConfidentialTransferWithFeeInstructionPlan({
-            payer,
-            rpc: client.rpc,
-            sourceToken: source.token,
-            mint,
-            destinationToken: destination.token,
-            sourceTokenAccount,
-            destinationTokenAccount,
-            mintAccount,
-            currentEpoch: epochInfo.epoch,
-            authority: sourceOwner,
-            amount: 200n,
-            sourceElgamalKeypair: source.elgamalKeypair,
-            aesKey: source.aesKey,
-        }),
-    );
+    const transferPlanPromise = getConfidentialTransferWithFeeInstructionPlan({
+        payer,
+        rpc: client.rpc,
+        sourceToken: source.token,
+        mint,
+        destinationToken: destination.token,
+        sourceTokenAccount,
+        destinationTokenAccount,
+        mintAccount,
+        currentEpoch: epochInfo.epoch,
+        authority: sourceOwner,
+        amount: 200n,
+        sourceElgamalKeypair: source.elgamalKeypair,
+        aesKey: source.aesKey,
+    });
+    if (!hasPedersenArithmetic()) {
+        await expect(transferPlanPromise).rejects.toThrow(
+            'Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.',
+        );
+        return;
+    }
+    await client.sendTransactions(await transferPlanPromise);
 
     // Then the source is debited by the gross amount, the destination receives the net amount,
     // and the confidential fee amount is withheld on the destination account.

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
@@ -17,7 +17,7 @@ import {
 } from '@solana/zk-sdk/bundler';
 import { expect, it } from 'vitest';
 
-import { ExtensionArgs, Token, extension, fetchMint, fetchToken } from '../../../src';
+import { ExtensionArgs, Mint, Token, extension, fetchMint, fetchToken } from '../../../src';
 import { getConfidentialTransferWithFeeInstructionPlan } from '../../../src/confidential';
 import {
     createConfidentialTokenAccount,
@@ -27,6 +27,9 @@ import {
     getTokenExtension,
     type ValidatorClient,
 } from '../../_setup';
+
+const PEDERSEN_ARITHMETIC_ERROR =
+    'Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment and opening arithmetic.';
 
 function elgamalPubkeyAsAddress(keypair: ElGamalKeypair): Address {
     return getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
@@ -198,9 +201,10 @@ it('transfers tokens confidentially with fees', async () => {
         aesKey: source.aesKey,
     });
     if (!hasPedersenArithmetic()) {
-        await expect(transferPlanPromise).rejects.toThrow(
-            'Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment arithmetic.',
-        );
+        // Published @solana/zk-sdk@0.4.2 does not expose the Pedersen arithmetic
+        // needed for the success path. Once it does, this test runs through the
+        // full transfer and balance assertions below.
+        await expect(transferPlanPromise).rejects.toThrow(PEDERSEN_ARITHMETIC_ERROR);
         return;
     }
     await client.sendTransactions(await transferPlanPromise);
@@ -215,4 +219,48 @@ it('transfers tokens confidentially with fees', async () => {
     expect(decryptPendingBalance(updatedDestination, destination.elgamalKeypair)).toBe(197n);
     expect(decryptWithheldAmount(updatedDestination, withdrawWithheldAuthorityElGamalKeypair)).toBe(3n);
     expect(getTokenExtension(updatedDestination, 'ConfidentialTransferAccount').pendingBalanceCreditCounter).toBe(1n);
+});
+
+it('rejects when the fee exceeds the transfer amount', async () => {
+    const [payer, sourceToken, mint, destinationToken] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const elgamalKeypair = new ElGamalKeypair();
+    const sourceTokenAccount = {
+        extensions: some([{ __kind: 'ConfidentialTransferAccount' }]),
+    } as Token;
+    const mintAccount = {
+        extensions: some([
+            {
+                __kind: 'TransferFeeConfig',
+                olderTransferFee: { epoch: 0n, maximumFee: 1_000n, transferFeeBasisPoints: 20_000 },
+                newerTransferFee: { epoch: 0n, maximumFee: 1_000n, transferFeeBasisPoints: 20_000 },
+            },
+            {
+                __kind: 'ConfidentialTransferFee',
+                elgamalPubkey: elgamalPubkeyAsAddress(elgamalKeypair),
+            },
+        ]),
+    } as Mint;
+
+    await expect(
+        getConfidentialTransferWithFeeInstructionPlan({
+            payer,
+            rpc: {} as ValidatorClient['rpc'],
+            sourceToken: sourceToken.address,
+            mint: mint.address,
+            destinationToken: destinationToken.address,
+            sourceTokenAccount,
+            destinationElgamalPubkey: elgamalPubkeyAsAddress(elgamalKeypair),
+            mintAccount,
+            currentEpoch: 0n,
+            authority: payer,
+            amount: 1n,
+            sourceElgamalKeypair: elgamalKeypair,
+            aesKey: new AeKey(),
+        }),
+    ).rejects.toThrow('Fee exceeds transfer amount.');
 });

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
@@ -140,12 +140,14 @@ it('transfers tokens confidentially with fees', async () => {
         mintAuthority,
         decimals,
         amount: 1000n,
+        includeConfidentialTransferFeeAmount: true,
     });
     const destination = await createConfidentialTokenAccount({
         client,
         payer,
         owner: destinationOwner,
         mint,
+        includeConfidentialTransferFeeAmount: true,
     });
 
     // When the source confidentially transfers 2.00 tokens with a 1.5% fee.

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
@@ -1,0 +1,187 @@
+import {
+    Address,
+    TransactionSigner,
+    generateKeyPairSigner,
+    getAddressDecoder,
+    none,
+    some,
+    type ReadonlyUint8Array,
+} from '@solana/kit';
+import { AeCiphertext, AeKey, ElGamalCiphertext, ElGamalKeypair } from '@solana/zk-sdk/bundler';
+import { expect, it } from 'vitest';
+
+import { ExtensionArgs, Token, extension, fetchMint, fetchToken } from '../../../src';
+import { getConfidentialTransferWithFeeInstructionPlan } from '../../../src/confidential';
+import {
+    createConfidentialTokenAccount,
+    createConfidentialTokenAccountWithBalance,
+    createValidatorClient,
+    generateKeyPairSignerWithSol,
+    getTokenExtension,
+    type ValidatorClient,
+} from '../../_setup';
+
+function elgamalPubkeyAsAddress(keypair: ElGamalKeypair): Address {
+    return getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
+}
+
+function parseElGamalCiphertext(bytes: ReadonlyUint8Array) {
+    const ciphertext = ElGamalCiphertext.fromBytes(new Uint8Array(bytes));
+    if (!ciphertext) {
+        throw new Error('Failed to deserialize ElGamal ciphertext.');
+    }
+    return ciphertext;
+}
+
+function decryptAvailableBalance(tokenAccount: Token, aesKey: AeKey) {
+    const confidentialTransferAccount = getTokenExtension(tokenAccount, 'ConfidentialTransferAccount');
+    const ciphertext = AeCiphertext.fromBytes(new Uint8Array(confidentialTransferAccount.decryptableAvailableBalance));
+    if (!ciphertext) {
+        throw new Error('Failed to deserialize decryptable available balance.');
+    }
+    return aesKey.decrypt(ciphertext);
+}
+
+function decryptPendingBalance(tokenAccount: Token, elgamalKeypair: ElGamalKeypair) {
+    const confidentialTransferAccount = getTokenExtension(tokenAccount, 'ConfidentialTransferAccount');
+    const amountLo = elgamalKeypair
+        .secret()
+        .decrypt(parseElGamalCiphertext(confidentialTransferAccount.pendingBalanceLow));
+    const amountHi = elgamalKeypair
+        .secret()
+        .decrypt(parseElGamalCiphertext(confidentialTransferAccount.pendingBalanceHigh));
+    return (amountHi << 16n) + amountLo;
+}
+
+function decryptWithheldAmount(tokenAccount: Token, withdrawWithheldAuthorityElGamalKeypair: ElGamalKeypair) {
+    const confidentialTransferFeeAmount = getTokenExtension(tokenAccount, 'ConfidentialTransferFeeAmount');
+    const ciphertext = parseElGamalCiphertext(confidentialTransferFeeAmount.withheldAmount);
+    return withdrawWithheldAuthorityElGamalKeypair.secret().decrypt(ciphertext);
+}
+
+async function createConfidentialTransferFeeMint(input: {
+    client: ValidatorClient;
+    payer: TransactionSigner;
+    decimals: number;
+    maximumFee: bigint;
+    transferFeeBasisPoints: number;
+}): Promise<{
+    mint: Address;
+    mintAuthority: TransactionSigner;
+    withdrawWithheldAuthorityElGamalKeypair: ElGamalKeypair;
+}> {
+    const [mintAuthority, mint, confidentialTransferAuthority] = await Promise.all([
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+        generateKeyPairSigner(),
+    ]);
+    const transferFees = {
+        epoch: 0n,
+        maximumFee: input.maximumFee,
+        transferFeeBasisPoints: input.transferFeeBasisPoints,
+    };
+    const withdrawWithheldAuthorityElGamalKeypair = new ElGamalKeypair();
+    const withdrawWithheldAuthorityElGamalPubkey = elgamalPubkeyAsAddress(withdrawWithheldAuthorityElGamalKeypair);
+    const extensions: ExtensionArgs[] = [
+        extension('TransferFeeConfig', {
+            transferFeeConfigAuthority: confidentialTransferAuthority.address,
+            withdrawWithheldAuthority: confidentialTransferAuthority.address,
+            withheldAmount: 0n,
+            olderTransferFee: transferFees,
+            newerTransferFee: transferFees,
+        }),
+        extension('ConfidentialTransferMint', {
+            authority: some(confidentialTransferAuthority.address),
+            autoApproveNewAccounts: true,
+            auditorElgamalPubkey: none(),
+        }),
+        extension('ConfidentialTransferFee', {
+            authority: some(confidentialTransferAuthority.address),
+            elgamalPubkey: withdrawWithheldAuthorityElGamalPubkey,
+            harvestToMintEnabled: true,
+            withheldAmount: new Uint8Array(64).fill(0),
+        }),
+    ];
+
+    await input.client.token2022.instructions
+        .createMint({
+            payer: input.payer,
+            newMint: mint,
+            decimals: input.decimals,
+            mintAuthority,
+            extensions,
+        })
+        .sendTransaction();
+
+    return { mint: mint.address, mintAuthority, withdrawWithheldAuthorityElGamalKeypair };
+}
+
+it('transfers tokens confidentially with fees', async () => {
+    // Given a confidential-transfer-fee mint, a funded source account, and an empty destination account.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const [sourceOwner, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const decimals = 2;
+    const { mint, mintAuthority, withdrawWithheldAuthorityElGamalKeypair } = await createConfidentialTransferFeeMint({
+        client,
+        payer,
+        decimals,
+        maximumFee: 1_000_000_000n,
+        transferFeeBasisPoints: 150,
+    });
+    const source = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner: sourceOwner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const destination = await createConfidentialTokenAccount({
+        client,
+        payer,
+        owner: destinationOwner,
+        mint,
+    });
+
+    // When the source confidentially transfers 2.00 tokens with a 1.5% fee.
+    const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }, { data: mintAccount }, epochInfo] =
+        await Promise.all([
+            fetchToken(client.rpc, source.token),
+            fetchToken(client.rpc, destination.token),
+            fetchMint(client.rpc, mint),
+            client.rpc.getEpochInfo().send(),
+        ]);
+    await client.sendTransactions(
+        await getConfidentialTransferWithFeeInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            sourceToken: source.token,
+            mint,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            mintAccount,
+            currentEpoch: epochInfo.epoch,
+            authority: sourceOwner,
+            amount: 200n,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+        }),
+    );
+
+    // Then the source is debited by the gross amount, the destination receives the net amount,
+    // and the confidential fee amount is withheld on the destination account.
+    const [{ data: updatedSource }, { data: updatedDestination }] = await Promise.all([
+        fetchToken(client.rpc, source.token),
+        fetchToken(client.rpc, destination.token),
+    ]);
+    expect(decryptAvailableBalance(updatedSource, source.aesKey)).toBe(800n);
+    expect(decryptPendingBalance(updatedDestination, destination.elgamalKeypair)).toBe(197n);
+    expect(decryptWithheldAmount(updatedDestination, withdrawWithheldAuthorityElGamalKeypair)).toBe(3n);
+    expect(getTokenExtension(updatedDestination, 'ConfidentialTransferAccount').pendingBalanceCreditCounter).toBe(1n);
+});


### PR DESCRIPTION
Adds `getConfidentialTransferWithFeeInstructionPlan` to the JS client.

This is the fee-aware confidential transfer helper for browser/native JS clients. It builds the proof context accounts the program expects, reads the active fee parameters from the decoded mint, and stages the oversized U256 range proof through SPL Record so the final transfer can fit in a transaction.

This depends on solana-program/zk-elgamal-proof#440. The fee path has to derive Pedersen openings for the net transfer amount, fee amount, percentage-with-cap delta, and remaining available balance. Published `@solana/zk-sdk@0.4.2` does not expose the opening arithmetic needed to do that in browser JS.
