### PR TITLE
cli: display scaled ui and pausable extensions

### DIFF
--- a/clients/cli/src/output.rs
+++ b/clients/cli/src/output.rs
@@ -10,8 +10,9 @@ use {
             UiConfidentialTransferFeeConfig, UiConfidentialTransferMint, UiCpiGuard,
             UiDefaultAccountState, UiExtension, UiGroupMemberPointer, UiGroupPointer,
             UiInterestBearingConfig, UiMemoTransfer, UiMetadataPointer, UiMintCloseAuthority,
-            UiPermanentDelegate, UiTokenGroup, UiTokenGroupMember, UiTokenMetadata,
-            UiTransferFeeAmount, UiTransferFeeConfig, UiTransferHook, UiTransferHookAccount,
+            UiPausableConfig, UiPermanentDelegate, UiScaledUiAmountConfig, UiTokenGroup,
+            UiTokenGroupMember, UiTokenMetadata, UiTransferFeeAmount, UiTransferFeeConfig,
+            UiTransferHook, UiTransferHookAccount,
         },
     },
     solana_cli_output::{display::writeln_name_value, OutputFormat, QuietDisplay, VerboseDisplay},
@@ -668,6 +669,36 @@ fn display_ui_extension(
                 rate_authority.as_ref().unwrap_or(&String::new()),
             )
         }
+        UiExtension::ScaledUiAmountConfig(UiScaledUiAmountConfig {
+            authority,
+            multiplier,
+            new_multiplier_effective_timestamp,
+            new_multiplier,
+        }) => {
+            writeln!(f, "  {}", style("Scaled UI amount:").bold())?;
+            writeln_name_value(
+                f,
+                "    Authority:",
+                authority.as_ref().unwrap_or(&String::new()),
+            )?;
+            writeln_name_value(f, "    Multiplier:", multiplier)?;
+            writeln_name_value(
+                f,
+                "    New multiplier effective timestamp:",
+                &new_multiplier_effective_timestamp.to_string(),
+            )?;
+            writeln_name_value(f, "    New multiplier:", new_multiplier)
+        }
+        UiExtension::PausableConfig(UiPausableConfig { authority, paused }) => {
+            writeln!(f, "  {}", style("Pausable:").bold())?;
+            writeln_name_value(
+                f,
+                "    Authority:",
+                authority.as_ref().unwrap_or(&String::new()),
+            )?;
+            writeln_name_value(f, "    Status:", if *paused { "Paused" } else { "Active" })
+        }
+        UiExtension::PausableAccount => writeln!(f, "  {}", style("Pausable account").bold()),
         UiExtension::CpiGuard(UiCpiGuard { lock_cpi }) => writeln_name_value(
             f,
             "  CPI Guard:",

--- a/clients/cli/tests/command.rs
+++ b/clients/cli/tests/command.rs
@@ -4765,7 +4765,7 @@ async fn compute_budget(test_validator: &TestValidator, payer: &Keypair) {
 }
 
 async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
-    let config =
+    let mut config =
         test_config_with_default_signer(test_validator, payer, &spl_token_2022_interface::id());
 
     // create token with scaled ui amount extension
@@ -4793,6 +4793,22 @@ async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
     let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
     let extension = test_mint.get_extension::<ScaledUiAmountConfig>().unwrap();
     assert_eq!(f64::from(extension.multiplier), ui_multiplier);
+
+    config.output_format = OutputFormat::Display;
+    let result = process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Display.into(),
+            &token_pubkey.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+    assert!(result.contains("Scaled UI amount:"));
+    assert!(result.contains("Multiplier:"));
+    config.output_format = OutputFormat::JsonCompact;
 
     // update multiplier
     let new_ui_multiplier = 5.0;
@@ -4844,7 +4860,7 @@ async fn scaled_ui_amount(test_validator: &TestValidator, payer: &Keypair) {
 }
 
 async fn pause(test_validator: &TestValidator, payer: &Keypair) {
-    let config =
+    let mut config =
         test_config_with_default_signer(test_validator, payer, &spl_token_2022_interface::id());
 
     // create token with pausable extension
@@ -4869,6 +4885,22 @@ async fn pause(test_validator: &TestValidator, payer: &Keypair) {
     let test_mint = StateWithExtensionsOwned::<Mint>::unpack(account.data).unwrap();
     let extension = test_mint.get_extension::<PausableConfig>().unwrap();
     assert!(!bool::from(extension.paused));
+
+    config.output_format = OutputFormat::Display;
+    let result = process_test_command(
+        &config,
+        payer,
+        &[
+            "spl-token",
+            CommandName::Display.into(),
+            &token_pubkey.to_string(),
+        ],
+    )
+    .await
+    .unwrap();
+    assert!(result.contains("Pausable:"));
+    assert!(result.contains("Status: Active"));
+    config.output_format = OutputFormat::JsonCompact;
 
     // pause the mint
     process_test_command(


### PR DESCRIPTION
Addresses #125.

Adds `spl-token display` output for Token-2022 scaled UI amount and pausable extensions.

The CLI can already initialize these extensions, and the current `solana-account-decoder` version exposes the corresponding UI extension variants. This updates the display formatter to render:

- `ScaledUiAmountConfig`
- `PausableConfig`
- `PausableAccount`

Also extends the existing CLI tests to assert that display output includes the new extension sections.

Verification:

- `cargo fmt --check --manifest-path clients/cli/Cargo.toml`
- `cargo check --manifest-path clients/cli/Cargo.toml --bin spl-token`

Full test-target check was blocked locally by missing Windows build dependencies (`libclang`, `perl`).