### PR TITLE
feat(clients/js): add confidential mint/burn instruction plan helpers

### DIFF
--- a/clients/js/src/confidentialTransferArithmetic.ts
+++ b/clients/js/src/confidentialTransferArithmetic.ts
@@ -51,6 +51,15 @@ export function extractCiphertextFromGroupedBytes(groupedCiphertext: ReadonlyUin
     return ciphertext;
 }
 
+function addCiphertexts(left: ReadonlyUint8Array, right: ReadonlyUint8Array) {
+    const leftPoints = ciphertextToPoints(left);
+    const rightPoints = ciphertextToPoints(right);
+    return pointsToCiphertext(
+        leftPoints.commitment.add(rightPoints.commitment),
+        leftPoints.handle.add(rightPoints.handle),
+    );
+}
+
 function subtractCiphertexts(left: ReadonlyUint8Array, right: ReadonlyUint8Array) {
     const leftPoints = ciphertextToPoints(left);
     const rightPoints = ciphertextToPoints(right);
@@ -68,6 +77,20 @@ function combineLoHiCiphertexts(ciphertextLo: ReadonlyUint8Array, ciphertextHi: 
         loPoints.commitment.add(hiPoints.commitment.multiply(scale)),
         loPoints.handle.add(hiPoints.handle.multiply(scale)),
     );
+}
+
+/**
+ * Combines lo/hi ciphertext halves (hi << bitLength + lo) and adds the result
+ * to `left`. Used to compute the new encrypted supply ciphertext after a
+ * confidential mint.
+ */
+export function addWithLoHiCiphertexts(
+    left: ReadonlyUint8Array,
+    ciphertextLo: ReadonlyUint8Array,
+    ciphertextHi: ReadonlyUint8Array,
+    bitLength: bigint,
+) {
+    return addCiphertexts(left, combineLoHiCiphertexts(ciphertextLo, ciphertextHi, bitLength));
 }
 
 /**

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -43,6 +43,7 @@ import {
 } from '@solana/zk-sdk/bundler';
 
 import {
+    addWithLoHiCiphertexts,
     extractCiphertextFromGroupedBytes,
     subtractAmountFromCiphertext,
     subtractWithLoHiCiphertexts,
@@ -56,12 +57,15 @@ import {
     fetchMint,
     findAssociatedTokenPda,
     getApplyConfidentialPendingBalanceInstruction,
+    getConfidentialBurnInstruction,
+    getConfidentialMintInstruction,
     getConfidentialTransferInstruction,
     getConfidentialWithdrawInstruction,
     getConfigureConfidentialTransferAccountInstruction,
     getCreateAssociatedTokenIdempotentInstruction,
     getEmptyConfidentialTransferAccountInstruction,
     getReallocateInstruction,
+    getUpdateConfidentialMintBurnDecryptableSupplyInstruction,
     fetchToken,
 } from './generated';
 
@@ -71,9 +75,15 @@ const TRANSFER_AMOUNT_LO_BIT_LENGTH = 16n;
 const TRANSFER_AMOUNT_HI_BIT_LENGTH = 32n;
 const REMAINING_BALANCE_BIT_LENGTH = 64;
 const RANGE_PROOF_PADDING_BIT_LENGTH = 16;
+// A mint/burn amount is range-proven as a 16-bit low half + 32-bit high half, so
+// it must fit in 48 bits (matching the Rust reference); a larger amount would
+// otherwise silently produce a range proof the on-chain verifier rejects.
+const MAX_MINT_BURN_AMOUNT = (1n << (TRANSFER_AMOUNT_LO_BIT_LENGTH + TRANSFER_AMOUNT_HI_BIT_LENGTH)) - 1n;
+const U64_MAX = (1n << 64n) - 1n;
 
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
+type ConfidentialMintBurnExtension = Extract<Extension, { __kind: 'ConfidentialMintBurn' }>;
 
 type ContextStateProofMode = {
     /**
@@ -206,6 +216,71 @@ type GetConfidentialTransferInstructionPlanBaseInput = {
 export type GetConfidentialTransferInstructionPlanInput = GetConfidentialTransferInstructionPlanBaseInput &
     ConfidentialTransferContextStateProofMode;
 
+export type GetConfidentialMintInstructionPlanInput = {
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+    /** The token account minted into (its confidential pending balance). */
+    token: Address;
+    mint: Address;
+    /** Decoded mint account, read for the `ConfidentialMintBurn` supply state and auditor key. */
+    mintAccount: Mint;
+    /** Decoded destination token account, read for its ElGamal public key. */
+    destinationTokenAccount: Token;
+    authority: Address | TransactionSigner;
+    amount: number | bigint;
+    /** The supply ElGamal keypair (backs the equality proof; encrypts the new supply). */
+    supplyElgamalKeypair: ElGamalKeypair;
+    /** The supply AES key (decrypts the current supply and encrypts the new decryptable supply). */
+    supplyAesKey: AeKey;
+    /**
+     * Auditor ElGamal public key to use for the auditor ciphertexts. When
+     * omitted, the helper resolves the key from `mintAccount`'s
+     * `ConfidentialTransferMint` extension. If the mint has no auditor
+     * configured, the zero auditor key is used.
+     */
+    auditorElgamalPubkey?: Address;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+export type GetConfidentialBurnInstructionPlanInput = {
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+    /** The token account burnt from (its confidential available balance). */
+    token: Address;
+    mint: Address;
+    /** Decoded mint account, read for the `ConfidentialMintBurn` supply ElGamal pubkey and auditor key. */
+    mintAccount: Mint;
+    /** Decoded source token account, read for its available-balance ciphertext and ElGamal public key. */
+    sourceTokenAccount: Token;
+    authority: Address | TransactionSigner;
+    amount: number | bigint;
+    /** The source account's ElGamal keypair (backs the equality proof). */
+    sourceElgamalKeypair: ElGamalKeypair;
+    /** The source account's AES key (decrypts and re-encrypts the available balance). */
+    aesKey: AeKey;
+    /**
+     * Auditor ElGamal public key to use for the auditor ciphertexts. When
+     * omitted, the helper resolves the key from `mintAccount`'s
+     * `ConfidentialTransferMint` extension. If the mint has no auditor
+     * configured, the zero auditor key is used.
+     */
+    auditorElgamalPubkey?: Address;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
+export type GetUpdateConfidentialMintBurnDecryptableSupplyInstructionFromSupplyInput = {
+    mint: Address;
+    authority: Address | TransactionSigner;
+    /** The supply AES key that encrypts the decryptable supply. */
+    supplyAesKey: AeKey;
+    /** The true current supply to encode into the decryptable supply. */
+    supply: number | bigint;
+    multiSigners?: Array<TransactionSigner>;
+    programAddress?: Address;
+};
+
 function getTokenProgramAddress(programAddress?: Address) {
     return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
 }
@@ -248,6 +323,21 @@ function getRequiredConfidentialTransferMintExtension(mint: Mint): ConfidentialT
     return extension;
 }
 
