### PR TITLE
interface: Fix scaled-UI amount_to_ui_amount for multipliers below one

### DIFF
--- a/interface/src/extension/scaled_ui_amount/mod.rs
+++ b/interface/src/extension/scaled_ui_amount/mod.rs
@@ -75,19 +75,15 @@ impl ScaledUiAmountConfig {
     }
 
     /// Convert a raw amount to its UI representation using the given decimals
-    /// field.
-    ///
-    /// The value is converted to a float and then truncated towards 0. Excess
-    /// zeroes or unneeded decimal point are trimmed.
+    /// field. Excess zeroes or unneeded decimal point are trimmed.
     pub fn amount_to_ui_amount(
         &self,
         amount: u64,
         decimals: u8,
         unix_timestamp: i64,
     ) -> Option<String> {
-        let scaled_amount = (amount as f64) * self.current_multiplier(unix_timestamp);
-        let truncated_amount = Float::trunc(scaled_amount) / pow(10_f64, decimals as usize);
-        let ui_amount = format!("{truncated_amount:.*}", decimals as usize);
+        let scaled_amount = (amount as f64) * self.total_multiplier(decimals, unix_timestamp);
+        let ui_amount = format!("{scaled_amount:.*}", decimals as usize);
         Some(trim_ui_amount_string(ui_amount, decimals))
     }
 
@@ -181,15 +177,33 @@ mod tests {
         let ui_amount = config.amount_to_ui_amount(u64::MAX, 0, 0).unwrap();
         assert_eq!(ui_amount, "inf");
 
-        // truncation
+        // rounding
         let config = ScaledUiAmountConfig {
             multiplier: PodF64::from(0.99),
             new_multiplier_effective_timestamp: UnixTimestamp::from(1),
             ..Default::default()
         };
-        // This is really 0.99999... but it gets truncated
+        // This is really 0.9999, which rounds up at 2 decimal places
         let ui_amount = config.amount_to_ui_amount(101, 2, 0).unwrap();
-        assert_eq!(ui_amount, "0.99");
+        assert_eq!(ui_amount, "1");
+
+        // multipliers below one keep sub-unit amounts visible
+        let config = ScaledUiAmountConfig {
+            multiplier: PodF64::from(0.001),
+            new_multiplier_effective_timestamp: UnixTimestamp::from(1),
+            ..Default::default()
+        };
+        let ui_amount = config.amount_to_ui_amount(500, 6, 0).unwrap();
+        assert_eq!(ui_amount, "0.000001");
+        let ui_amount = config.amount_to_ui_amount(1500, 6, 0).unwrap();
+        assert_eq!(ui_amount, "0.000002");
+        let config = ScaledUiAmountConfig {
+            multiplier: PodF64::from(0.5),
+            new_multiplier_effective_timestamp: UnixTimestamp::from(1),
+            ..Default::default()
+        };
+        let ui_amount = config.amount_to_ui_amount(1, 2, 0).unwrap();
+        assert_eq!(ui_amount, "0.01");
     }
 
     #[test]


### PR DESCRIPTION
`amount_to_ui_amount` truncates the scaled amount before dividing by `10^decimals`, which floors the result to the display grid. With a multiplier below one, any amount scaling below one base unit renders as `"0"`: amount 500 at 6 decimals with multiplier 0.001 returns `"0"` instead of `"0.000001"`.

This scales with `total_multiplier` and formats to the mint's decimals, the same as the interest-bearing extension, then trims as before.

One intentional behavior change: 101 at 2 decimals with multiplier 0.99 (really 0.9999) now renders `"1"` instead of the floored `"0.99"`.

Output precision stays capped at `decimals` digits, so the issue's decimals=0 example still renders `"0"` by design. A follow-up will bring the JS clients in line with the fixed behavior (#1325).

Fixes #1324
