### PR TITLE
[rust-legacy, token-cli] Remove `split_account_creation_and_proof_verification` parameter in rust client

### DIFF
--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -1814,6 +1814,12 @@ async fn command_transfer(
                     &context_state_authority_pubkey,
                     close_context_state_signer
                 ),
+                token.confidential_transfer_close_record_account(
+                    &range_proof_record_pubkey,
+                    &sender,
+                    &context_state_authority_pubkey,
+                    close_context_state_signer
+                )
             )?;
 
             transfer_result
@@ -4254,12 +4260,7 @@ async fn command_deposit_withdraw_confidential_tokens(
                         create_range_proof_signer,
                     )
                     .await
-                } // token.confidential_transfer_create_context_state_account(
-                  //     &range_proof_context_state_pubkey,
-                  //     &context_state_authority_pubkey,
-                  //     &range_proof_data,
-                  //     create_range_proof_signer,
-                  // )
+                }
             )?;
 
             // do the withdrawal
@@ -4289,6 +4290,12 @@ async fn command_deposit_withdraw_confidential_tokens(
                 ),
                 token.confidential_transfer_close_context_state_account(
                     &range_proof_context_state_pubkey,
+                    &token_account_address,
+                    &context_state_authority_pubkey,
+                    close_context_state_signer
+                ),
+                token.confidential_transfer_close_record_account(
+                    &range_proof_record_pubkey,
                     &token_account_address,
                     &context_state_authority_pubkey,
                     close_context_state_signer

--- a/clients/cli/src/command.rs
+++ b/clients/cli/src/command.rs
@@ -35,6 +35,7 @@ use {
     solana_system_interface::program as system_program,
     solana_zk_elgamal_proof_interface::proof_data::{
         BatchedRangeProofContext, BatchedRangeProofU128Data, BatchedRangeProofU256Data,
+        BatchedRangeProofU64Data,
     },
     solana_zk_sdk::encryption::{
         auth_encryption::AeKey,
@@ -1733,14 +1734,12 @@ async fn command_transfer(
                     &equality_proof_pubkey,
                     &context_state_authority_pubkey,
                     &equality_proof_data,
-                    false,
                     create_equality_proof_context_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &ciphertext_validity_proof_pubkey,
                     &context_state_authority_pubkey,
                     &ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                    false,
                     create_ciphertext_validity_proof_context_signer
                 ),
                 // Range proof too large, so we must explicitly send them in chunks
@@ -1924,28 +1923,24 @@ async fn command_transfer(
                     &equality_proof_pubkey,
                     &context_state_authority_pubkey,
                     &equality_proof_data,
-                    false,
                     create_equality_proof_context_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &ciphertext_validity_proof_pubkey,
                     &context_state_authority_pubkey,
                     &transfer_amount_ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                    false,
                     create_ciphertext_validity_proof_context_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &percentage_with_cap_proof_pubkey,
                     &context_state_authority_pubkey,
                     &percentage_with_cap_proof_data,
-                    false,
                     create_percentage_with_cap_proof_context_signer
                 ),
                 token.confidential_transfer_create_context_state_account(
                     &fee_ciphertext_validity_proof_pubkey,
                     &context_state_authority_pubkey,
                     &fee_ciphertext_validity_proof_data,
-                    false,
                     create_fee_ciphertext_validity_proof_context_signer
                 ),
                 // Range proof too large, so we must explicitly send them in chunks
@@ -2215,14 +2210,12 @@ async fn command_burn(
                 &equality_proof_pubkey,
                 &context_state_authority_pubkey,
                 &equality_proof_data,
-                false,
                 create_equality_proof_context_signer
             ),
             token.confidential_transfer_create_context_state_account(
                 &ciphertext_validity_proof_pubkey,
                 &context_state_authority_pubkey,
                 &ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                false,
                 create_ciphertext_validity_proof_context_signer
             ),
             // Range proof too large, so we must explicitly send them in chunks
@@ -2451,14 +2444,12 @@ async fn command_mint(
                 &equality_proof_pubkey,
                 &context_state_authority_pubkey,
                 &equality_proof_data,
-                false,
                 create_equality_proof_context_signer
             ),
             token.confidential_transfer_create_context_state_account(
                 &ciphertext_validity_proof_pubkey,
                 &context_state_authority_pubkey,
                 &ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                false,
                 create_ciphertext_validity_proof_context_signer
             ),
             // Range proof too large, so we must explicitly send them in chunks
@@ -4230,21 +4221,45 @@ async fn command_deposit_withdraw_confidential_tokens(
             let create_equality_proof_signer = &[&equality_proof_context_state_keypair];
             let create_range_proof_signer = &[&range_proof_context_state_keypair];
 
+            // Upload the range proof using record account in chunks
+            let range_proof_record_account = Keypair::new();
+            let range_proof_record_pubkey = range_proof_record_account.pubkey();
+
             let _ = try_join!(
                 token.confidential_transfer_create_context_state_account(
                     &equality_proof_context_state_pubkey,
                     &context_state_authority_pubkey,
                     &equality_proof_data,
-                    false,
                     create_equality_proof_signer
                 ),
-                token.confidential_transfer_create_context_state_account(
-                    &range_proof_context_state_pubkey,
-                    &context_state_authority_pubkey,
-                    &range_proof_data,
-                    true,
-                    create_range_proof_signer,
-                )
+                async {
+                    token
+                        .confidential_transfer_create_record_account(
+                            &range_proof_record_pubkey,
+                            &context_state_authority_pubkey,
+                            &range_proof_data,
+                            &range_proof_record_account,
+                            &context_state_authority,
+                        )
+                        .await?;
+
+                    token.confidential_transfer_create_context_state_account_from_record::<
+                        _,
+                        BatchedRangeProofU64Data,
+                        BatchedRangeProofContext,
+                    >(
+                        &range_proof_context_state_pubkey,
+                        &context_state_authority_pubkey,
+                        &range_proof_record_pubkey,
+                        create_range_proof_signer,
+                    )
+                    .await
+                } // token.confidential_transfer_create_context_state_account(
+                  //     &range_proof_context_state_pubkey,
+                  //     &context_state_authority_pubkey,
+                  //     &range_proof_data,
+                  //     create_range_proof_signer,
+                  // )
             )?;
 
             // do the withdrawal

--- a/clients/rust-legacy/src/token.rs
+++ b/clients/rust-legacy/src/token.rs
@@ -2641,7 +2641,6 @@ where
         context_state_account: &Address,
         context_state_authority: &Address,
         proof_data: &ZK,
-        split_account_creation_and_proof_verification: bool,
         signing_keypairs: &S,
     ) -> TokenResult<T::Output> {
         let instruction_type = zk_proof_type_to_instruction(ZK::PROOF_TYPE)?;
@@ -2657,54 +2656,20 @@ where
             context_state_authority,
         };
 
-        // Some proof instructions are right at the transaction size limit, but in the
-        // future it might be able to support the transfer too
-        if split_account_creation_and_proof_verification {
-            self.process_ixs(
-                &[system_instruction::create_account(
+        self.process_ixs(
+            &[
+                system_instruction::create_account(
                     &self.payer.pubkey(),
                     context_state_account,
                     rent,
                     space as u64,
                     &zk_elgamal_proof_program::id(),
-                )],
-                signing_keypairs,
-            )
-            .await?;
-
-            let blockhash = self
-                .client
-                .get_latest_blockhash()
-                .await
-                .map_err(TokenError::Client)?;
-
-            let transaction = Transaction::new_signed_with_payer(
-                &[instruction_type.encode_verify_proof(Some(context_state_info), proof_data)],
-                Some(&self.payer.pubkey()),
-                &[self.payer.as_ref()],
-                blockhash,
-            );
-
-            self.client
-                .send_transaction(&transaction)
-                .await
-                .map_err(TokenError::Client)
-        } else {
-            self.process_ixs(
-                &[
-                    system_instruction::create_account(
-                        &self.payer.pubkey(),
-                        context_state_account,
-                        rent,
-                        space as u64,
-                        &zk_elgamal_proof_program::id(),
-                    ),
-                    instruction_type.encode_verify_proof(Some(context_state_info), proof_data),
-                ],
-                signing_keypairs,
-            )
-            .await
-        }
+                ),
+                instruction_type.encode_verify_proof(Some(context_state_info), proof_data),
+            ],
+            signing_keypairs,
+        )
+        .await
     }
 
     /// Create a context state account from another account containing

--- a/clients/rust-legacy/tests/confidential_mint_burn.rs
+++ b/clients/rust-legacy/tests/confidential_mint_burn.rs
@@ -193,7 +193,6 @@ async fn rotate_supply_elgamal_pubkey<S: Signers>(
                     &context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &proof_data,
-                    false,
                     &[&context_account],
                 )
                 .await
@@ -495,7 +494,6 @@ async fn mint_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
-                    false,
                     &[&equality_proof_context_account],
                 )
                 .await
@@ -506,7 +504,6 @@ async fn mint_with_option<S: Signers>(
                     &ciphertext_validity_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                    false,
                     &[&ciphertext_validity_proof_context_account],
                 )
                 .await
@@ -517,7 +514,6 @@ async fn mint_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &range_proof_data,
-                    false,
                     &[&range_proof_context_account],
                 )
                 .await