+function getRequiredConfidentialMintBurnExtension(mint: Mint): ConfidentialMintBurnExtension {
+    if (!isSome(mint.extensions)) {
+        throw new Error('Mint account is missing extensions.');
+    }
+
+    const extension = mint.extensions.value.find(candidate => candidate.__kind === 'ConfidentialMintBurn') as
+        | ConfidentialMintBurnExtension
+        | undefined;
+    if (!extension) {
+        throw new Error('Mint account is missing the ConfidentialMintBurn extension.');
+    }
+
+    return extension;
+}
+
 function parseAeCiphertext(bytes: ReadonlyUint8Array) {
     const ciphertext = AeCiphertext.fromBytes(new Uint8Array(bytes));
     if (!ciphertext) {
@@ -279,6 +369,17 @@ async function getAuditorElGamalPubkey(input: GetConfidentialTransferInstruction
 
     const mint = input.mintAccount ?? (await fetchMint(input.rpc, input.mint)).data;
     const extension = getRequiredConfidentialTransferMintExtension(mint);
+    return isSome(extension.auditorElgamalPubkey)
+        ? getElGamalPubkeyFromAddress(extension.auditorElgamalPubkey.value)
+        : getDefaultAuditorElGamalPubkey();
+}
+
+function resolveAuditorElGamalPubkey(mintAccount: Mint, auditorElgamalPubkey?: Address) {
+    if (auditorElgamalPubkey) {
+        return getElGamalPubkeyFromAddress(auditorElgamalPubkey);
+    }
+
+    const extension = getRequiredConfidentialTransferMintExtension(mintAccount);
     return isSome(extension.auditorElgamalPubkey)
         ? getElGamalPubkeyFromAddress(extension.auditorElgamalPubkey.value)
         : getDefaultAuditorElGamalPubkey();
@@ -744,4 +845,338 @@ export async function getConfidentialTransferInstructionPlan(
             rangeProofPlan.cleanup,
         ]),
     ]);
