### PR TITLE
clients-js: Derive confidential transfer auditor from mint

### DIFF
--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -16,6 +16,7 @@ import {
     nonDivisibleSequentialInstructionPlan,
     parallelInstructionPlan,
     sequentialInstructionPlan,
+    type GetAccountInfoApi,
     type GetMinimumBalanceForRentExemptionApi,
     type InstructionPlan,
     type ReadonlyUint8Array,
@@ -46,8 +47,10 @@ import {
 import {
     ExtensionType,
     Extension,
+    Mint,
     TOKEN_2022_PROGRAM_ADDRESS,
     Token,
+    fetchMint,
     findAssociatedTokenPda,
     getApplyConfidentialPendingBalanceInstruction,
     getConfidentialTransferInstruction,
@@ -65,6 +68,7 @@ const REMAINING_BALANCE_BIT_LENGTH = 64;
 const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
 
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
+type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
 
 type ContextStateProofMode = {
     /**
@@ -78,6 +82,20 @@ type ContextStateProofMode = {
     proofMode?: 'context-state';
     payer: TransactionSigner;
     rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+};
+
+type ConfidentialTransferContextStateProofMode = {
+    /**
+     * The strategy used to provide zero-knowledge proofs to the program.
+     *
+     * Currently, only `context-state` is supported, where each proof is verified
+     * into a dedicated context-state account before the instruction is executed.
+     * Additional modes — such as `instruction-data`, where proofs are provided
+     * inline within the same transaction — may be supported in the future.
+     */
+    proofMode?: 'context-state';
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi & GetAccountInfoApi>;
 };
 
 export type GetCreateConfidentialTransferAccountInstructionPlanInput = {
@@ -138,7 +156,7 @@ type GetConfidentialTransferInstructionPlanBaseInput = {
 );
 
 export type GetConfidentialTransferInstructionPlanInput = GetConfidentialTransferInstructionPlanBaseInput &
-    ContextStateProofMode;
+    ConfidentialTransferContextStateProofMode;
 
 function getTokenProgramAddress(programAddress?: Address) {
     return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
@@ -167,6 +185,21 @@ function getRequiredConfidentialTransferAccountExtension(tokenAccount: Token): C
     return extension;
 }
 
+function getRequiredConfidentialTransferMintExtension(mint: Mint): ConfidentialTransferMintExtension {
+    if (!isSome(mint.extensions)) {
+        throw new Error('Mint account is missing extensions.');
+    }
+
+    const extension = mint.extensions.value.find(candidate => candidate.__kind === 'ConfidentialTransferMint') as
+        | ConfidentialTransferMintExtension
+        | undefined;
+    if (!extension) {
+        throw new Error('Mint account is missing the ConfidentialTransferMint extension.');
+    }
+
+    return extension;
+}
+
 function parseAeCiphertext(bytes: ReadonlyUint8Array) {
     const ciphertext = AeCiphertext.fromBytes(new Uint8Array(bytes));
     if (!ciphertext) {
@@ -189,6 +222,18 @@ function getElGamalPubkeyFromAddress(value: Address) {
 
 function getDefaultAuditorElGamalPubkey() {
     return ElGamalPubkey.fromBytes(new Uint8Array(32));
+}
+
+async function getAuditorElGamalPubkey(input: GetConfidentialTransferInstructionPlanInput) {
+    if (input.auditorElgamalPubkey) {
+        return getElGamalPubkeyFromAddress(input.auditorElgamalPubkey);
+    }
+
+    const { data: mint } = await fetchMint(input.rpc, input.mint);
+    const extension = getRequiredConfidentialTransferMintExtension(mint);
+    return isSome(extension.auditorElgamalPubkey)
+        ? getElGamalPubkeyFromAddress(extension.auditorElgamalPubkey.value)
+        : getDefaultAuditorElGamalPubkey();
 }
 
 function getDestinationElGamalPubkey(input: GetConfidentialTransferInstructionPlanInput) {
@@ -461,9 +506,7 @@ export async function getConfidentialTransferInstructionPlan(
 
     const sourcePubkey = input.sourceElgamalKeypair.pubkey();
     const destinationPubkey = getDestinationElGamalPubkey(input);
-    const auditorPubkey = input.auditorElgamalPubkey
-        ? getElGamalPubkeyFromAddress(input.auditorElgamalPubkey)
-        : getDefaultAuditorElGamalPubkey();
+    const auditorPubkey = await getAuditorElGamalPubkey(input);
 
     const openingLo = new PedersenOpening();
     const openingHi = new PedersenOpening();

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -141,8 +141,20 @@ export type GetConfidentialWithdrawInstructionPlanInput = GetConfidentialWithdra
 type GetConfidentialTransferInstructionPlanBaseInput = {
     sourceToken: Address;
     mint: Address;
+    /**
+     * Decoded mint account used to resolve the configured auditor key when
+     * `auditorElgamalPubkey` is omitted. Supplying this avoids an extra mint
+     * fetch for callers that already have the mint account loaded.
+     */
+    mintAccount?: Mint;
     destinationToken: Address;
     sourceTokenAccount: Token;
+    /**
+     * Auditor ElGamal public key to use for the auditor ciphertexts. When
+     * omitted, the helper resolves the key from `mintAccount`, then by fetching
+     * the mint account. If the mint has no auditor configured, the zero auditor
+     * key is used.
+     */
     auditorElgamalPubkey?: Address;
     authority: Address | TransactionSigner;
     amount: number | bigint;
@@ -229,7 +241,7 @@ async function getAuditorElGamalPubkey(input: GetConfidentialTransferInstruction
         return getElGamalPubkeyFromAddress(input.auditorElgamalPubkey);
     }
 
-    const { data: mint } = await fetchMint(input.rpc, input.mint);
+    const mint = input.mintAccount ?? (await fetchMint(input.rpc, input.mint)).data;
     const extension = getRequiredConfidentialTransferMintExtension(mint);
     return isSome(extension.auditorElgamalPubkey)
         ? getElGamalPubkeyFromAddress(extension.auditorElgamalPubkey.value)

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -259,6 +259,7 @@ export const createConfidentialMint = async (input: {
     client: Client;
     payer: TransactionSigner;
     decimals?: number;
+    auditorElgamalPubkey?: Address;
 }): Promise<{ mint: Address; mintAuthority: TransactionSigner }> => {
     const [mintAuthority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
     await input.client.token2022.instructions
@@ -271,7 +272,7 @@ export const createConfidentialMint = async (input: {
                 extension('ConfidentialTransferMint', {
                     authority: some(mintAuthority.address),
                     autoApproveNewAccounts: true,
-                    auditorElgamalPubkey: none(),
+                    auditorElgamalPubkey: input.auditorElgamalPubkey ? some(input.auditorElgamalPubkey) : none(),
                 }),
             ],
         })

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
@@ -2,7 +2,7 @@ import { getAddressDecoder } from '@solana/kit';
 import { ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import { expect, it } from 'vitest';
 
-import { fetchToken } from '../../../src';
+import { fetchMint, fetchToken } from '../../../src';
 import { getConfidentialTransferInstructionPlan } from '../../../src/confidential';
 import {
     createConfidentialMint,
@@ -13,6 +13,13 @@ import {
     generateKeyPairSignerWithSol,
     getTokenExtension,
 } from '../../_setup';
+
+function getElGamalPubkeyAddress() {
+    // ElGamal public keys and Solana addresses share the same 32-byte layout,
+    // so use the address decoder to thread this key through Address-typed
+    // confidential transfer configuration fields.
+    return getAddressDecoder().decode(new ElGamalKeypair().pubkey().toBytes());
+}
 
 it('transfers tokens confidentially between two accounts', async () => {
     // Given a funded source account and an empty destination account.
@@ -70,7 +77,7 @@ it('fetches the mint auditor ElGamal pubkey when omitted', async () => {
         generateKeyPairSignerWithSol(client),
         generateKeyPairSignerWithSol(client),
     ]);
-    const auditorElgamalPubkey = getAddressDecoder().decode(new ElGamalKeypair().pubkey().toBytes());
+    const auditorElgamalPubkey = getElGamalPubkeyAddress();
     const { mint, mintAuthority } = await createConfidentialMint({
         client,
         payer,
@@ -110,6 +117,70 @@ it('fetches the mint auditor ElGamal pubkey when omitted', async () => {
     );
 
     // Then the helper found the auditor key on the mint and the transfer succeeded.
+    const updatedDestination = await fetchAssociatedToken(client, destinationOwner.address, mint);
+    const destinationConfidential = getTokenExtension(updatedDestination, 'ConfidentialTransferAccount');
+    expect(destinationConfidential.pendingBalanceCreditCounter).toBe(1n);
+});
+
+it('uses a provided mint account to resolve the auditor ElGamal pubkey', async () => {
+    // Given a confidential transfer mint configured with an auditor.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const [sourceOwner, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const auditorElgamalPubkey = getElGamalPubkeyAddress();
+    const { mint, mintAuthority } = await createConfidentialMint({
+        client,
+        payer,
+        auditorElgamalPubkey,
+    });
+    const decimals = 2;
+    const source = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner: sourceOwner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const destination = await createConfidentialTokenAccount({ client, payer, owner: destinationOwner, mint });
+
+    // When the caller supplies a decoded mint account.
+    const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }, { data: mintAccount }] = await Promise.all([
+        fetchToken(client.rpc, source.token),
+        fetchToken(client.rpc, destination.token),
+        fetchMint(client.rpc, mint),
+    ]);
+    const rpcWithoutGetAccountInfo = new Proxy(client.rpc, {
+        get(target, property, receiver) {
+            if (property === 'getAccountInfo') {
+                throw new Error('getAccountInfo should not be called when mintAccount is provided.');
+            }
+            return Reflect.get(target, property, receiver);
+        },
+    }) as typeof client.rpc;
+
+    await client.sendTransactions(
+        await getConfidentialTransferInstructionPlan({
+            payer,
+            rpc: rpcWithoutGetAccountInfo,
+            sourceToken: source.token,
+            mint,
+            mintAccount,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            authority: sourceOwner,
+            amount: 600n,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+        }),
+    );
+
+    // Then the transfer succeeds without fetching the mint inside the helper.
     const updatedDestination = await fetchAssociatedToken(client, destinationOwner.address, mint);
     const destinationConfidential = getTokenExtension(updatedDestination, 'ConfidentialTransferAccount');
     expect(destinationConfidential.pendingBalanceCreditCounter).toBe(1n);

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
@@ -1,3 +1,5 @@
+import { getAddressDecoder } from '@solana/kit';
+import { ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import { expect, it } from 'vitest';
 
 import { fetchToken } from '../../../src';
@@ -55,6 +57,59 @@ it('transfers tokens confidentially between two accounts', async () => {
     );
 
     // Then the destination account received a confidential credit in its pending balance.
+    const updatedDestination = await fetchAssociatedToken(client, destinationOwner.address, mint);
+    const destinationConfidential = getTokenExtension(updatedDestination, 'ConfidentialTransferAccount');
+    expect(destinationConfidential.pendingBalanceCreditCounter).toBe(1n);
+});
+
+it('fetches the mint auditor ElGamal pubkey when omitted', async () => {
+    // Given a confidential transfer mint configured with an auditor.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const [sourceOwner, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const auditorElgamalPubkey = getAddressDecoder().decode(new ElGamalKeypair().pubkey().toBytes());
+    const { mint, mintAuthority } = await createConfidentialMint({
+        client,
+        payer,
+        auditorElgamalPubkey,
+    });
+    const decimals = 2;
+    const source = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner: sourceOwner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const destination = await createConfidentialTokenAccount({ client, payer, owner: destinationOwner, mint });
+
+    // When the caller omits the auditor ElGamal pubkey.
+    const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }] = await Promise.all([
+        fetchToken(client.rpc, source.token),
+        fetchToken(client.rpc, destination.token),
+    ]);
+    await client.sendTransactions(
+        await getConfidentialTransferInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            sourceToken: source.token,
+            mint,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            authority: sourceOwner,
+            amount: 600n,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+        }),
+    );
+
+    // Then the helper found the auditor key on the mint and the transfer succeeded.
     const updatedDestination = await fetchAssociatedToken(client, destinationOwner.address, mint);
     const destinationConfidential = getTokenExtension(updatedDestination, 'ConfidentialTransferAccount');
     expect(destinationConfidential.pendingBalanceCreditCounter).toBe(1n);


### PR DESCRIPTION
Updates getConfidentialTransferInstructionPlan so callers do not have to manually fetch the mint just to discover the configured auditor key.

Behavior:
- if auditorElgamalPubkey is passed, the helper uses it as before
- if it is omitted, the helper fetches the mint account and reads ConfidentialTransferMint.auditorElgamalPubkey
- if the mint has no auditor configured, the helper keeps using the default zero auditor key
- if the mint is missing the ConfidentialTransferMint extension, the helper now fails earlier with a clearer error

This avoids the current confusing path where a mint with an auditor configured can produce proof/transfer data using the default auditor key, and the transaction then fails without pointing the caller at the missing auditor input.