@@ -671,7 +667,6 @@ async fn burn_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
-                    false,
                     &[&equality_proof_context_account],
                 )
                 .await
@@ -682,7 +677,6 @@ async fn burn_with_option<S: Signers>(
                     &ciphertext_validity_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                    false,
                     &[&ciphertext_validity_proof_context_account],
                 )
                 .await
@@ -693,7 +687,6 @@ async fn burn_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &range_proof_data,
-                    false,
                     &[&range_proof_context_account],
                 )
                 .await

--- a/clients/rust-legacy/tests/confidential_transfer.rs
+++ b/clients/rust-legacy/tests/confidential_transfer.rs
@@ -84,7 +84,6 @@ async fn configure_account_with_option<S: Signers>(
                     &pubkey_validity_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &pubkey_validity_proof_data,
-                    false,
                     &[&pubkey_validity_proof_context_account],
                 )
                 .await
@@ -555,7 +554,6 @@ async fn empty_account_with_option<S: Signers>(
                     &zero_ciphertext_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &zero_ciphertext_proof_data,
-                    false,
                     &[&zero_ciphertext_proof_context_account],
                 )
                 .await
@@ -919,7 +917,6 @@ async fn withdraw_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
-                    false,
                     &[&equality_proof_context_account],
                 )
                 .await
