### PR TITLE
Interface publish follow up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10929,7 +10929,7 @@ dependencies = [
  "spl-elgamal-registry-interface",
  "spl-memo-interface",
  "spl-tlv-account-resolution",
- "spl-token-2022-interface 3.0.1",
+ "spl-token-2022-interface 3.1.0",
  "spl-token-confidential-transfer-ciphertext-arithmetic",
  "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-group-interface",
@@ -10969,7 +10969,7 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022-interface"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -10993,7 +10993,7 @@ dependencies = [
  "solana-zero-copy",
  "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk-pod",
- "spl-token-2022-interface 3.0.1",
+ "spl-token-2022-interface 3.1.0",
  "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-group-interface",
  "spl-token-interface 3.0.0",
@@ -11038,7 +11038,7 @@ dependencies = [
  "spl-memo-interface",
  "spl-record",
  "spl-token-2022",
- "spl-token-2022-interface 3.0.1",
+ "spl-token-2022-interface 3.1.0",
  "spl-token-client",
  "spl-token-confidential-transfer-proof-generation 0.6.1",
  "spl-token-group-interface",
@@ -11092,7 +11092,7 @@ dependencies = [
  "spl-record",
  "spl-tlv-account-resolution",
  "spl-token-2022",
- "spl-token-2022-interface 3.0.1",
+ "spl-token-2022-interface 3.1.0",
  "spl-token-client",
  "spl-token-confidential-transfer-proof-extraction 0.6.1",
  "spl-token-confidential-transfer-proof-generation 0.6.1",

--- a/clients/cli/Cargo.toml
+++ b/clients/cli/Cargo.toml
@@ -37,7 +37,7 @@ spl-associated-token-account-interface = { version = "2.0.0" }
 spl-memo-interface = "2.1.0"
 spl-record = { version = "0.4.0", features = ["no-entrypoint"] }
 spl-token-interface = "3.0.0"
-spl-token-2022-interface = { version = "3.0.0", path = "../../interface" }
+spl-token-2022-interface = { version = "3.1.0", path = "../../interface" }
 spl-token-2022 = { version = "11.0.0", path = "../../program", features = ["no-entrypoint"] }
 spl-token-client = { version = "0.19.0", path = "../rust-legacy" }
 spl-token-confidential-transfer-proof-generation = { version = "0.6.0", path = "../../confidential/proof-generation" }

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -52,7 +52,7 @@ spl-record = { version = "0.4.0", features = ["no-entrypoint"] }
 spl-token-interface = "3.0.0"
 spl-token-confidential-transfer-proof-extraction = { path = "../../confidential/proof-extraction", version = "0.6.0" }
 spl-token-confidential-transfer-proof-generation = { path = "../../confidential/proof-generation", version = "0.6.0" }
-spl-token-2022-interface = { version = "3.0.0", path = "../../interface" }
+spl-token-2022-interface = { version = "3.1.0", path = "../../interface" }
 spl-token-2022 = { version = "11.0.0", path = "../../program", features = ["no-entrypoint"] }
 spl-token-group-interface = "0.7.2"
 spl-token-metadata-interface = "1.0.0"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spl-token-2022-interface"
-version = "3.0.1"
+version = "3.1.0"
 description = "Solana Program Library Token 2022 Interface"
 documentation = "https://docs.rs/spl-token-2022-interface"
 readme = "README.md"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -42,7 +42,7 @@ solana-zk-sdk-pod = "0.1.2"
 solana-zk-elgamal-proof-interface = "0.1.2"
 spl-elgamal-registry-interface = { version = "0.2.0", path = "../confidential/elgamal-registry-interface" }
 spl-memo-interface = { version = "2.1" }
-spl-token-2022-interface = { version = "3.0.0", path = "../interface" }
+spl-token-2022-interface = { version = "3.1.0", path = "../interface" }
 spl-token-confidential-transfer-ciphertext-arithmetic = { version = "0.5.0", path = "../confidential/ciphertext-arithmetic" }
 spl-token-confidential-transfer-proof-extraction = { version = "0.6.0", path = "../confidential/proof-extraction" }
 spl-token-group-interface = "0.7.2"


### PR DESCRIPTION
Reference: https://github.com/solana-program/token-2022/actions/runs/27691488565/job/81904551601

Interface crate had a [successful publish](https://crates.io/crates/spl-token-2022-interface/3.1.0), but the crate released failed after it noticed another commit came ahead of it (https://github.com/solana-program/token-2022/commit/d259b422200e9f049dafd2e7273fc6bf4e5ca365) before the publish job was approved. At the moment, the publish job is not atomic so we need to do a bit of recovery here with the versions.

Next up, will manually create a release for interface@3.1.0 in the UI. 