### PR TITLE
fix(idl): give metadata and group discriminators a fixed size

### DIFF
--- a/clients/js/src/generated/instructions/emitTokenMetadata.ts
+++ b/clients/js/src/generated/instructions/emitTokenMetadata.ts
@@ -8,6 +8,8 @@
 
 import {
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getBytesDecoder,
     getBytesEncoder,
     getOptionDecoder,
@@ -41,7 +43,7 @@ export const EMIT_TOKEN_METADATA_DISCRIMINATOR: ReadonlyUint8Array = new Uint8Ar
 ]);
 
 export function getEmitTokenMetadataDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(EMIT_TOKEN_METADATA_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(EMIT_TOKEN_METADATA_DISCRIMINATOR);
 }
 
 export type EmitTokenMetadataInstruction<
@@ -72,7 +74,7 @@ export type EmitTokenMetadataInstructionDataArgs = {
 export function getEmitTokenMetadataInstructionDataEncoder(): Encoder<EmitTokenMetadataInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['start', getOptionEncoder(getU64Encoder())],
             ['end', getOptionEncoder(getU64Encoder())],
         ]),
@@ -87,7 +89,7 @@ export function getEmitTokenMetadataInstructionDataEncoder(): Encoder<EmitTokenM
 
 export function getEmitTokenMetadataInstructionDataDecoder(): Decoder<EmitTokenMetadataInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['start', getOptionDecoder(getU64Decoder())],
         ['end', getOptionDecoder(getU64Decoder())],
     ]);

--- a/clients/js/src/generated/instructions/initializeTokenGroup.ts
+++ b/clients/js/src/generated/instructions/initializeTokenGroup.ts
@@ -8,6 +8,8 @@
 
 import {
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getAddressDecoder,
     getAddressEncoder,
     getBytesDecoder,
@@ -24,9 +26,9 @@ import {
     type AccountMeta,
     type AccountSignerMeta,
     type Address,
-    type Codec,
-    type Decoder,
-    type Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
@@ -46,7 +48,7 @@ export const INITIALIZE_TOKEN_GROUP_DISCRIMINATOR: ReadonlyUint8Array = new Uint
 ]);
 
 export function getInitializeTokenGroupDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(INITIALIZE_TOKEN_GROUP_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(INITIALIZE_TOKEN_GROUP_DISCRIMINATOR);
 }
 
 export type InitializeTokenGroupInstruction<
@@ -83,10 +85,10 @@ export type InitializeTokenGroupInstructionDataArgs = {
     maxSize: number | bigint;
 };
 
-export function getInitializeTokenGroupInstructionDataEncoder(): Encoder<InitializeTokenGroupInstructionDataArgs> {
+export function getInitializeTokenGroupInstructionDataEncoder(): FixedSizeEncoder<InitializeTokenGroupInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['updateAuthority', getOptionEncoder(getAddressEncoder(), { prefix: null, noneValue: 'zeroes' })],
             ['maxSize', getU64Encoder()],
         ]),
@@ -94,15 +96,15 @@ export function getInitializeTokenGroupInstructionDataEncoder(): Encoder<Initial
     );
 }
 
-export function getInitializeTokenGroupInstructionDataDecoder(): Decoder<InitializeTokenGroupInstructionData> {
+export function getInitializeTokenGroupInstructionDataDecoder(): FixedSizeDecoder<InitializeTokenGroupInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['updateAuthority', getOptionDecoder(getAddressDecoder(), { prefix: null, noneValue: 'zeroes' })],
         ['maxSize', getU64Decoder()],
     ]);
 }
 