@@ -930,7 +927,6 @@ async fn withdraw_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &range_proof_data,
-                    false,
                     &[&range_proof_context_account],
                 )
                 .await
@@ -1174,7 +1170,6 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
-                    false,
                     &[&equality_proof_context_account],
                 )
                 .await
@@ -1185,7 +1180,6 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &ciphertext_validity_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                    false,
                     &[&ciphertext_validity_proof_context_account],
                 )
                 .await
@@ -1196,7 +1190,6 @@ async fn confidential_transfer_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &range_proof_data,
-                    false,
                     &[&range_proof_context_account],
                 )
                 .await
@@ -1845,7 +1838,6 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &equality_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof_data,
-                    false,
                     &[&equality_proof_context_account],
                 )
                 .await
@@ -1856,7 +1848,6 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &transfer_amount_ciphertext_validity_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &transfer_amount_ciphertext_validity_proof_data_with_ciphertext.proof_data,
-                    false,
                     &[&transfer_amount_ciphertext_validity_proof_context_account],
                 )
                 .await
@@ -1867,7 +1858,6 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &percentage_with_cap_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &percentage_with_cap_proof_data,
-                    false,
                     &[&percentage_with_cap_proof_context_account],
                 )
                 .await
@@ -1878,7 +1868,6 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &fee_ciphertext_validity_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &fee_ciphertext_validity_proof_data,
-                    false,
                     &[&fee_ciphertext_validity_proof_context_account],
                 )
                 .await
@@ -1889,7 +1878,6 @@ async fn confidential_transfer_with_fee_with_option<S: Signers>(
                     &range_proof_context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &range_proof_data,
-                    false,
                     &[&range_proof_context_account],
                 )
                 .await

--- a/clients/rust-legacy/tests/confidential_transfer_fee.rs
+++ b/clients/rust-legacy/tests/confidential_transfer_fee.rs
@@ -500,7 +500,6 @@ async fn withdraw_withheld_tokens_from_mint_with_option<S: Signers>(
                     &context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof,
-                    false,
                     &[&context_account],
                 )
                 .await
@@ -729,7 +728,6 @@ async fn withdraw_withheld_tokens_from_accounts_with_option<S: Signers>(
                     &context_account.pubkey(),
                     &context_account_authority.pubkey(),
                     &equality_proof,
-                    false,
                     &[&context_account],
                 )
                 .await


### PR DESCRIPTION
#### Problem

Right now, the function `confidential_transfer_create_context_state_account` has a `split_account_creation_and_proof_verification` boolean parameter. When it is set, the function will include the `CreateAccount` and the `Verify...` instruction in separate transactions.

This is a relic from long time ago when there was no way around the transaction size limit. However, we can now split the proofs using the record program, so there is no need to have this field. This logic can especially set a bad example given that the `CreateAccount` and `Verify...` instructions should always be atomically executed to prevent front-running.

#### Summary of Changes

I removed the `split_account_creation_and_proof_verification` parameter in the rust client. This did cause the withdraw command in the token-cli to error due to the transaction size limit, so I updated the token-cli so that the withdraw instruction uses the record program for its range proof.

Sorry this should have been done long time ago 🙏 