+}
+
+function assertMintBurnAmount(amount: bigint, label: 'Mint' | 'Burn'): void {
+    if (amount <= 0n) {
+        throw new Error(`${label} amount must be positive.`);
+    }
+    if (amount > MAX_MINT_BURN_AMOUNT) {
+        throw new Error(
+            `${label} amount exceeds the maximum confidential mint/burn amount (2^48 - 1 = ${MAX_MINT_BURN_AMOUNT}).`,
+        );
+    }
+}
+
+/**
+ * Returns an instruction plan that confidentially mints `amount` tokens into a
+ * token account's pending balance, encrypting the amount on-chain and advancing
+ * the mint's encrypted supply. Splits the amount into lo/hi halves and verifies
+ * the three required proofs (equality, grouped-ciphertext validity, batched
+ * range) via context-state accounts.
+ *
+ * The amount is grouped-encrypted under `[destination, supply, auditor]`; the
+ * supply handle (index 1) is homomorphically added to the mint's current supply
+ * ciphertext, and the auditor handle (index 2) is carried by the instruction.
+ */
+export async function getConfidentialMintInstructionPlan(
+    input: GetConfidentialMintInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const mintBurnExtension = getRequiredConfidentialMintBurnExtension(input.mintAccount);
+    const amount = BigInt(input.amount);
+    assertMintBurnAmount(amount, 'Mint');
+
+    const currentSupply = input.supplyAesKey.decrypt(parseAeCiphertext(mintBurnExtension.decryptableSupply));
+    const newSupply = currentSupply + amount;
+    if (newSupply > U64_MAX) {
+        throw new Error('Mint would overflow the maximum u64 supply.');
+    }
+
+    const [amountLo, amountHi] = splitAmount(amount, TRANSFER_AMOUNT_LO_BIT_LENGTH);
+    const destinationPubkey = getElGamalPubkeyFromAddress(
+        getRequiredConfidentialTransferAccountExtension(input.destinationTokenAccount).elgamalPubkey,
+    );
+    const supplyPubkey = input.supplyElgamalKeypair.pubkey();
+    const auditorPubkey = resolveAuditorElGamalPubkey(input.mintAccount, input.auditorElgamalPubkey);
+
+    const openingLo = new PedersenOpening();
+    const openingHi = new PedersenOpening();
+    // Grouped handle order for MINT: [destination, supply, auditor].
+    const groupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptWith(
+        destinationPubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountLo,
+        openingLo,
+    );
+    const groupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptWith(
+        destinationPubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountHi,
+        openingHi,
+    );
+
+    const groupedCiphertextLoBytes = groupedCiphertextLo.toBytes();
+    const groupedCiphertextHiBytes = groupedCiphertextHi.toBytes();
+    // New supply ciphertext = current supply + combine_lo_hi(supply handle, index 1).
+    const supplyCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 1);
+    const supplyCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 1);
+    const mintAmountAuditorCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 2);
+    const mintAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 2);
+
+    const newSupplyCiphertext = parseElGamalCiphertext(
+        addWithLoHiCiphertexts(
+            mintBurnExtension.confidentialSupply,
+            supplyCiphertextLo,
+            supplyCiphertextHi,
+            TRANSFER_AMOUNT_LO_BIT_LENGTH,
+        ),
+    );
+
+    const newSupplyOpening = new PedersenOpening();
+    const newSupplyCommitment = PedersenCommitment.from(newSupply, newSupplyOpening);
+
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
+        input.supplyElgamalKeypair,
+        newSupplyCiphertext,
+        newSupplyCommitment,
+        newSupplyOpening,
+        newSupply,
+    );
+    const ciphertextValidityProofData = new BatchedGroupedCiphertext3HandlesValidityProofData(
+        destinationPubkey,
+        supplyPubkey,
+        auditorPubkey,
+        groupedCiphertextLo,
+        groupedCiphertextHi,
+        amountLo,
+        amountHi,
+        openingLo,
+        openingHi,
+    );
+
+    const commitmentLo = PedersenCommitment.fromBytes(groupedCiphertextLoBytes.slice(0, 32));
+    const commitmentHi = PedersenCommitment.fromBytes(groupedCiphertextHiBytes.slice(0, 32));
+    const paddingOpening = new PedersenOpening();
+    const paddingCommitment = PedersenCommitment.from(0n, paddingOpening);
+    const rangeProofData = new BatchedRangeProofU128Data(
+        [newSupplyCommitment, commitmentLo, commitmentHi, paddingCommitment],
+        new BigUint64Array([newSupply, amountLo, amountHi, 0n]),
+        Uint8Array.from([
+            REMAINING_BALANCE_BIT_LENGTH,
+            Number(TRANSFER_AMOUNT_LO_BIT_LENGTH),
+            Number(TRANSFER_AMOUNT_HI_BIT_LENGTH),
+            RANGE_PROOF_PADDING_BIT_LENGTH,
+        ]),
+        [newSupplyOpening, openingLo, openingHi, paddingOpening],
+    );
+
+    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            ciphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU128, input.payer, input.rpc),
+    ]);
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([equalityProofPlan.setup, ciphertextValidityProofPlan.setup, rangeProofPlan.setup]),
+        getConfidentialMintInstruction(
+            {
+                token: input.token,
+                mint: input.mint,
+                equalityRecord: equalityProofPlan.address,
+                ciphertextValidityRecord: ciphertextValidityProofPlan.address,
+                rangeRecord: rangeProofPlan.address,
+                authority: input.authority,
+                newDecryptableSupply: input.supplyAesKey.encrypt(newSupply).toBytes(),
+                mintAmountAuditorCiphertextLo,
+                mintAmountAuditorCiphertextHi,
+                equalityProofInstructionOffset: 0,
+                ciphertextValidityProofInstructionOffset: 0,
+                rangeProofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: getTokenProgramAddress(input.programAddress) },
+        ),
+        parallelInstructionPlan([
+            equalityProofPlan.cleanup,
+            ciphertextValidityProofPlan.cleanup,
+            rangeProofPlan.cleanup,
+        ]),
+    ]);
+}
+
+/**
+ * Returns an instruction plan that confidentially burns `amount` tokens from a
+ * token account's available balance, encrypting the amount on-chain and
+ * advancing the mint's encrypted pending burn. Symmetric to
+ * `getConfidentialMintInstructionPlan`.
+ *
+ * The amount is grouped-encrypted under `[source, supply, auditor]`; the source
+ * handle (index 0) is homomorphically subtracted from the account's available
+ * balance, and the auditor handle (index 2) is carried by the instruction.
+ */
+export async function getConfidentialBurnInstructionPlan(
+    input: GetConfidentialBurnInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const sourceAccount = getRequiredConfidentialTransferAccountExtension(input.sourceTokenAccount);
+    const mintBurnExtension = getRequiredConfidentialMintBurnExtension(input.mintAccount);
+    const amount = BigInt(input.amount);
+    assertMintBurnAmount(amount, 'Burn');
+
+    const currentAvailableBalance = decryptAvailableBalance(sourceAccount, input.aesKey);
+    const remainingBalance = computeNewAvailableBalance(currentAvailableBalance, amount);
+
+    const [amountLo, amountHi] = splitAmount(amount, TRANSFER_AMOUNT_LO_BIT_LENGTH);
+    const sourcePubkey = input.sourceElgamalKeypair.pubkey();
+    const supplyPubkey = getElGamalPubkeyFromAddress(mintBurnExtension.supplyElgamalPubkey);
+    const auditorPubkey = resolveAuditorElGamalPubkey(input.mintAccount, input.auditorElgamalPubkey);
+
+    const openingLo = new PedersenOpening();
+    const openingHi = new PedersenOpening();
+    // Grouped handle order for BURN: [source, supply, auditor].
+    const groupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountLo,
+        openingLo,
+    );
+    const groupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptWith(
+        sourcePubkey,
+        supplyPubkey,
+        auditorPubkey,
+        amountHi,
+        openingHi,
+    );
+
+    const groupedCiphertextLoBytes = groupedCiphertextLo.toBytes();
+    const groupedCiphertextHiBytes = groupedCiphertextHi.toBytes();
+    // New available balance ciphertext = current balance − combine_lo_hi(source handle, index 0).
+    const sourceCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 0);
+    const sourceCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 0);
+    const burnAmountAuditorCiphertextLo = extractCiphertextFromGroupedBytes(groupedCiphertextLoBytes, 2);
+    const burnAmountAuditorCiphertextHi = extractCiphertextFromGroupedBytes(groupedCiphertextHiBytes, 2);
+
+    const newAvailableBalanceCiphertext = parseElGamalCiphertext(
+        subtractWithLoHiCiphertexts(
+            sourceAccount.availableBalance,
+            sourceCiphertextLo,
+            sourceCiphertextHi,
+            TRANSFER_AMOUNT_LO_BIT_LENGTH,
+        ),
+    );
+
+    const newAvailableBalanceOpening = new PedersenOpening();
+    const newAvailableBalanceCommitment = PedersenCommitment.from(remainingBalance, newAvailableBalanceOpening);
+
+    const equalityProofData = new CiphertextCommitmentEqualityProofData(
+        input.sourceElgamalKeypair,
+        newAvailableBalanceCiphertext,
+        newAvailableBalanceCommitment,
+        newAvailableBalanceOpening,
+        remainingBalance,
+    );
+    const ciphertextValidityProofData = new BatchedGroupedCiphertext3HandlesValidityProofData(
+        sourcePubkey,
+        supplyPubkey,
+        auditorPubkey,
+        groupedCiphertextLo,
+        groupedCiphertextHi,
+        amountLo,
+        amountHi,
+        openingLo,
+        openingHi,
+    );
+
+    const commitmentLo = PedersenCommitment.fromBytes(groupedCiphertextLoBytes.slice(0, 32));
+    const commitmentHi = PedersenCommitment.fromBytes(groupedCiphertextHiBytes.slice(0, 32));
+    const paddingOpening = new PedersenOpening();
+    const paddingCommitment = PedersenCommitment.from(0n, paddingOpening);
+    const rangeProofData = new BatchedRangeProofU128Data(
+        [newAvailableBalanceCommitment, commitmentLo, commitmentHi, paddingCommitment],
+        new BigUint64Array([remainingBalance, amountLo, amountHi, 0n]),
+        Uint8Array.from([
+            REMAINING_BALANCE_BIT_LENGTH,
+            Number(TRANSFER_AMOUNT_LO_BIT_LENGTH),
+            Number(TRANSFER_AMOUNT_HI_BIT_LENGTH),
+            RANGE_PROOF_PADDING_BIT_LENGTH,
+        ]),
+        [newAvailableBalanceOpening, openingLo, openingHi, paddingOpening],
+    );
+
+    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            ciphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU128, input.payer, input.rpc),
+    ]);
+
+    return sequentialInstructionPlan([
+        parallelInstructionPlan([equalityProofPlan.setup, ciphertextValidityProofPlan.setup, rangeProofPlan.setup]),
+        getConfidentialBurnInstruction(
+            {
+                token: input.token,
+                mint: input.mint,
+                equalityRecord: equalityProofPlan.address,
+                ciphertextValidityRecord: ciphertextValidityProofPlan.address,
+                rangeRecord: rangeProofPlan.address,
+                authority: input.authority,
+                newDecryptableAvailableBalance: input.aesKey.encrypt(remainingBalance).toBytes(),
+                burnAmountAuditorCiphertextLo,
+                burnAmountAuditorCiphertextHi,
+                equalityProofInstructionOffset: 0,
+                ciphertextValidityProofInstructionOffset: 0,
+                rangeProofInstructionOffset: 0,
+                multiSigners: input.multiSigners,
+            },
+            { programAddress: getTokenProgramAddress(input.programAddress) },
+        ),
+        parallelInstructionPlan([
+            equalityProofPlan.cleanup,
+            ciphertextValidityProofPlan.cleanup,
+            rangeProofPlan.cleanup,
+        ]),
+    ]);
+}
+
+/**
+ * Re-encrypts and updates the mint's decryptable supply to `supply` under the
+ * supply AES key. Signed by the mint authority. No proof required — returns a
+ * single instruction.
+ *
+ * The confidential supply is maintained on-chain both as an ElGamal ciphertext
+ * (updated homomorphically by mint/burn) and as a cheap-to-decrypt AES
+ * "decryptable supply". The two can drift — e.g. `ApplyPendingBurn` advances the
+ * ElGamal supply but cannot re-encrypt the AES form — so the authority uses this
+ * to re-assert the decryptable supply to the true supply it tracks.
+ */
+export function getUpdateConfidentialMintBurnDecryptableSupplyInstructionFromSupply(
+    input: GetUpdateConfidentialMintBurnDecryptableSupplyInstructionFromSupplyInput,
+): Instruction {
+    const supply = BigInt(input.supply);
+    // Supply is a u64 on-chain; reject out-of-range values before handing them
+    // to the WASM AES encrypt (which would otherwise fail opaquely or wrap).
+    if (supply < 0n || supply > U64_MAX) {
+        throw new Error(`supply must be a u64 (0..2^64-1), got ${supply}.`);
+    }
+
+    return getUpdateConfidentialMintBurnDecryptableSupplyInstruction(
+        {
+            mint: input.mint,
+            authority: input.authority,
+            newDecryptableSupply: input.supplyAesKey.encrypt(supply).toBytes(),
+            multiSigners: input.multiSigners,
+        },
+        { programAddress: getTokenProgramAddress(input.programAddress) },
+    );
 }

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -14,6 +14,7 @@ import {
     createTransactionPlanner,
     extendClient,
     generateKeyPairSigner,
+    getAddressDecoder,
     isSome,
     lamports,
     none,
@@ -278,6 +279,52 @@ export const createConfidentialMint = async (input: {
         })
         .sendTransaction();
     return { mint: mint.address, mintAuthority };
+};
+
+// Creates a mint configured for confidential mint/burn: it carries both the
+// `ConfidentialTransferMint` extension (auto-approve, required by mint/burn) and
+// the `ConfidentialMintBurn` extension with a fresh supply ElGamal keypair and
+// AES key and a zero-initialized encrypted/decryptable supply.
+export const createConfidentialMintBurnMint = async (input: {
+    client: Client;
+    payer: TransactionSigner;
+    decimals?: number;
+    auditorElgamalPubkey?: Address;
+}): Promise<{
+    mint: Address;
+    mintAuthority: TransactionSigner;
+    supplyElgamalKeypair: ElGamalKeypair;
+    supplyAesKey: AeKey;
+}> => {
+    const [mintAuthority, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    const supplyElgamalKeypair = new ElGamalKeypair();
+    const supplyAesKey = new AeKey();
+    const supplyElgamalPubkey = getAddressDecoder().decode(new Uint8Array(supplyElgamalKeypair.pubkey().toBytes()));
+
+    await input.client.token2022.instructions
+        .createMint({
+            payer: input.payer,
+            newMint: mint,
+            decimals: input.decimals ?? 2,
+            mintAuthority,
+            extensions: [
+                extension('ConfidentialTransferMint', {
+                    authority: some(mintAuthority.address),
+                    autoApproveNewAccounts: true,
+                    auditorElgamalPubkey: input.auditorElgamalPubkey ? some(input.auditorElgamalPubkey) : none(),
+                }),
+                extension('ConfidentialMintBurn', {
+                    // The confidential supply and pending burn are zero-initialized;
+                    // the decryptable supply is an AES encryption of zero.
+                    confidentialSupply: new Uint8Array(64).fill(0),
+                    decryptableSupply: supplyAesKey.encrypt(0n).toBytes(),
+                    supplyElgamalPubkey,
+                    pendingBurn: new Uint8Array(64).fill(0),
+                }),
+            ],
+        })
+        .sendTransaction();
+    return { mint: mint.address, mintAuthority, supplyElgamalKeypair, supplyAesKey };
 };
 
 export type ConfidentialTokenAccount = {

--- a/clients/js/test/confidentialTransferArithmetic.test.ts
+++ b/clients/js/test/confidentialTransferArithmetic.test.ts
@@ -1,0 +1,104 @@
+import {
+    ElGamalCiphertext,
+    ElGamalKeypair,
+    GroupedElGamalCiphertext3Handles,
+    PedersenOpening,
+} from '@solana/zk-sdk/node';
+import { expect, it } from 'vitest';
+
+import {
+    addWithLoHiCiphertexts,
+    extractCiphertextFromGroupedBytes,
+    subtractWithLoHiCiphertexts,
+} from '../src/confidentialTransferArithmetic';
+
+const LO_BIT_LENGTH = 16n;
+
+function splitAmount(amount: bigint, bitLength: bigint): [bigint, bigint] {
+    const mask = (1n << bitLength) - 1n;
+    return [amount & mask, amount >> bitLength];
+}
+
+// Builds the raw bytes of a grouped 3-handle ciphertext of `amount` under
+// `[pubkey0, pubkey1, pubkey2]`, the layout the mint/burn helpers encrypt into.
+function groupedCiphertextBytes(
+    pubkey0: ReturnType<ElGamalKeypair['pubkey']>,
+    pubkey1: ReturnType<ElGamalKeypair['pubkey']>,
+    pubkey2: ReturnType<ElGamalKeypair['pubkey']>,
+    amount: bigint,
+): Uint8Array {
+    return GroupedElGamalCiphertext3Handles.encryptWith(
+        pubkey0,
+        pubkey1,
+        pubkey2,
+        amount,
+        new PedersenOpening(),
+    ).toBytes();
+}
+
+function decrypt(keypair: ElGamalKeypair, ciphertextBytes: Uint8Array): bigint {
+    const ciphertext = ElGamalCiphertext.fromBytes(new Uint8Array(ciphertextBytes));
+    if (!ciphertext) {
+        throw new Error('Failed to decode ciphertext.');
+    }
+    return keypair.secret().decrypt(ciphertext);
+}
+
+// Exercises the exact arithmetic `getConfidentialMintInstructionPlan` performs:
+// the amount is grouped-encrypted under [destination, supply, auditor], the
+// supply handle (index 1) is combined lo/hi and homomorphically added to the
+// mint's current encrypted supply. An amount that straddles the 16-bit boundary
+// exercises both the lo and hi halves.
+it('addWithLoHiCiphertexts adds the grouped mint amount to the running supply', () => {
+    const supply = new ElGamalKeypair();
+    const destination = new ElGamalKeypair();
+    const auditor = new ElGamalKeypair();
+
+    const currentSupply = 10n;
+    const amount = 65541n; // lo = 5, hi = 1
+    const [amountLo, amountHi] = splitAmount(amount, LO_BIT_LENGTH);
+
+    const currentSupplyCiphertext = new Uint8Array(supply.pubkey().encryptU64(currentSupply).toBytes());
+    const groupedLo = groupedCiphertextBytes(destination.pubkey(), supply.pubkey(), auditor.pubkey(), amountLo);
+    const groupedHi = groupedCiphertextBytes(destination.pubkey(), supply.pubkey(), auditor.pubkey(), amountHi);
+    const supplyCiphertextLo = extractCiphertextFromGroupedBytes(groupedLo, 1);
+    const supplyCiphertextHi = extractCiphertextFromGroupedBytes(groupedHi, 1);
+
+    const newSupplyCiphertext = addWithLoHiCiphertexts(
+        currentSupplyCiphertext,
+        supplyCiphertextLo,
+        supplyCiphertextHi,
+        LO_BIT_LENGTH,
+    );
+
+    expect(decrypt(supply, newSupplyCiphertext)).toBe(currentSupply + amount);
+});
+
+// Exercises the arithmetic `getConfidentialBurnInstructionPlan` performs: the
+// amount is grouped-encrypted under [source, supply, auditor], the source handle
+// (index 0) is combined lo/hi and homomorphically subtracted from the account's
+// available balance.
+it('subtractWithLoHiCiphertexts subtracts the grouped burn amount from the balance', () => {
+    const source = new ElGamalKeypair();
+    const supply = new ElGamalKeypair();
+    const auditor = new ElGamalKeypair();
+
+    const currentBalance = 65600n;
+    const amount = 65541n; // lo = 5, hi = 1
+    const [amountLo, amountHi] = splitAmount(amount, LO_BIT_LENGTH);
+
+    const currentBalanceCiphertext = new Uint8Array(source.pubkey().encryptU64(currentBalance).toBytes());
+    const groupedLo = groupedCiphertextBytes(source.pubkey(), supply.pubkey(), auditor.pubkey(), amountLo);
+    const groupedHi = groupedCiphertextBytes(source.pubkey(), supply.pubkey(), auditor.pubkey(), amountHi);
+    const sourceCiphertextLo = extractCiphertextFromGroupedBytes(groupedLo, 0);
+    const sourceCiphertextHi = extractCiphertextFromGroupedBytes(groupedHi, 0);
+
+    const newBalanceCiphertext = subtractWithLoHiCiphertexts(
+        currentBalanceCiphertext,
+        sourceCiphertextLo,
+        sourceCiphertextHi,
+        LO_BIT_LENGTH,
+    );
+
+    expect(decrypt(source, newBalanceCiphertext)).toBe(currentBalance - amount);
+});

--- a/clients/js/test/extensions/confidentialMintBurn/getConfidentialMintBurnInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialMintBurn/getConfidentialMintBurnInstructionPlan.test.ts
@@ -1,0 +1,140 @@
+import { isSome } from '@solana/kit';
+import { AeCiphertext } from '@solana/zk-sdk/bundler';
+import { expect, it } from 'vitest';
+
+import { Mint, fetchMint, fetchToken, getApplyConfidentialPendingBurnInstruction } from '../../../src';
+import {
+    decryptConfidentialTransferBalance,
+    getApplyConfidentialPendingBalanceInstructionFromToken,
+    getConfidentialBurnInstructionPlan,
+    getConfidentialMintInstructionPlan,
+    getUpdateConfidentialMintBurnDecryptableSupplyInstructionFromSupply,
+} from '../../../src/confidential';
+import {
+    createConfidentialMintBurnMint,
+    createConfidentialTokenAccount,
+    createValidatorClient,
+    generateKeyPairSignerWithSol,
+} from '../../_setup';
+
+const DECIMALS = 2;
+const MINT_AMOUNT = 500n;
+const BURN_AMOUNT = 200n;
+
+function getConfidentialMintBurnExtension(mint: Mint) {
+    if (!isSome(mint.extensions)) {
+        throw new Error('Mint account is missing extensions.');
+    }
+    const extension = mint.extensions.value.find(candidate => candidate.__kind === 'ConfidentialMintBurn');
+    if (!extension || extension.__kind !== 'ConfidentialMintBurn') {
+        throw new Error('Mint account is missing the ConfidentialMintBurn extension.');
+    }
+    return extension;
+}
+
+it('confidentially mints into, applies, burns from, and re-syncs the supply of a mint-burn mint', async () => {
+    // Given a mint-burn mint (both ConfidentialTransferMint + ConfidentialMintBurn)
+    // and a confidential token account for an owner.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const owner = await generateKeyPairSignerWithSol(client);
+    const { mint, mintAuthority, supplyElgamalKeypair, supplyAesKey } = await createConfidentialMintBurnMint({
+        client,
+        payer,
+        decimals: DECIMALS,
+    });
+    const account = await createConfidentialTokenAccount({ client, payer, owner, mint });
+
+    // When the authority confidentially mints into the account's pending balance.
+    const [{ data: destinationTokenAccount }, { data: mintAccount }] = await Promise.all([
+        fetchToken(client.rpc, account.token),
+        fetchMint(client.rpc, mint),
+    ]);
+    await client.sendTransactions(
+        await getConfidentialMintInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: account.token,
+            mint,
+            mintAccount,
+            destinationTokenAccount,
+            authority: mintAuthority,
+            amount: MINT_AMOUNT,
+            supplyElgamalKeypair,
+            supplyAesKey,
+        }),
+    );
+
+    // And the owner applies the pending balance so the minted amount is available.
+    const { data: afterMint } = await fetchToken(client.rpc, account.token);
+    await client.sendTransaction([
+        getApplyConfidentialPendingBalanceInstructionFromToken({
+            token: account.token,
+            tokenAccount: afterMint,
+            authority: owner,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }),
+    ]);
+
+    // Then the account's available balance decrypts to the minted amount.
+    const { data: appliedAccount } = await fetchToken(client.rpc, account.token);
+    expect(
+        decryptConfidentialTransferBalance({
+            tokenAccount: appliedAccount,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }).availableBalance,
+    ).toBe(MINT_AMOUNT);
+
+    // When the owner confidentially burns part of the available balance.
+    const [{ data: sourceTokenAccount }, { data: mintForBurn }] = await Promise.all([
+        fetchToken(client.rpc, account.token),
+        fetchMint(client.rpc, mint),
+    ]);
+    await client.sendTransactions(
+        await getConfidentialBurnInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            token: account.token,
+            mint,
+            mintAccount: mintForBurn,
+            sourceTokenAccount,
+            authority: owner,
+            amount: BURN_AMOUNT,
+            sourceElgamalKeypair: account.elgamalKeypair,
+            aesKey: account.aesKey,
+        }),
+    );
+
+    // Then the available balance drops by the burnt amount.
+    const { data: afterBurn } = await fetchToken(client.rpc, account.token);
+    expect(
+        decryptConfidentialTransferBalance({
+            tokenAccount: afterBurn,
+            elgamalSecretKey: account.elgamalKeypair.secret(),
+            aesKey: account.aesKey,
+        }).availableBalance,
+    ).toBe(MINT_AMOUNT - BURN_AMOUNT);
+
+    // Finally the authority applies the mint's pending burn and re-syncs the
+    // decryptable supply (ApplyPendingBurn advances the encrypted supply but
+    // cannot re-encrypt the AES decryptable supply).
+    await client.sendTransaction([
+        getApplyConfidentialPendingBurnInstruction({ mint, authority: mintAuthority }),
+        getUpdateConfidentialMintBurnDecryptableSupplyInstructionFromSupply({
+            mint,
+            authority: mintAuthority,
+            supplyAesKey,
+            supply: MINT_AMOUNT - BURN_AMOUNT,
+        }),
+    ]);
+
+    const { data: finalMint } = await fetchMint(client.rpc, mint);
+    const mintBurnExtension = getConfidentialMintBurnExtension(finalMint);
+    const decryptableSupplyCiphertext = AeCiphertext.fromBytes(new Uint8Array(mintBurnExtension.decryptableSupply));
+    if (!decryptableSupplyCiphertext) {
+        throw new Error('Failed to decode the decryptable supply ciphertext.');
+    }
+    expect(supplyAesKey.decrypt(decryptableSupplyCiphertext)).toBe(MINT_AMOUNT - BURN_AMOUNT);
+});


### PR DESCRIPTION
Token-2022's /confidential subpath ships InstructionPlan helpers for transfer, withdraw and configure, but nothing for confidential mint/burn — downstream consumers had to re-derive the three-proof orchestration themselves. Add helpers so that logic lives upstream.

- getConfidentialMintInstructionPlan / getConfidentialBurnInstructionPlan: build the equality, batched grouped-3-handles validity and U128 range proofs, verify them via context-state accounts, and assemble the token instruction — reusing the existing transfer/withdraw plumbing.
- getUpdateConfidentialMintBurnDecryptableSupplyInstructionFromSupply: re-encrypt the decryptable supply under the supply AES key (u64-guarded).
- addWithLoHiCiphertexts: the one missing arithmetic primitive, mirroring subtractWithLoHiCiphertexts, for homomorphically adding the minted amount to the encrypted supply.
- test setup: createConfidentialMintBurnMint, initializing a mint with both the ConfidentialTransferMint and ConfidentialMintBurn extensions.

Covered by a new offline arithmetic test and a validator e2e that exercises mint -> apply -> burn -> apply-pending-burn -> update-supply against the on-chain ZK verifiers.