-export function getInitializeTokenGroupInstructionDataCodec(): Codec<
+export function getInitializeTokenGroupInstructionDataCodec(): FixedSizeCodec<
     InitializeTokenGroupInstructionDataArgs,
     InitializeTokenGroupInstructionData
 > {

--- a/clients/js/src/generated/instructions/initializeTokenGroupMember.ts
+++ b/clients/js/src/generated/instructions/initializeTokenGroupMember.ts
@@ -8,6 +8,8 @@
 
 import {
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getBytesDecoder,
     getBytesEncoder,
     getStructDecoder,
@@ -18,9 +20,9 @@ import {
     type AccountMeta,
     type AccountSignerMeta,
     type Address,
-    type Codec,
-    type Decoder,
-    type Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
@@ -38,7 +40,7 @@ export const INITIALIZE_TOKEN_GROUP_MEMBER_DISCRIMINATOR: ReadonlyUint8Array = n
 ]);
 
 export function getInitializeTokenGroupMemberDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(INITIALIZE_TOKEN_GROUP_MEMBER_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(INITIALIZE_TOKEN_GROUP_MEMBER_DISCRIMINATOR);
 }
 
 export type InitializeTokenGroupMemberInstruction<
@@ -70,18 +72,18 @@ export type InitializeTokenGroupMemberInstructionData = { discriminator: Readonl
 
 export type InitializeTokenGroupMemberInstructionDataArgs = {};
 
-export function getInitializeTokenGroupMemberInstructionDataEncoder(): Encoder<InitializeTokenGroupMemberInstructionDataArgs> {
-    return transformEncoder(getStructEncoder([['discriminator', getBytesEncoder()]]), value => ({
+export function getInitializeTokenGroupMemberInstructionDataEncoder(): FixedSizeEncoder<InitializeTokenGroupMemberInstructionDataArgs> {
+    return transformEncoder(getStructEncoder([['discriminator', fixEncoderSize(getBytesEncoder(), 8)]]), value => ({
         ...value,
         discriminator: INITIALIZE_TOKEN_GROUP_MEMBER_DISCRIMINATOR,
     }));
 }
 
-export function getInitializeTokenGroupMemberInstructionDataDecoder(): Decoder<InitializeTokenGroupMemberInstructionData> {
-    return getStructDecoder([['discriminator', getBytesDecoder()]]);
+export function getInitializeTokenGroupMemberInstructionDataDecoder(): FixedSizeDecoder<InitializeTokenGroupMemberInstructionData> {
+    return getStructDecoder([['discriminator', fixDecoderSize(getBytesDecoder(), 8)]]);
 }
 
-export function getInitializeTokenGroupMemberInstructionDataCodec(): Codec<
+export function getInitializeTokenGroupMemberInstructionDataCodec(): FixedSizeCodec<
     InitializeTokenGroupMemberInstructionDataArgs,
     InitializeTokenGroupMemberInstructionData
 > {

--- a/clients/js/src/generated/instructions/initializeTokenMetadata.ts
+++ b/clients/js/src/generated/instructions/initializeTokenMetadata.ts
@@ -10,6 +10,8 @@ import {
     addDecoderSizePrefix,
     addEncoderSizePrefix,
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getBytesDecoder,
     getBytesEncoder,
     getStructDecoder,
@@ -44,7 +46,7 @@ export const INITIALIZE_TOKEN_METADATA_DISCRIMINATOR: ReadonlyUint8Array = new U
 ]);
 
 export function getInitializeTokenMetadataDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(INITIALIZE_TOKEN_METADATA_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(INITIALIZE_TOKEN_METADATA_DISCRIMINATOR);
 }
 
 export type InitializeTokenMetadataInstruction<
@@ -90,7 +92,7 @@ export type InitializeTokenMetadataInstructionDataArgs = {
 export function getInitializeTokenMetadataInstructionDataEncoder(): Encoder<InitializeTokenMetadataInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['name', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
             ['symbol', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
             ['uri', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
@@ -101,7 +103,7 @@ export function getInitializeTokenMetadataInstructionDataEncoder(): Encoder<Init
 
 export function getInitializeTokenMetadataInstructionDataDecoder(): Decoder<InitializeTokenMetadataInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
         ['symbol', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
         ['uri', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],

--- a/clients/js/src/generated/instructions/removeTokenMetadataKey.ts
+++ b/clients/js/src/generated/instructions/removeTokenMetadataKey.ts
@@ -10,6 +10,8 @@ import {
     addDecoderSizePrefix,
     addEncoderSizePrefix,
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getBooleanDecoder,
     getBooleanEncoder,
     getBytesDecoder,
@@ -45,7 +47,7 @@ export const REMOVE_TOKEN_METADATA_KEY_DISCRIMINATOR: ReadonlyUint8Array = new U
 ]);
 
 export function getRemoveTokenMetadataKeyDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(REMOVE_TOKEN_METADATA_KEY_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(REMOVE_TOKEN_METADATA_KEY_DISCRIMINATOR);
 }
 
 export type RemoveTokenMetadataKeyInstruction<
@@ -89,7 +91,7 @@ export type RemoveTokenMetadataKeyInstructionDataArgs = {
 export function getRemoveTokenMetadataKeyInstructionDataEncoder(): Encoder<RemoveTokenMetadataKeyInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['idempotent', getBooleanEncoder()],
             ['key', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
         ]),
@@ -103,7 +105,7 @@ export function getRemoveTokenMetadataKeyInstructionDataEncoder(): Encoder<Remov
 
 export function getRemoveTokenMetadataKeyInstructionDataDecoder(): Decoder<RemoveTokenMetadataKeyInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['idempotent', getBooleanDecoder()],
         ['key', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
     ]);

--- a/clients/js/src/generated/instructions/updateTokenGroupMaxSize.ts
+++ b/clients/js/src/generated/instructions/updateTokenGroupMaxSize.ts
@@ -8,6 +8,8 @@
 
 import {
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getBytesDecoder,
     getBytesEncoder,
     getStructDecoder,
@@ -20,9 +22,9 @@ import {
     type AccountMeta,
     type AccountSignerMeta,
     type Address,
-    type Codec,
-    type Decoder,
-    type Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
@@ -39,7 +41,7 @@ export const UPDATE_TOKEN_GROUP_MAX_SIZE_DISCRIMINATOR: ReadonlyUint8Array = new
 ]);
 
 export function getUpdateTokenGroupMaxSizeDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(UPDATE_TOKEN_GROUP_MAX_SIZE_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(UPDATE_TOKEN_GROUP_MAX_SIZE_DISCRIMINATOR);
 }
 
 export type UpdateTokenGroupMaxSizeInstruction<
@@ -70,24 +72,24 @@ export type UpdateTokenGroupMaxSizeInstructionDataArgs = {
     maxSize: number | bigint;
 };
 
-export function getUpdateTokenGroupMaxSizeInstructionDataEncoder(): Encoder<UpdateTokenGroupMaxSizeInstructionDataArgs> {
+export function getUpdateTokenGroupMaxSizeInstructionDataEncoder(): FixedSizeEncoder<UpdateTokenGroupMaxSizeInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['maxSize', getU64Encoder()],
         ]),
         value => ({ ...value, discriminator: UPDATE_TOKEN_GROUP_MAX_SIZE_DISCRIMINATOR }),
     );
 }
 
-export function getUpdateTokenGroupMaxSizeInstructionDataDecoder(): Decoder<UpdateTokenGroupMaxSizeInstructionData> {
+export function getUpdateTokenGroupMaxSizeInstructionDataDecoder(): FixedSizeDecoder<UpdateTokenGroupMaxSizeInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['maxSize', getU64Decoder()],
     ]);
 }
 
-export function getUpdateTokenGroupMaxSizeInstructionDataCodec(): Codec<
+export function getUpdateTokenGroupMaxSizeInstructionDataCodec(): FixedSizeCodec<
     UpdateTokenGroupMaxSizeInstructionDataArgs,
     UpdateTokenGroupMaxSizeInstructionData
 > {

--- a/clients/js/src/generated/instructions/updateTokenGroupUpdateAuthority.ts
+++ b/clients/js/src/generated/instructions/updateTokenGroupUpdateAuthority.ts
@@ -8,6 +8,8 @@
 
 import {
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getAddressDecoder,
     getAddressEncoder,
     getBytesDecoder,
@@ -22,9 +24,9 @@ import {
     type AccountMeta,
     type AccountSignerMeta,
     type Address,
-    type Codec,
-    type Decoder,
-    type Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
@@ -43,7 +45,7 @@ export const UPDATE_TOKEN_GROUP_UPDATE_AUTHORITY_DISCRIMINATOR: ReadonlyUint8Arr
 ]);
 
 export function getUpdateTokenGroupUpdateAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(UPDATE_TOKEN_GROUP_UPDATE_AUTHORITY_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(UPDATE_TOKEN_GROUP_UPDATE_AUTHORITY_DISCRIMINATOR);
 }
 
 export type UpdateTokenGroupUpdateAuthorityInstruction<
@@ -74,24 +76,24 @@ export type UpdateTokenGroupUpdateAuthorityInstructionDataArgs = {
     newUpdateAuthority: OptionOrNullable<Address>;
 };
 
-export function getUpdateTokenGroupUpdateAuthorityInstructionDataEncoder(): Encoder<UpdateTokenGroupUpdateAuthorityInstructionDataArgs> {
+export function getUpdateTokenGroupUpdateAuthorityInstructionDataEncoder(): FixedSizeEncoder<UpdateTokenGroupUpdateAuthorityInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['newUpdateAuthority', getOptionEncoder(getAddressEncoder(), { prefix: null, noneValue: 'zeroes' })],
         ]),
         value => ({ ...value, discriminator: UPDATE_TOKEN_GROUP_UPDATE_AUTHORITY_DISCRIMINATOR }),
     );
 }
 
-export function getUpdateTokenGroupUpdateAuthorityInstructionDataDecoder(): Decoder<UpdateTokenGroupUpdateAuthorityInstructionData> {
+export function getUpdateTokenGroupUpdateAuthorityInstructionDataDecoder(): FixedSizeDecoder<UpdateTokenGroupUpdateAuthorityInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['newUpdateAuthority', getOptionDecoder(getAddressDecoder(), { prefix: null, noneValue: 'zeroes' })],
     ]);
 }
 
-export function getUpdateTokenGroupUpdateAuthorityInstructionDataCodec(): Codec<
+export function getUpdateTokenGroupUpdateAuthorityInstructionDataCodec(): FixedSizeCodec<
     UpdateTokenGroupUpdateAuthorityInstructionDataArgs,
     UpdateTokenGroupUpdateAuthorityInstructionData
 > {

--- a/clients/js/src/generated/instructions/updateTokenMetadataField.ts
+++ b/clients/js/src/generated/instructions/updateTokenMetadataField.ts
@@ -10,6 +10,8 @@ import {
     addDecoderSizePrefix,
     addEncoderSizePrefix,
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getBytesDecoder,
     getBytesEncoder,
     getStructDecoder,
@@ -49,7 +51,7 @@ export const UPDATE_TOKEN_METADATA_FIELD_DISCRIMINATOR: ReadonlyUint8Array = new
 ]);
 
 export function getUpdateTokenMetadataFieldDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(UPDATE_TOKEN_METADATA_FIELD_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(UPDATE_TOKEN_METADATA_FIELD_DISCRIMINATOR);
 }
 
 export type UpdateTokenMetadataFieldInstruction<
@@ -87,7 +89,7 @@ export type UpdateTokenMetadataFieldInstructionDataArgs = {
 export function getUpdateTokenMetadataFieldInstructionDataEncoder(): Encoder<UpdateTokenMetadataFieldInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['field', getTokenMetadataFieldEncoder()],
             ['value', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
         ]),
@@ -97,7 +99,7 @@ export function getUpdateTokenMetadataFieldInstructionDataEncoder(): Encoder<Upd
 
 export function getUpdateTokenMetadataFieldInstructionDataDecoder(): Decoder<UpdateTokenMetadataFieldInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['field', getTokenMetadataFieldDecoder()],
         ['value', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
     ]);

