### PR TITLE
Remove @solana/zk-sdk runtime duck-typing now that 0.5.1 exposes the API

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -61,7 +61,7 @@
         "@solana/kit-plugin-litesvm": "^0.15.0",
         "@solana/kit-plugin-rpc": "^0.15.0",
         "@solana/kit-plugin-signer": "^0.13.0",
-        "@solana/zk-sdk": "^0.4.2",
+        "@solana/zk-sdk": "^0.5.1",
         "@types/node": "^26",
         "oxfmt": "^0.61.0",
         "oxlint": "^1.70.0",
@@ -75,7 +75,7 @@
     "peerDependencies": {
         "@solana/kit": "^7.0.0",
         "@solana/sysvars": "^7.0.0",
-        "@solana/zk-sdk": "^0.4.2"
+        "@solana/zk-sdk": "^0.5.1"
     },
     "peerDependenciesMeta": {
         "@solana/zk-sdk": {

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0(@solana/kit@7.0.0(typescript@6.0.3))
       '@solana/zk-sdk':
-        specifier: ^0.4.2
-        version: 0.4.2
+        specifier: ^0.5.1
+        version: 0.5.1
       '@types/node':
         specifier: ^26
         version: 26.1.2
@@ -321,48 +321,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.61.0':
     resolution: {integrity: sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
     resolution: {integrity: sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
     resolution: {integrity: sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.61.0':
     resolution: {integrity: sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.61.0':
     resolution: {integrity: sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.61.0':
     resolution: {integrity: sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.61.0':
     resolution: {integrity: sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.61.0':
     resolution: {integrity: sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==}
@@ -465,48 +473,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.76.0':
     resolution: {integrity: sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.76.0':
     resolution: {integrity: sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.76.0':
     resolution: {integrity: sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.76.0':
     resolution: {integrity: sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.76.0':
     resolution: {integrity: sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.76.0':
     resolution: {integrity: sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.76.0':
     resolution: {integrity: sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.76.0':
     resolution: {integrity: sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==}
@@ -567,36 +583,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -658,66 +680,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -1595,8 +1630,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/zk-sdk@0.4.2':
-    resolution: {integrity: sha512-lTc3lvg2b14oP7XURa6jmI2m7CLyJR5otf6TVdzw+xo/A9aYvXEQxCqaK7qpfu2JYuzNxRGqP3RnjAvdOSOEUQ==}
+  '@solana/zk-sdk@0.5.1':
+    resolution: {integrity: sha512-dWGAzjApjsVGtwllaXxlD2DxpCdTD4yr1eMQOJBSZglTe0dtVW2TFShABRNkWtD11ZekZ+6kODVSDkWt6RL7mw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1806,24 +1841,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1868,24 +1907,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-arm64-musl@1.3.0:
     resolution: {integrity: sha512-FO9p6rx+/3h7R3CU7lkOebL+jy8UEDngSrENHu7pj9EOr78QVyE3Fm0O+WMnwXpMoCSgW0XLhu1cI9NHAbzCTA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   litesvm-linux-x64-gnu@1.3.0:
     resolution: {integrity: sha512-yXC8ZAdIei9JQ2xw5/BocOTu/7EqZuFPyhgENQ1mYDhjNpoyUbIuGCWnqtria14mDda0aV9yVev8plGUrUpjUw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   litesvm-linux-x64-musl@1.3.0:
     resolution: {integrity: sha512-oedromp1gTjShXmKmxZ1FYtnfM824vRcrPSPvGM0CrqJqKK61m1+tFwNRAVsDlpmWKvO/zsz90ctbgAUo/3TXg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   litesvm@1.3.0:
     resolution: {integrity: sha512-tMu9sBIqSbF1gQluXEUtGmXPfZlMc10tOoBVeDokgK77nl/CcuC506sEoFKM5Rq58Dkb070lBMVBLc43TbMUzQ==}
@@ -3677,7 +3720,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/zk-sdk@0.4.2': {}
+  '@solana/zk-sdk@0.5.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -96,28 +96,10 @@ const NET_TRANSFER_AMOUNT_BIT_LENGTH = 64;
 const COMPUTE_BUDGET_PROGRAM_ADDRESS =
     'ComputeBudget111111111111111111111111111111' as Address<'ComputeBudget111111111111111111111111111111'>;
 const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
-const PEDERSEN_ARITHMETIC_ERROR =
-    'Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment and opening arithmetic.';
-
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
 type TransferFeeConfigExtension = Extract<Extension, { __kind: 'TransferFeeConfig' }>;
 type TransferFee = TransferFeeConfigExtension['olderTransferFee'];
-type PedersenCommitmentWithArithmetic = PedersenCommitment & {
-    subtract(other: PedersenCommitment): PedersenCommitment;
-    multiplyByU64(scalar: bigint): PedersenCommitment;
-};
-type PedersenCommitmentConstructorWithArithmetic = typeof PedersenCommitment & {
-    combineLoHi(lo: PedersenCommitment, hi: PedersenCommitment, bitLength: number): PedersenCommitment;
-};
-type PedersenOpeningWithArithmetic = PedersenOpening & {
-    subtract(other: PedersenOpening): PedersenOpening;
-    multiplyByU64(scalar: bigint): PedersenOpening;
-};
-type PedersenOpeningConstructorWithArithmetic = typeof PedersenOpening & {
-    zero(): PedersenOpening;
-    combineLoHi(lo: PedersenOpening, hi: PedersenOpening, bitLength: number): PedersenOpening;
-};
 type ProofDataInput = Uint8Array | { account: Address; offset: number };
 type ContextStateProofPlan = Readonly<{ address: Address; setup: InstructionPlan; cleanup: InstructionPlan }>;
 
@@ -453,60 +435,6 @@ function calculateTransferWithFeeAmounts(transferAmount: bigint, transferFeeBasi
     }
 
     return { feeAmount, claimedDeltaFee, netTransferAmount };
-}
-
-function assertPedersenArithmeticAvailable(): void {
-    const commitmentConstructor = PedersenCommitment as unknown as PedersenCommitmentConstructorWithArithmetic;
-    const openingConstructor = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
-    const commitment = PedersenCommitment.from(0n, new PedersenOpening()) as PedersenCommitmentWithArithmetic;
-    const opening = new PedersenOpening() as PedersenOpeningWithArithmetic;
-    if (
-        typeof commitmentConstructor.combineLoHi !== 'function' ||
-        typeof openingConstructor.combineLoHi !== 'function' ||
-        typeof openingConstructor.zero !== 'function' ||
-        typeof commitment.subtract !== 'function' ||
-        typeof commitment.multiplyByU64 !== 'function' ||
-        typeof opening.subtract !== 'function' ||
-        typeof opening.multiplyByU64 !== 'function'
-    ) {
-        throw new Error(PEDERSEN_ARITHMETIC_ERROR);
-    }
-}
-
-function combineLoHiCommitments(lo: PedersenCommitment, hi: PedersenCommitment, bitLength: bigint): PedersenCommitment {
-    const PedersenCommitmentWithArithmetic =
-        PedersenCommitment as unknown as PedersenCommitmentConstructorWithArithmetic;
-    return PedersenCommitmentWithArithmetic.combineLoHi(lo, hi, Number(bitLength));
-}
-
-function combineLoHiOpenings(lo: PedersenOpening, hi: PedersenOpening, bitLength: bigint): PedersenOpening {
-    const PedersenOpeningWithArithmetic = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
-    return PedersenOpeningWithArithmetic.combineLoHi(lo, hi, Number(bitLength));
-}
-
-function getZeroOpening(): PedersenOpening {
-    const PedersenOpeningWithArithmetic = PedersenOpening as unknown as PedersenOpeningConstructorWithArithmetic;
-    return PedersenOpeningWithArithmetic.zero();
-}
-
-function subtractCommitments(left: PedersenCommitment, right: PedersenCommitment): PedersenCommitment {
-    const leftWithArithmetic = left as PedersenCommitmentWithArithmetic;
-    return leftWithArithmetic.subtract(right);
-}
-
-function subtractOpenings(left: PedersenOpening, right: PedersenOpening): PedersenOpening {
-    const leftWithArithmetic = left as PedersenOpeningWithArithmetic;
-    return leftWithArithmetic.subtract(right);
-}
-
-function multiplyCommitment(commitment: PedersenCommitment, scalar: bigint): PedersenCommitment {
-    const commitmentWithArithmetic = commitment as PedersenCommitmentWithArithmetic;
-    return commitmentWithArithmetic.multiplyByU64(scalar);
-}
-
-function multiplyOpening(opening: PedersenOpening, scalar: bigint): PedersenOpening {
-    const openingWithArithmetic = opening as PedersenOpeningWithArithmetic;
-    return openingWithArithmetic.multiplyByU64(scalar);
 }
 
 function getSetComputeUnitLimitInstruction(units: number): Instruction {
@@ -983,10 +911,8 @@ export async function getConfidentialTransferInstructionPlan(
  * Returns an instruction plan that confidentially transfers tokens between
  * two accounts when the mint is configured for confidential transfer fees.
  * Builds and verifies the five proofs required by `TransferWithFee` via
- * context-state accounts.
- *
- * This helper requires the Pedersen arithmetic helpers added to
- * `@solana/zk-sdk` after v0.4.2.
+ * context-state accounts, using the `@solana/zk-sdk` Pedersen arithmetic API
+ * to derive the combined fee and net-transfer commitments.
  */
 export async function getConfidentialTransferWithFeeInstructionPlan(
     input: GetConfidentialTransferWithFeeInstructionPlanInput,
@@ -1009,7 +935,6 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
     assertU64Amount(feeAmount, 'Fee amount');
     assertU64Amount(claimedDeltaFee, 'Claimed delta fee');
     assertU64Amount(netTransferAmount, 'Net transfer amount');
-    assertPedersenArithmeticAvailable();
 
     const [transferAmountLo, transferAmountHi] = splitAmount(amount, TRANSFER_AMOUNT_LO_BIT_LENGTH);
     const [feeAmountLo, feeAmountHi] = splitAmount(feeAmount, FEE_AMOUNT_LO_BIT_LENGTH);
@@ -1095,15 +1020,15 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
     const transferAmountCommitmentHi = PedersenCommitment.fromBytes(
         transferAmountGroupedCiphertextHiBytes.slice(0, 32),
     );
-    const combinedTransferAmountCommitment = combineLoHiCommitments(
+    const combinedTransferAmountCommitment = PedersenCommitment.combineLoHi(
         transferAmountCommitmentLo,
         transferAmountCommitmentHi,
-        TRANSFER_AMOUNT_LO_BIT_LENGTH,
+        Number(TRANSFER_AMOUNT_LO_BIT_LENGTH),
     );
-    const combinedTransferAmountOpening = combineLoHiOpenings(
+    const combinedTransferAmountOpening = PedersenOpening.combineLoHi(
         transferAmountOpeningLo,
         transferAmountOpeningHi,
-        TRANSFER_AMOUNT_LO_BIT_LENGTH,
+        Number(TRANSFER_AMOUNT_LO_BIT_LENGTH),
     );
 
     const feeOpeningLo = new PedersenOpening();
@@ -1124,21 +1049,27 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
     const feeGroupedCiphertextHiBytes = feeGroupedCiphertextHi.toBytes();
     const feeCommitmentLo = PedersenCommitment.fromBytes(feeGroupedCiphertextLoBytes.slice(0, 32));
     const feeCommitmentHi = PedersenCommitment.fromBytes(feeGroupedCiphertextHiBytes.slice(0, 32));
-    const combinedFeeCommitment = combineLoHiCommitments(feeCommitmentLo, feeCommitmentHi, FEE_AMOUNT_LO_BIT_LENGTH);
-    const combinedFeeOpening = combineLoHiOpenings(feeOpeningLo, feeOpeningHi, FEE_AMOUNT_LO_BIT_LENGTH);
+    const combinedFeeCommitment = PedersenCommitment.combineLoHi(
+        feeCommitmentLo,
+        feeCommitmentHi,
+        Number(FEE_AMOUNT_LO_BIT_LENGTH),
+    );
+    const combinedFeeOpening = PedersenOpening.combineLoHi(
+        feeOpeningLo,
+        feeOpeningHi,
+        Number(FEE_AMOUNT_LO_BIT_LENGTH),
+    );
 
-    const netTransferAmountCommitment = subtractCommitments(combinedTransferAmountCommitment, combinedFeeCommitment);
-    const netTransferAmountOpening = subtractOpenings(combinedTransferAmountOpening, combinedFeeOpening);
+    const netTransferAmountCommitment = combinedTransferAmountCommitment.subtract(combinedFeeCommitment);
+    const netTransferAmountOpening = combinedTransferAmountOpening.subtract(combinedFeeOpening);
     const claimedOpening = new PedersenOpening();
     const claimedCommitment = PedersenCommitment.from(claimedDeltaFee, claimedOpening);
-    const deltaCommitment = subtractCommitments(
-        multiplyCommitment(combinedFeeCommitment, MAX_FEE_BASIS_POINTS),
-        multiplyCommitment(combinedTransferAmountCommitment, BigInt(transferFee.transferFeeBasisPoints)),
-    );
-    const deltaOpening = subtractOpenings(
-        multiplyOpening(combinedFeeOpening, MAX_FEE_BASIS_POINTS),
-        multiplyOpening(combinedTransferAmountOpening, BigInt(transferFee.transferFeeBasisPoints)),
-    );
+    const deltaCommitment = combinedFeeCommitment
+        .multiplyByU64(MAX_FEE_BASIS_POINTS)
+        .subtract(combinedTransferAmountCommitment.multiplyByU64(BigInt(transferFee.transferFeeBasisPoints)));
+    const deltaOpening = combinedFeeOpening
+        .multiplyByU64(MAX_FEE_BASIS_POINTS)
+        .subtract(combinedTransferAmountOpening.multiplyByU64(BigInt(transferFee.transferFeeBasisPoints)));
     const percentageWithCapProofData = new PercentageWithCapProofData(
         combinedFeeCommitment,
         combinedFeeOpening,
@@ -1161,10 +1092,10 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
         feeOpeningHi,
     );
 
-    const zeroOpening = getZeroOpening();
+    const zeroOpening = PedersenOpening.zero();
     const maxFeeBasisPointsSubOneCommitment = PedersenCommitment.from(MAX_FEE_BASIS_POINTS_SUB_ONE, zeroOpening);
-    const claimedComplementCommitment = subtractCommitments(maxFeeBasisPointsSubOneCommitment, claimedCommitment);
-    const claimedComplementOpening = subtractOpenings(zeroOpening, claimedOpening);
+    const claimedComplementCommitment = maxFeeBasisPointsSubOneCommitment.subtract(claimedCommitment);
+    const claimedComplementOpening = zeroOpening.subtract(claimedOpening);
     const deltaFeeComplement = MAX_FEE_BASIS_POINTS_SUB_ONE - claimedDeltaFee;
     if (deltaFeeComplement < 0n) {
         throw new Error('Claimed delta fee exceeds maximum range.');

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -7,8 +7,7 @@ import {
     type MessagePartialSigner,
     type ReadonlyUint8Array,
 } from '@solana/kit';
-import { AeKey, ElGamalKeypair } from '@solana/zk-sdk/bundler';
-import * as ZkSdk from '@solana/zk-sdk/bundler';
+import { ConfidentialKeys } from '@solana/zk-sdk/bundler';
 
 export type DerivedElGamalKeypair = Readonly<{
     elgamalPubkey: Address;
@@ -24,36 +23,14 @@ async function signDerivationMessage(signer: MessagePartialSigner, message: Uint
     return new Uint8Array(signature);
 }
 
-type ConfidentialKeysInstance = Readonly<{
-    ae(): AeKey;
-    elgamal(): ElGamalKeypair;
-}>;
-type ConfidentialKeysConstructor = Readonly<{
-    fromSignature(signature: Uint8Array): ConfidentialKeysInstance;
-    signerMessage(publicSeed: Uint8Array): Uint8Array;
-}>;
-type LegacyAeKeyConstructor = typeof AeKey &
-    Readonly<{
-        fromSignature?: (signature: Uint8Array) => AeKey;
-        signerMessage?: (publicSeed: Uint8Array) => Uint8Array;
-    }>;
-type LegacyElGamalKeypairConstructor = typeof ElGamalKeypair &
-    Readonly<{
-        fromSignature?: (signature: Uint8Array) => ElGamalKeypair;
-        signerMessage?: (publicSeed: Uint8Array) => Uint8Array;
-    }>;
-
-function getConfidentialKeysConstructor(): ConfidentialKeysConstructor | undefined {
-    return (ZkSdk as unknown as { ConfidentialKeys?: ConfidentialKeysConstructor }).ConfidentialKeys;
-}
-
 function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
     return getTupleEncoder([getAddressEncoder(), getAddressEncoder()]).encode([owner, mint]);
 }
 
 /**
- * Derives an ElGamal keypair by having the signer sign a domain-separated
- * message and feeding the resulting Ed25519 signature into the WASM ZK SDK.
+ * Derives an ElGamal keypair following the `solana-conf-bal/v1` standard: the
+ * signer signs a domain-separated message and the resulting Ed25519 signature
+ * is fed into the WASM ZK SDK's `ConfidentialKeys` to derive the keypair.
  */
 export async function deriveElGamalKeypair({
     signer,
@@ -62,19 +39,9 @@ export async function deriveElGamalKeypair({
     signer: MessagePartialSigner;
     publicSeed?: ReadonlyUint8Array;
 }): Promise<DerivedElGamalKeypair> {
-    const confidentialKeys = getConfidentialKeysConstructor();
-    const legacyElGamal = ElGamalKeypair as LegacyElGamalKeypairConstructor;
-    const message =
-        confidentialKeys?.signerMessage(new Uint8Array(publicSeed)) ??
-        legacyElGamal.signerMessage?.(new Uint8Array(publicSeed));
-    if (message == null) {
-        throw new Error('The installed @solana/zk-sdk does not expose confidential key derivation.');
-    }
+    const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
-    const keypair = confidentialKeys?.fromSignature(signature).elgamal() ?? legacyElGamal.fromSignature?.(signature);
-    if (keypair == null) {
-        throw new Error('The installed @solana/zk-sdk does not expose ElGamal key derivation.');
-    }
+    const keypair = ConfidentialKeys.fromSignature(signature).elgamal();
     const secretKey = new Uint8Array(keypair.secret().toBytes());
     const elgamalPubkey = getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
     return { elgamalPubkey, secretKey };
@@ -98,9 +65,9 @@ export async function deriveElGamalKeypairForOwnerMint({
 }
 
 /**
- * Derives an AES-128 authenticated-encryption key by having the signer
- * sign a domain-separated message and feeding the signature into the
- * WASM ZK SDK.
+ * Derives an AES-128 authenticated-encryption key following the
+ * `solana-conf-bal/v1` standard: the signer signs a domain-separated message
+ * and the resulting signature is fed into the WASM ZK SDK's `ConfidentialKeys`.
  */
 export async function deriveAeKey({
     signer,
@@ -109,19 +76,9 @@ export async function deriveAeKey({
     signer: MessagePartialSigner;
     publicSeed?: ReadonlyUint8Array;
 }): Promise<Uint8Array> {
-    const confidentialKeys = getConfidentialKeysConstructor();
-    const legacyAeKey = AeKey as LegacyAeKeyConstructor;
-    const message =
-        confidentialKeys?.signerMessage(new Uint8Array(publicSeed)) ??
-        legacyAeKey.signerMessage?.(new Uint8Array(publicSeed));
-    if (message == null) {
-        throw new Error('The installed @solana/zk-sdk does not expose confidential key derivation.');
-    }
+    const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
-    const aeKey = confidentialKeys?.fromSignature(signature).ae() ?? legacyAeKey.fromSignature?.(signature);
-    if (aeKey == null) {
-        throw new Error('The installed @solana/zk-sdk does not expose AES key derivation.');
-    }
+    const aeKey = ConfidentialKeys.fromSignature(signature).ae();
     return new Uint8Array(aeKey.toBytes());
 }
 

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -31,14 +31,14 @@ const RUST_VECTOR_PUBLIC_SEED = new Uint8Array([
     1,
 ]);
 const RUST_VECTOR_ELGAMAL_SECRET_KEY = new Uint8Array([
-    241, 57, 101, 25, 81, 46, 182, 190, 48, 67, 70, 212, 112, 100, 196, 151, 81, 38, 121, 14, 125, 101, 91, 57, 182,
-    241, 127, 250, 6, 41, 183, 15,
+    148, 147, 19, 10, 117, 168, 174, 32, 148, 35, 232, 108, 225, 144, 210, 91, 130, 229, 59, 231, 81, 116, 192, 231, 21,
+    212, 43, 72, 179, 254, 237, 11,
 ]);
 const RUST_VECTOR_ELGAMAL_PUBKEY = new Uint8Array([
-    214, 11, 48, 194, 204, 45, 151, 60, 254, 187, 74, 62, 160, 235, 15, 191, 75, 101, 68, 140, 231, 60, 57, 244, 153,
-    44, 163, 98, 166, 34, 173, 16,
+    58, 106, 251, 3, 220, 178, 230, 94, 18, 53, 78, 182, 197, 128, 78, 222, 154, 202, 127, 181, 84, 63, 174, 230, 34,
+    170, 249, 12, 225, 217, 217, 102,
 ]);
-const RUST_VECTOR_AE_KEY = new Uint8Array([227, 20, 117, 208, 41, 69, 224, 51, 180, 203, 193, 101, 242, 164, 192, 190]);
+const RUST_VECTOR_AE_KEY = new Uint8Array([160, 210, 197, 15, 158, 3, 217, 111, 220, 216, 102, 104, 164, 25, 214, 183]);
 
 it('derives a 32-byte ElGamal secret key and a public key Address', async () => {
     const signer = await generateKeyPairSigner();
@@ -111,7 +111,7 @@ it('derives different keys for different signers', async () => {
     expect(aeA).not.toEqual(aeB);
 });
 
-it('matches the Rust solana-zk-sdk derivation vector', async () => {
+it('matches the solana-conf-bal/v1 derivation vector', async () => {
     const signer = await createKeyPairSignerFromPrivateKeyBytes(RUST_VECTOR_PRIVATE_KEY);
 
     const [derivedElGamal, derivedAeKey] = await Promise.all([

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithFeeInstructionPlan.test.ts
@@ -7,14 +7,7 @@ import {
     some,
     type ReadonlyUint8Array,
 } from '@solana/kit';
-import {
-    AeCiphertext,
-    AeKey,
-    ElGamalCiphertext,
-    ElGamalKeypair,
-    PedersenCommitment,
-    PedersenOpening,
-} from '@solana/zk-sdk/bundler';
+import { AeCiphertext, AeKey, ElGamalCiphertext, ElGamalKeypair } from '@solana/zk-sdk/bundler';
 import { expect, it } from 'vitest';
 
 import { ExtensionArgs, Mint, Token, extension, fetchMint, fetchToken } from '../../../src';
@@ -27,9 +20,6 @@ import {
     getTokenExtension,
     type ValidatorClient,
 } from '../../_setup';
-
-const PEDERSEN_ARITHMETIC_ERROR =
-    'Confidential transfer with fee requires @solana/zk-sdk Pedersen commitment and opening arithmetic.';
 
 function elgamalPubkeyAsAddress(keypair: ElGamalKeypair): Address {
     return getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
@@ -67,23 +57,6 @@ function decryptWithheldAmount(tokenAccount: Token, withdrawWithheldAuthorityElG
     const confidentialTransferFeeAmount = getTokenExtension(tokenAccount, 'ConfidentialTransferFeeAmount');
     const ciphertext = parseElGamalCiphertext(confidentialTransferFeeAmount.withheldAmount);
     return withdrawWithheldAuthorityElGamalKeypair.secret().decrypt(ciphertext);
-}
-
-function hasPedersenArithmetic() {
-    const opening = new PedersenOpening() as PedersenOpening & Record<string, unknown>;
-    const commitment = PedersenCommitment.from(0n, new PedersenOpening()) as PedersenCommitment &
-        Record<string, unknown>;
-    const PedersenOpeningConstructor = PedersenOpening as unknown as Record<string, unknown>;
-    const PedersenCommitmentConstructor = PedersenCommitment as unknown as Record<string, unknown>;
-    return (
-        typeof PedersenOpeningConstructor.zero === 'function' &&
-        typeof PedersenOpeningConstructor.combineLoHi === 'function' &&
-        typeof opening.subtract === 'function' &&
-        typeof opening.multiplyByU64 === 'function' &&
-        typeof PedersenCommitmentConstructor.combineLoHi === 'function' &&
-        typeof commitment.subtract === 'function' &&
-        typeof commitment.multiplyByU64 === 'function'
-    );
 }
 
 async function createConfidentialTransferFeeMint(input: {
@@ -143,8 +116,23 @@ async function createConfidentialTransferFeeMint(input: {
     return { mint: mint.address, mintAuthority, withdrawWithheldAuthorityElGamalKeypair };
 }
 
-it('transfers tokens confidentially with fees', async () => {
-    // Given a confidential-transfer-fee mint, a funded source account, and an empty destination account.
+/**
+ * Sets up a confidential-transfer-fee mint with a funded source account and an
+ * empty destination account, confidentially transfers `amount` from source to
+ * destination, and returns the decrypted post-transfer balances so each test
+ * can assert its own expected values.
+ */
+async function runTransferWithFee(input: {
+    initialSourceAmount: bigint;
+    amount: bigint;
+    maximumFee: bigint;
+    transferFeeBasisPoints: number;
+}): Promise<{
+    sourceAvailableBalance: bigint;
+    destinationPendingBalance: bigint;
+    destinationWithheldAmount: bigint;
+    destinationPendingBalanceCreditCounter: bigint;
+}> {
     const client = await createValidatorClient();
     const payer = client.payer;
     const [sourceOwner, destinationOwner] = await Promise.all([
@@ -156,8 +144,8 @@ it('transfers tokens confidentially with fees', async () => {
         client,
         payer,
         decimals,
-        maximumFee: 1_000_000_000n,
-        transferFeeBasisPoints: 150,
+        maximumFee: input.maximumFee,
+        transferFeeBasisPoints: input.transferFeeBasisPoints,
     });
     const source = await createConfidentialTokenAccountWithBalance({
         client,
@@ -166,7 +154,7 @@ it('transfers tokens confidentially with fees', async () => {
         mint,
         mintAuthority,
         decimals,
-        amount: 1000n,
+        amount: input.initialSourceAmount,
         includeConfidentialTransferFeeAmount: true,
     });
     const destination = await createConfidentialTokenAccount({
@@ -177,7 +165,6 @@ it('transfers tokens confidentially with fees', async () => {
         includeConfidentialTransferFeeAmount: true,
     });
 
-    // When the source confidentially transfers 2.00 tokens with a 1.5% fee.
     const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }, { data: mintAccount }, epochInfo] =
         await Promise.all([
             fetchToken(client.rpc, source.token),
@@ -185,40 +172,87 @@ it('transfers tokens confidentially with fees', async () => {
             fetchMint(client.rpc, mint),
             client.rpc.getEpochInfo().send(),
         ]);
-    const transferPlanPromise = getConfidentialTransferWithFeeInstructionPlan({
-        payer,
-        rpc: client.rpc,
-        sourceToken: source.token,
-        mint,
-        destinationToken: destination.token,
-        sourceTokenAccount,
-        destinationTokenAccount,
-        mintAccount,
-        currentEpoch: epochInfo.epoch,
-        authority: sourceOwner,
-        amount: 200n,
-        sourceElgamalKeypair: source.elgamalKeypair,
-        aesKey: source.aesKey,
-    });
-    if (!hasPedersenArithmetic()) {
-        // Published @solana/zk-sdk@0.4.2 does not expose the Pedersen arithmetic
-        // needed for the success path. Once it does, this test runs through the
-        // full transfer and balance assertions below.
-        await expect(transferPlanPromise).rejects.toThrow(PEDERSEN_ARITHMETIC_ERROR);
-        return;
-    }
-    await client.sendTransactions(await transferPlanPromise);
+    await client.sendTransactions(
+        await getConfidentialTransferWithFeeInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            sourceToken: source.token,
+            mint,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            mintAccount,
+            currentEpoch: epochInfo.epoch,
+            authority: sourceOwner,
+            amount: input.amount,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+        }),
+    );
 
-    // Then the source is debited by the gross amount, the destination receives the net amount,
-    // and the confidential fee amount is withheld on the destination account.
     const [{ data: updatedSource }, { data: updatedDestination }] = await Promise.all([
         fetchToken(client.rpc, source.token),
         fetchToken(client.rpc, destination.token),
     ]);
-    expect(decryptAvailableBalance(updatedSource, source.aesKey)).toBe(800n);
-    expect(decryptPendingBalance(updatedDestination, destination.elgamalKeypair)).toBe(197n);
-    expect(decryptWithheldAmount(updatedDestination, withdrawWithheldAuthorityElGamalKeypair)).toBe(3n);
-    expect(getTokenExtension(updatedDestination, 'ConfidentialTransferAccount').pendingBalanceCreditCounter).toBe(1n);
+    return {
+        sourceAvailableBalance: decryptAvailableBalance(updatedSource, source.aesKey),
+        destinationPendingBalance: decryptPendingBalance(updatedDestination, destination.elgamalKeypair),
+        destinationWithheldAmount: decryptWithheldAmount(updatedDestination, withdrawWithheldAuthorityElGamalKeypair),
+        destinationPendingBalanceCreditCounter: getTokenExtension(updatedDestination, 'ConfidentialTransferAccount')
+            .pendingBalanceCreditCounter,
+    };
+}
+
+it('transfers tokens confidentially with fees', async () => {
+    // When the source confidentially transfers 2.00 tokens with a 1.5% fee (uncapped).
+    // fee = ceil(200 * 150 / 10_000) = 3, net = 197.
+    const result = await runTransferWithFee({
+        initialSourceAmount: 1000n,
+        amount: 200n,
+        maximumFee: 1_000_000_000n,
+        transferFeeBasisPoints: 150,
+    });
+
+    // Then the source is debited by the gross amount, the destination receives the net amount,
+    // and the confidential fee amount is withheld on the destination account.
+    expect(result.sourceAvailableBalance).toBe(800n);
+    expect(result.destinationPendingBalance).toBe(197n);
+    expect(result.destinationWithheldAmount).toBe(3n);
+    expect(result.destinationPendingBalanceCreditCounter).toBe(1n);
+});
+
+it('caps the confidential fee at the maximum fee', async () => {
+    // When the raw 1.5% fee (3) exceeds the maximum fee (2), the fee is capped at 2 and
+    // `claimedDeltaFee` is 0. net = 200 - 2 = 198.
+    const result = await runTransferWithFee({
+        initialSourceAmount: 1000n,
+        amount: 200n,
+        maximumFee: 2n,
+        transferFeeBasisPoints: 150,
+    });
+
+    // Then the source is still debited by the gross amount, the destination receives the
+    // capped net amount, and only the maximum fee is withheld.
+    expect(result.sourceAvailableBalance).toBe(800n);
+    expect(result.destinationPendingBalance).toBe(198n);
+    expect(result.destinationWithheldAmount).toBe(2n);
+    expect(result.destinationPendingBalanceCreditCounter).toBe(1n);
+});
+
+it('transfers the full amount when the fee basis points are zero', async () => {
+    // When the fee basis points are 0, no fee is charged. net = 200.
+    const result = await runTransferWithFee({
+        initialSourceAmount: 1000n,
+        amount: 200n,
+        maximumFee: 1_000_000_000n,
+        transferFeeBasisPoints: 0,
+    });
+
+    // Then the destination receives the full amount and nothing is withheld.
+    expect(result.sourceAvailableBalance).toBe(800n);
+    expect(result.destinationPendingBalance).toBe(200n);
+    expect(result.destinationWithheldAmount).toBe(0n);
+    expect(result.destinationPendingBalanceCreditCounter).toBe(1n);
 });
 
 it('rejects when the fee exceeds the transfer amount', async () => {

--- a/scripts/restart-test-validator.sh
+++ b/scripts/restart-test-validator.sh
@@ -9,6 +9,7 @@ ARGS=(
   -q
   --bpf-program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb ./target/deploy/spl_token_2022.so
   --bpf-program TokenHookExampLe8smaVNrxTBezWTRbEwxwb1Zykrb ./clients/rust-legacy/tests/fixtures/spl_transfer_hook_example_no_default_features.so
+  --bpf-program recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5 ./clients/rust-legacy/tests/fixtures/spl_record.so
 )
 PORT=8899
 PID=$(lsof -t -i:$PORT)


### PR DESCRIPTION
This PR bumps `@solana/zk-sdk` to `^0.5.1`, which exposes `ConfidentialKeys` and the Pedersen arithmetic API directly, and removes the runtime duck-typing the client previously needed.

It calls `ConfidentialKeys.signerMessage`/`fromSignature` directly, dropping the shim types, legacy fallbacks, and availability guards in `confidentialTransferKeys.ts`. It also removes the `assertPedersenArithmeticAvailable` guard and the seven Pedersen commitment/opening wrapper functions (with their `*WithArithmetic` casts) in `confidentialTransferHelpers.ts`, inlining the direct zk-sdk calls at each call site.

The key-derivation test vectors are regenerated because `0.5.1` adopts the new foundation-backed `solana-conf-bal/v1` derivation standard, which intentionally produces different keys from `0.4.2`. Per the zk-sdk maintainer no existing accounts used the old derivation, so no migration is required.

Finally, it un-gates the confidential-transfer-with-fee happy-path test and adds capped-fee and zero-fee edge cases.