### PR TITLE
fix: use DeltaCommitmentMismatch error instead of CurveArithmetic

### DIFF
--- a/confidential/proof-extraction/src/errors.rs
+++ b/confidential/proof-extraction/src/errors.rs
@@ -14,4 +14,6 @@ pub enum TokenProofExtractionError {
     CurveArithmetic,
     #[error("Ciphertext extraction failed")]
     CiphertextExtraction,
+    #[error("Delta commitment mismatch")]
+    DeltaCommitmentMismatch,
 }

--- a/confidential/proof-extraction/src/transfer_with_fee.rs
+++ b/confidential/proof-extraction/src/transfer_with_fee.rs
@@ -336,7 +336,7 @@ fn verify_delta_commitment(
 
     let proof_delta_commitment_point = commitment_to_ristretto(proof_delta_commitment);
     if expected_delta_commitment_point != proof_delta_commitment_point {
-        return Err(TokenProofExtractionError::CurveArithmetic);
+        return Err(TokenProofExtractionError::DeltaCommitmentMismatch);
     }
     Ok(())
 }

--- a/program/src/extension/confidential_transfer/processor.rs
+++ b/program/src/extension/confidential_transfer/processor.rs
@@ -724,7 +724,7 @@ fn process_transfer(
 
         let fee_sigma_proof_instruction_offset =
             fee_sigma_proof_instruction_offset.ok_or(ProgramError::InvalidInstructionData)?;
-        let fee_ciphertext_validity_proof_insruction_offset =
+        let fee_ciphertext_validity_proof_instruction_offset =
             fee_ciphertext_validity_proof_instruction_offset
                 .ok_or(ProgramError::InvalidInstructionData)?;
 
@@ -739,7 +739,7 @@ fn process_transfer(
             equality_proof_instruction_offset,
             transfer_amount_ciphertext_validity_proof_instruction_offset,
             fee_sigma_proof_instruction_offset,
-            fee_ciphertext_validity_proof_insruction_offset,
+            fee_ciphertext_validity_proof_instruction_offset,
             range_proof_instruction_offset,
             fee_parameters,
         )?;


### PR DESCRIPTION
In `verify_delta_commitment`, when the proof's delta commitment doesn't match the on-chain recomputed value, the code was returning `CurveArithmetic` — which is misleading since both points are valid and the math succeeded. It's a data mismatch, not an arithmetic failure.

Added a `DeltaCommitmentMismatch` variant to `TokenProofExtractionError` and used it in the correct place.

Also fixed a typo in `processor.rs` (`insruction` → `instruction`).