--- a/clients/js/src/generated/instructions/updateTokenMetadataUpdateAuthority.ts
+++ b/clients/js/src/generated/instructions/updateTokenMetadataUpdateAuthority.ts
@@ -8,6 +8,8 @@
 
 import {
     combineCodec,
+    fixDecoderSize,
+    fixEncoderSize,
     getAddressDecoder,
     getAddressEncoder,
     getBytesDecoder,
@@ -22,9 +24,9 @@ import {
     type AccountMeta,
     type AccountSignerMeta,
     type Address,
-    type Codec,
-    type Decoder,
-    type Encoder,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
     type Instruction,
     type InstructionWithAccounts,
     type InstructionWithData,
@@ -43,7 +45,7 @@ export const UPDATE_TOKEN_METADATA_UPDATE_AUTHORITY_DISCRIMINATOR: ReadonlyUint8
 ]);
 
 export function getUpdateTokenMetadataUpdateAuthorityDiscriminatorBytes(): ReadonlyUint8Array {
-    return getBytesEncoder().encode(UPDATE_TOKEN_METADATA_UPDATE_AUTHORITY_DISCRIMINATOR);
+    return fixEncoderSize(getBytesEncoder(), 8).encode(UPDATE_TOKEN_METADATA_UPDATE_AUTHORITY_DISCRIMINATOR);
 }
 
 export type UpdateTokenMetadataUpdateAuthorityInstruction<
