### PR TITLE
feat(clients/js): add confidential balance and empty account helpers

### DIFF
--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -5,6 +5,7 @@ import {
     verifyBatchedRangeProofU64,
     verifyCiphertextCommitmentEquality,
     verifyPubkeyValidity,
+    verifyZeroCiphertext,
 } from '@solana-program/zk-elgamal-proof';
 import {
     Address,
@@ -17,6 +18,7 @@ import {
     parallelInstructionPlan,
     sequentialInstructionPlan,
     type GetMinimumBalanceForRentExemptionApi,
+    type FetchAccountConfig,
     type InstructionPlan,
     type ReadonlyUint8Array,
     type Rpc,
@@ -36,6 +38,7 @@ import {
     PedersenCommitment,
     PedersenOpening,
     PubkeyValidityProofData,
+    ZeroCiphertextProofData,
 } from '@solana/zk-sdk/bundler';
 
 import {
@@ -54,7 +57,9 @@ import {
     getConfidentialWithdrawInstruction,
     getConfigureConfidentialTransferAccountInstruction,
     getCreateAssociatedTokenIdempotentInstruction,
+    getEmptyConfidentialTransferAccountInstruction,
     getReallocateInstruction,
+    fetchToken,
 } from './generated';
 
 const DEFAULT_MAXIMUM_PENDING_BALANCE_CREDIT_COUNTER = 1n << 16n;
@@ -104,6 +109,28 @@ export type GetApplyConfidentialPendingBalanceInstructionFromTokenInput = {
     programAddress?: Address;
 };
 
+export type DecryptConfidentialTransferBalanceInput = {
+    tokenAccount: Token;
+    elgamalSecretKey: ElGamalSecretKey;
+    aesKey: AeKey;
+};
+
+export type FetchConfidentialTransferBalanceInput = Omit<DecryptConfidentialTransferBalanceInput, 'tokenAccount'> & {
+    token: Address;
+    rpc: Parameters<typeof fetchToken>[0];
+    config?: FetchAccountConfig;
+};
+
+export type ConfidentialTransferBalance = {
+    availableBalance: bigint;
+    pendingBalance: bigint;
+    totalBalance: bigint;
+    pendingBalanceCreditCounter: bigint;
+    maximumPendingBalanceCreditCounter: bigint;
+    expectedPendingBalanceCreditCounter: bigint;
+    actualPendingBalanceCreditCounter: bigint;
+};
+
 type GetConfidentialWithdrawInstructionPlanBaseInput = {
     token: Address;
     mint: Address;
@@ -119,6 +146,15 @@ type GetConfidentialWithdrawInstructionPlanBaseInput = {
 
 export type GetConfidentialWithdrawInstructionPlanInput = GetConfidentialWithdrawInstructionPlanBaseInput &
     ContextStateProofMode;
+
+export type GetEmptyConfidentialTransferAccountInstructionPlanInput = {
+    token: Address;
+    tokenAccount: Token;
+    authority: Address | TransactionSigner;
+    elgamalKeypair: ElGamalKeypair;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+} & ContextStateProofMode;
 
 type GetConfidentialTransferInstructionPlanBaseInput = {
     sourceToken: Address;
@@ -215,6 +251,12 @@ function combineAmounts(amountLo: bigint, amountHi: bigint, bitLength: bigint): 
 
 function decryptAvailableBalance(account: ConfidentialTransferAccountExtension, aesKey: AeKey) {
     return aesKey.decrypt(parseAeCiphertext(account.decryptableAvailableBalance));
+}
+
+function decryptPendingBalance(account: ConfidentialTransferAccountExtension, elgamalSecretKey: ElGamalSecretKey) {
+    const pendingBalanceLo = elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceLow));
+    const pendingBalanceHi = elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceHigh));
+    return combineAmounts(pendingBalanceLo, pendingBalanceHi, PENDING_BALANCE_LO_BIT_LENGTH);
 }
 
 function assertCreateHelperOwnerMatchesAuthority(
@@ -351,6 +393,40 @@ export async function getCreateConfidentialTransferAccountInstructionPlan(
 }
 
 /**
+ * Decrypts a decoded token account's confidential-transfer balances.
+ */
+export function decryptConfidentialTransferBalance(
+    input: DecryptConfidentialTransferBalanceInput,
+): ConfidentialTransferBalance {
+    const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
+    const availableBalance = decryptAvailableBalance(account, input.aesKey);
+    const pendingBalance = decryptPendingBalance(account, input.elgamalSecretKey);
+    return {
+        availableBalance,
+        pendingBalance,
+        totalBalance: availableBalance + pendingBalance,
+        pendingBalanceCreditCounter: account.pendingBalanceCreditCounter,
+        maximumPendingBalanceCreditCounter: account.maximumPendingBalanceCreditCounter,
+        expectedPendingBalanceCreditCounter: account.expectedPendingBalanceCreditCounter,
+        actualPendingBalanceCreditCounter: account.actualPendingBalanceCreditCounter,
+    };
+}
+
+/**
+ * Fetches a token account and decrypts its confidential-transfer balances.
+ */
+export async function fetchConfidentialTransferBalance(
+    input: FetchConfidentialTransferBalanceInput,
+): Promise<ConfidentialTransferBalance> {
+    const { data: tokenAccount } = await fetchToken(input.rpc, input.token, input.config);
+    return decryptConfidentialTransferBalance({
+        tokenAccount,
+        elgamalSecretKey: input.elgamalSecretKey,
+        aesKey: input.aesKey,
+    });
+}
+
+/**
  * Builds an `ApplyPendingBalance` instruction plan from a decoded token
  * account, decrypting the pending balance and re-encrypting the new
  * available balance locally.
@@ -359,13 +435,9 @@ export function getApplyConfidentialPendingBalanceInstructionFromToken(
     input: GetApplyConfidentialPendingBalanceInstructionFromTokenInput,
 ): Instruction {
     const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
-    const pendingBalanceLo = input.elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceLow));
-    const pendingBalanceHi = input.elgamalSecretKey.decrypt(parseElGamalCiphertext(account.pendingBalanceHigh));
+    const pendingBalance = decryptPendingBalance(account, input.elgamalSecretKey);
     const newDecryptableAvailableBalance = input.aesKey
-        .encrypt(
-            decryptAvailableBalance(account, input.aesKey) +
-                combineAmounts(pendingBalanceLo, pendingBalanceHi, PENDING_BALANCE_LO_BIT_LENGTH),
-        )
+        .encrypt(decryptAvailableBalance(account, input.aesKey) + pendingBalance)
         .toBytes();
 
     return getApplyConfidentialPendingBalanceInstruction(
@@ -378,6 +450,41 @@ export function getApplyConfidentialPendingBalanceInstructionFromToken(
         },
         { programAddress: getTokenProgramAddress(input.programAddress) },
     );
+}
+
+/**
+ * Returns an instruction plan that empties the confidential-transfer
+ * extension state once the available encrypted balance decrypts to zero.
+ */
+export async function getEmptyConfidentialTransferAccountInstructionPlan(
+    input: GetEmptyConfidentialTransferAccountInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
+    const zeroCiphertextProofData = new ZeroCiphertextProofData(
+        input.elgamalKeypair,
+        parseElGamalCiphertext(account.availableBalance),
+    );
+    const proofPlan = await buildContextStateProofPlan(
+        zeroCiphertextProofData.toBytes(),
+        verifyZeroCiphertext,
+        input.payer,
+        input.rpc,
+    );
+
+    return sequentialInstructionPlan([
+        proofPlan.setup,
+        getEmptyConfidentialTransferAccountInstruction(
+            {
+                token: input.token,
+                instructionsSysvarOrContextState: proofPlan.address,
+                authority: input.authority,
+                proofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: getTokenProgramAddress(input.programAddress) },
+        ),
+        proofPlan.cleanup,
+    ]);
 }
 
 /**

--- a/clients/js/test/extensions/confidentialTransfer/decryptConfidentialTransferBalance.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/decryptConfidentialTransferBalance.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from 'vitest';
+
+import { fetchToken, getConfidentialDepositInstruction, getMintToInstruction } from '../../../src';
+import { decryptConfidentialTransferBalance, fetchConfidentialTransferBalance } from '../../../src/confidential';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccountWithBalance,
+    createValidatorClient,
+    generateKeyPairSignerWithSol,
+} from '../../_setup';
+
+it('decrypts available and pending confidential balances', async () => {
+    // Given a confidential token account with available and pending balances.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const owner = await generateKeyPairSignerWithSol(client);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
+    const decimals = 2;
+    const account = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    await client.sendTransaction([
+        getMintToInstruction({ mint, token: account.token, mintAuthority, amount: 250n }),
+        getConfidentialDepositInstruction({ token: account.token, mint, authority: owner, amount: 250n, decimals }),
+    ]);
+
+    // When the decoded account is decrypted locally.
+    const { data: tokenAccount } = await fetchToken(client.rpc, account.token);
+    const balance = decryptConfidentialTransferBalance({
+        tokenAccount,
+        elgamalSecretKey: account.elgamalKeypair.secret(),
+        aesKey: account.aesKey,
+    });
+
+    // Then the helper reports available, pending, and total confidential balances.
+    expect(balance.availableBalance).toBe(1000n);
+    expect(balance.pendingBalance).toBe(250n);
+    expect(balance.totalBalance).toBe(1250n);
+    expect(balance.pendingBalanceCreditCounter).toBe(1n);
+
+    await expect(
+        fetchConfidentialTransferBalance({
+            rpc: client.rpc,
+            token: account.token,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }),
+    ).resolves.toEqual(balance);
+});

--- a/clients/js/test/extensions/confidentialTransfer/getEmptyConfidentialTransferAccountInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getEmptyConfidentialTransferAccountInstructionPlan.test.ts
@@ -1,0 +1,73 @@
+import { expect, it } from 'vitest';
+
+import { fetchToken } from '../../../src';
+import {
+    decryptConfidentialTransferBalance,
+    getConfidentialWithdrawInstructionPlan,
+    getEmptyConfidentialTransferAccountInstructionPlan,
+} from '../../../src/confidential';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccountWithBalance,
+    createValidatorClient,
+    generateKeyPairSignerWithSol,
+    getTokenExtension,
+} from '../../_setup';
+
+it('empties a zero confidential available balance for account closing', async () => {
+    // Given a confidential token account whose confidential balance was fully withdrawn.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const owner = await generateKeyPairSignerWithSol(client);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
+    const decimals = 2;
+    const account = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const { data: fundedTokenAccount } = await fetchToken(client.rpc, account.token);
+    await client.sendTransactions(
+        await getConfidentialWithdrawInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: account.token,
+            mint,
+            tokenAccount: fundedTokenAccount,
+            authority: owner,
+            amount: 1000n,
+            decimals,
+            elgamalKeypair: account.elgamalKeypair,
+            aesKey: account.aesKey,
+        }),
+    );
+
+    // When the confidential account is emptied.
+    const { data: withdrawnTokenAccount } = await fetchToken(client.rpc, account.token);
+    expect(
+        decryptConfidentialTransferBalance({
+            tokenAccount: withdrawnTokenAccount,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }).availableBalance,
+    ).toBe(0n);
+    await client.sendTransactions(
+        await getEmptyConfidentialTransferAccountInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: account.token,
+            tokenAccount: withdrawnTokenAccount,
+            authority: owner,
+            elgamalKeypair: account.elgamalKeypair,
+        }),
+    );
+
+    // Then the available-balance ciphertext is reset to its all-zero closable state.
+    const { data: emptiedTokenAccount } = await fetchToken(client.rpc, account.token);
+    const confidentialAccount = getTokenExtension(emptiedTokenAccount, 'ConfidentialTransferAccount');
+    expect(confidentialAccount.availableBalance).toEqual(new Uint8Array(64).fill(0));
+});


### PR DESCRIPTION
Adds small JS helpers for confidential-transfer account lifecycle work:

- `decryptConfidentialTransferBalance` for decoded token accounts
- `fetchConfidentialTransferBalance` for fetching and decrypting by token address
- `getEmptyConfidentialTransferAccountInstructionPlan` for proving the available encrypted balance is zero and clearing the confidential-transfer account state before close flows
