### PR TITLE
js-legacy: Update package.json for trusted publishing

### DIFF
--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -1,10 +1,16 @@
 {
     "name": "@solana/spl-token",
-    "description": "SPL Token Program JS API",
     "version": "0.4.14",
-    "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
-    "repository": "https://github.com/solana-labs/solana-program-library",
+    "description": "SPL Token Program JS API",
+    "homepage": "https://github.com/solana-program/token-2022#readme",
+    "bugs": {
+        "url": "https://github.com/solana-program/token-2022/issues"
+    },
     "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/solana-program/token-2022.git"
+    },
     "type": "module",
     "sideEffects": false,
     "engines": {


### PR DESCRIPTION
#### Problem

The most recent publish failed because the `repository.url` in the package.json is not consistent with the trusted repo configured in npm.

#### Summary of changes

Make package.json consistent with the non-legacy client.