@@ -74,24 +76,24 @@ export type UpdateTokenMetadataUpdateAuthorityInstructionDataArgs = {
     newUpdateAuthority: OptionOrNullable<Address>;
 };
 
-export function getUpdateTokenMetadataUpdateAuthorityInstructionDataEncoder(): Encoder<UpdateTokenMetadataUpdateAuthorityInstructionDataArgs> {
+export function getUpdateTokenMetadataUpdateAuthorityInstructionDataEncoder(): FixedSizeEncoder<UpdateTokenMetadataUpdateAuthorityInstructionDataArgs> {
     return transformEncoder(
         getStructEncoder([
-            ['discriminator', getBytesEncoder()],
+            ['discriminator', fixEncoderSize(getBytesEncoder(), 8)],
             ['newUpdateAuthority', getOptionEncoder(getAddressEncoder(), { prefix: null, noneValue: 'zeroes' })],
         ]),
         value => ({ ...value, discriminator: UPDATE_TOKEN_METADATA_UPDATE_AUTHORITY_DISCRIMINATOR }),
     );
 }
 
-export function getUpdateTokenMetadataUpdateAuthorityInstructionDataDecoder(): Decoder<UpdateTokenMetadataUpdateAuthorityInstructionData> {
+export function getUpdateTokenMetadataUpdateAuthorityInstructionDataDecoder(): FixedSizeDecoder<UpdateTokenMetadataUpdateAuthorityInstructionData> {
     return getStructDecoder([
-        ['discriminator', getBytesDecoder()],
+        ['discriminator', fixDecoderSize(getBytesDecoder(), 8)],
         ['newUpdateAuthority', getOptionDecoder(getAddressDecoder(), { prefix: null, noneValue: 'zeroes' })],
     ]);
 }
 
-export function getUpdateTokenMetadataUpdateAuthorityInstructionDataCodec(): Codec<
+export function getUpdateTokenMetadataUpdateAuthorityInstructionDataCodec(): FixedSizeCodec<
     UpdateTokenMetadataUpdateAuthorityInstructionDataArgs,
     UpdateTokenMetadataUpdateAuthorityInstructionData
 > {

--- a/clients/js/src/generated/programs/token2022.ts
+++ b/clients/js/src/generated/programs/token2022.ts
@@ -10,6 +10,8 @@ import {
     assertIsInstructionWithAccounts,
     containsBytes,
     extendClient,
+    fixEncoderSize,
+    getBytesEncoder,
     getU8Encoder,
     SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT,
     SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION,
@@ -834,31 +836,85 @@ export function identifyToken2022Instruction(
     if (containsBytes(data, getU8Encoder().encode(44), 0) && containsBytes(data, getU8Encoder().encode(2), 1)) {
         return Token2022Instruction.Resume;
     }
-    if (containsBytes(data, new Uint8Array([210, 225, 30, 162, 88, 184, 77, 141]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([210, 225, 30, 162, 88, 184, 77, 141])),
+            0,
+        )
+    ) {
         return Token2022Instruction.InitializeTokenMetadata;
     }
-    if (containsBytes(data, new Uint8Array([221, 233, 49, 45, 181, 202, 220, 200]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([221, 233, 49, 45, 181, 202, 220, 200])),
+            0,
+        )
+    ) {
         return Token2022Instruction.UpdateTokenMetadataField;
     }
-    if (containsBytes(data, new Uint8Array([234, 18, 32, 56, 89, 141, 37, 181]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([234, 18, 32, 56, 89, 141, 37, 181])),
+            0,
+        )
+    ) {
         return Token2022Instruction.RemoveTokenMetadataKey;
     }
-    if (containsBytes(data, new Uint8Array([215, 228, 166, 228, 84, 100, 86, 123]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([215, 228, 166, 228, 84, 100, 86, 123])),
+            0,
+        )
+    ) {
         return Token2022Instruction.UpdateTokenMetadataUpdateAuthority;
     }
-    if (containsBytes(data, new Uint8Array([250, 166, 180, 250, 13, 12, 184, 70]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([250, 166, 180, 250, 13, 12, 184, 70])),
+            0,
+        )
+    ) {
         return Token2022Instruction.EmitTokenMetadata;
     }
-    if (containsBytes(data, new Uint8Array([121, 113, 108, 39, 54, 51, 0, 4]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([121, 113, 108, 39, 54, 51, 0, 4])),
+            0,
+        )
+    ) {
         return Token2022Instruction.InitializeTokenGroup;
     }
-    if (containsBytes(data, new Uint8Array([108, 37, 171, 143, 248, 30, 18, 110]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([108, 37, 171, 143, 248, 30, 18, 110])),
+            0,
+        )
+    ) {
         return Token2022Instruction.UpdateTokenGroupMaxSize;
     }
-    if (containsBytes(data, new Uint8Array([161, 105, 88, 1, 237, 221, 216, 203]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([161, 105, 88, 1, 237, 221, 216, 203])),
+            0,
+        )
+    ) {
         return Token2022Instruction.UpdateTokenGroupUpdateAuthority;
     }
-    if (containsBytes(data, new Uint8Array([152, 32, 222, 176, 223, 237, 116, 134]), 0)) {
+    if (
+        containsBytes(
+            data,
+            fixEncoderSize(getBytesEncoder(), 8).encode(new Uint8Array([152, 32, 222, 176, 223, 237, 116, 134])),
+            0,
+        )
+    ) {
         return Token2022Instruction.InitializeTokenGroupMember;
     }
     if (containsBytes(data, getU8Encoder().encode(45), 0)) {

--- a/clients/js/test/instructionDataRoundTrip.test.ts
+++ b/clients/js/test/instructionDataRoundTrip.test.ts
@@ -1,0 +1,165 @@
+import { generateKeyPairSigner, none, some, type Address } from '@solana/kit';
+import { describe, expect, it } from 'vitest';
+
+import {
+    INITIALIZE_TOKEN_GROUP_MEMBER_DISCRIMINATOR,
+    getEmitTokenMetadataInstruction,
+    getInitializeTokenGroupInstruction,
+    getInitializeTokenGroupMemberInstruction,
+    getInitializeTokenMetadataInstruction,
+    getRemoveTokenMetadataKeyInstruction,
+    getUpdateTokenGroupMaxSizeInstruction,
+    getUpdateTokenGroupUpdateAuthorityInstruction,
+    getUpdateTokenMetadataFieldInstruction,
+    getUpdateTokenMetadataUpdateAuthorityInstruction,
+    parseEmitTokenMetadataInstruction,
+    parseInitializeTokenGroupInstruction,
+    parseInitializeTokenGroupMemberInstruction,
+    parseInitializeTokenMetadataInstruction,
+    parseRemoveTokenMetadataKeyInstruction,
+    parseUpdateTokenGroupMaxSizeInstruction,
+    parseUpdateTokenGroupUpdateAuthorityInstruction,
+    parseUpdateTokenMetadataFieldInstruction,
+    parseUpdateTokenMetadataUpdateAuthorityInstruction,
+} from '../src';
+
+const ADDRESS = '11111111111111111111111111111112' as Address;
+
+describe('token metadata instructions', () => {
+    it('round-trips InitializeTokenMetadata', async () => {
+        const mintAuthority = await generateKeyPairSigner();
+        const instruction = getInitializeTokenMetadataInstruction({
+            metadata: ADDRESS,
+            updateAuthority: ADDRESS,
+            mint: ADDRESS,
+            mintAuthority,
+            name: 'My Token',
+            symbol: 'MTK',
+            uri: 'https://example.com/token.json',
+        });
+
+        const { data } = parseInitializeTokenMetadataInstruction(instruction);
+
+        expect(data.name).toBe('My Token');
+        expect(data.symbol).toBe('MTK');
+        expect(data.uri).toBe('https://example.com/token.json');
+    });
+
+    it('round-trips UpdateTokenMetadataField', async () => {
+        const updateAuthority = await generateKeyPairSigner();
+        const instruction = getUpdateTokenMetadataFieldInstruction({
+            metadata: ADDRESS,
+            updateAuthority,
+            field: { __kind: 'Key', fields: ['custom'] },
+            value: 'value',
+        });
+
+        const { data } = parseUpdateTokenMetadataFieldInstruction(instruction);
+
+        expect(data.field).toStrictEqual({ __kind: 'Key', fields: ['custom'] });
+        expect(data.value).toBe('value');
+    });
+
+    it('round-trips RemoveTokenMetadataKey', async () => {
+        const updateAuthority = await generateKeyPairSigner();
+        const instruction = getRemoveTokenMetadataKeyInstruction({
+            metadata: ADDRESS,
+            updateAuthority,
+            idempotent: true,
+            key: 'custom',
+        });
+
+        const { data } = parseRemoveTokenMetadataKeyInstruction(instruction);
+
+        expect(data.idempotent).toBe(true);
+        expect(data.key).toBe('custom');
+    });
+
+    it('round-trips UpdateTokenMetadataUpdateAuthority', async () => {
+        const updateAuthority = await generateKeyPairSigner();
+        const instruction = getUpdateTokenMetadataUpdateAuthorityInstruction({
+            metadata: ADDRESS,
+            updateAuthority,
+            newUpdateAuthority: some(ADDRESS),
+        });
+
+        const { data } = parseUpdateTokenMetadataUpdateAuthorityInstruction(instruction);
+
+        expect(data.newUpdateAuthority).toStrictEqual(some(ADDRESS));
+    });
+
+    it('round-trips EmitTokenMetadata', () => {
+        const instruction = getEmitTokenMetadataInstruction({
+            metadata: ADDRESS,
+            start: some(4n),
+            end: some(20n),
+        });
+
+        const { data } = parseEmitTokenMetadataInstruction(instruction);
+
+        expect(data.start).toStrictEqual(some(4n));
+        expect(data.end).toStrictEqual(some(20n));
+    });
+});
+
+describe('token group instructions', () => {
+    it('round-trips InitializeTokenGroup', async () => {
+        const mintAuthority = await generateKeyPairSigner();
+        const instruction = getInitializeTokenGroupInstruction({
+            group: ADDRESS,
+            mint: ADDRESS,
+            mintAuthority,
+            updateAuthority: none(),
+            maxSize: 100n,
+        });
+
+        const { data } = parseInitializeTokenGroupInstruction(instruction);
+
+        expect(data.updateAuthority).toStrictEqual(none());
+        expect(data.maxSize).toBe(100n);
+    });
+
+    it('round-trips UpdateTokenGroupMaxSize', async () => {
+        const updateAuthority = await generateKeyPairSigner();
+        const instruction = getUpdateTokenGroupMaxSizeInstruction({
+            group: ADDRESS,
+            updateAuthority,
+            maxSize: 30_000n,
+        });
+
+        const { data } = parseUpdateTokenGroupMaxSizeInstruction(instruction);
+
+        expect(data.maxSize).toBe(30_000n);
+    });
+
+    it('round-trips UpdateTokenGroupUpdateAuthority', async () => {
+        const updateAuthority = await generateKeyPairSigner();
+        const instruction = getUpdateTokenGroupUpdateAuthorityInstruction({
+            group: ADDRESS,
+            updateAuthority,
+            newUpdateAuthority: some(ADDRESS),
+        });
+
+        const { data } = parseUpdateTokenGroupUpdateAuthorityInstruction(instruction);
+
+        expect(data.newUpdateAuthority).toStrictEqual(some(ADDRESS));
+    });
+
+    it('round-trips InitializeTokenGroupMember', async () => {
+        const [memberMintAuthority, groupUpdateAuthority] = await Promise.all([
+            generateKeyPairSigner(),
+            generateKeyPairSigner(),
+        ]);
+        const instruction = getInitializeTokenGroupMemberInstruction({
+            member: ADDRESS,
+            memberMint: ADDRESS,
+            memberMintAuthority,
+            group: ADDRESS,
+            groupUpdateAuthority,
+        });
+
+        const { data } = parseInitializeTokenGroupMemberInstruction(instruction);
+
+        expect(data.discriminator).toStrictEqual(INITIALIZE_TOKEN_GROUP_MEMBER_DISCRIMINATOR);
+    });
+});

--- a/idl.json
+++ b/idl.json
@@ -8558,7 +8558,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -8669,7 +8673,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -8750,7 +8758,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -8834,7 +8846,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -8894,7 +8910,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -8991,7 +9011,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -9059,7 +9083,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -9116,7 +9144,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",
@@ -9203,7 +9235,11 @@
                         "defaultValueStrategy": "omitted",
                         "docs": [],
                         "type": {
-                            "kind": "bytesTypeNode"
+                            "kind": "fixedSizeTypeNode",
+                            "size": 8,
+                            "type": {
+                                "kind": "bytesTypeNode"
+                            }
                         },
                         "defaultValue": {
                             "kind": "bytesValueNode",


### PR DESCRIPTION
## Summary

- Type the 8-byte discriminator of all nine token-metadata and token-group instructions as `fixedSizeTypeNode` in `idl.json`
- Regenerate the JS client, so decoders use `fixDecoderSize(getBytesDecoder(), 8)` instead of an unbounded `getBytesDecoder()`
- Add round-trip coverage for the nine affected instructions

## Problem

An unwrapped `bytesTypeNode` is greedy by design in Codama, so the discriminator consumed the entire instruction buffer and every subsequent field decoded from zero bytes and threw. The encoders were correct, so the client could not parse instructions it had just built:

```
RemoveTokenMetadataKey             -> Codec [u8] cannot decode empty byte arrays.
UpdateTokenGroupMaxSize            -> Codec [u64] cannot decode empty byte arrays.
UpdateTokenMetadataUpdateAuthority -> Codec [fixCodecSize] expected 32 bytes, got 0.
UpdateTokenGroupUpdateAuthority    -> Codec [fixCodecSize] expected 32 bytes, got 0.
```

Eight of the nine threw. `InitializeTokenGroupMember` did not, since it has no fields after the discriminator, but it was equally unsized.

Fixing this in the IDL rather than the generated output keeps it from returning on the next regeneration. `fixedSizeTypeNode(bytesTypeNode(), 8)` is also what `@codama/nodes-from-anchor` emits for Anchor-style discriminators, and it pairs with the `fieldDiscriminatorNode` entries these instructions already carry.

The size is not arbitrary: these discriminators are `sha256(hash_input)[..8]` via `SplDiscriminate`, where `ArrayDiscriminator::LENGTH == 8`. Each of the nine `defaultValue` byte strings reproduces exactly from its `discriminator_hash_input` string in `spl-token-metadata-interface` / `spl-token-group-interface`.

## Test plan

- `clients/js/test/instructionDataRoundTrip.test.ts` asserts `parse(build(input))` returns the original fields for all nine instructions; 8 of the 9 cases fail without this change
- `make generate-clients` leaves the tree clean, so the committed output matches the IDL
- `clients/js`: `pnpm test` (tsc + vitest), `pnpm lint`, `pnpm format` all pass
- `clients/js-legacy`: 106 tests pass, lint and format clean
- Pre-existing `confidentialTransfer` failures are unchanged from `main`

Closes DEV-821
