### PR TITLE
dependabot: Don't update wincode / solana SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     time: "08:00"
     timezone: UTC
   open-pull-requests-limit: 6
+  ignore:
+    # Ignore Solana dependencies and wincode for now, to avoid introducing
+    # incompatibilities in libraries used by Agave
+    - dependency-name: "solana-*"
+    - dependency-name: "wincode"
 - package-ecosystem: npm
   directories:
     - "/"


### PR DESCRIPTION
#### Problem

The SDK has been updated to wincode v0.6, which is incompatible with v0.5. If we update the SPL deps to use the newest SDK or wincode versions, then they won't be able to use Agave v4.2 when those are released, since they're still on wincode v0.5, and the bump to wincode v0.6 will only happen for Agave v4.3.

#### Summary of changes

Ignore solana-* and wincode deps for dependabot for now.

@kskalski can you take a look?