### PR TITLE
Stop injecting a compute-unit-limit instruction into confidential proof plans

### DIFF
--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -93,9 +93,6 @@ const MAX_FEE_BASIS_POINTS_SUB_ONE = 9_999n;
 const MAX_FEE_BASIS_POINTS = 10_000n;
 const DELTA_BIT_LENGTH = 16;
 const NET_TRANSFER_AMOUNT_BIT_LENGTH = 64;
-const COMPUTE_BUDGET_PROGRAM_ADDRESS =
-    'ComputeBudget111111111111111111111111111111' as Address<'ComputeBudget111111111111111111111111111111'>;
-const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;
 type ConfidentialTransferAccountExtension = Extract<Extension, { __kind: 'ConfidentialTransferAccount' }>;
 type ConfidentialTransferMintExtension = Extract<Extension, { __kind: 'ConfidentialTransferMint' }>;
 type TransferFeeConfigExtension = Extract<Extension, { __kind: 'TransferFeeConfig' }>;
@@ -437,13 +434,6 @@ function calculateTransferWithFeeAmounts(transferAmount: bigint, transferFeeBasi
     return { feeAmount, claimedDeltaFee, netTransferAmount };
 }
 
-function getSetComputeUnitLimitInstruction(units: number): Instruction {
-    const data = new Uint8Array(5);
-    data[0] = 2;
-    new DataView(data.buffer).setUint32(1, units, true);
-    return { programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS, data };
-}
-
 /**
  * Builds the setup-and-cleanup instruction plans for a single proof's
  * context-state account. The setup plan creates the context-state account
@@ -496,10 +486,7 @@ async function buildContextStateProofPlan(
                     authority: recordAuthority,
                     data: proofDataBytes,
                 }),
-                nonDivisibleSequentialInstructionPlan([
-                    getSetComputeUnitLimitInstruction(MAX_COMPUTE_UNIT_LIMIT),
-                    ...verifyInstructions,
-                ]),
+                nonDivisibleSequentialInstructionPlan(verifyInstructions),
             ]),
             cleanup: sequentialInstructionPlan([
                 closeContextStateProof({

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -5,27 +5,15 @@ import {
     Address,
     Transaction,
     TransactionSigner,
-    assertIsSendableTransaction,
     assertIsSingleTransactionPlanResult,
-    assertIsTransactionWithBlockhashLifetime,
     createClient,
-    createTransactionMessage,
-    createTransactionPlanExecutor,
-    createTransactionPlanner,
-    extendClient,
     generateKeyPairSigner,
     isSome,
     lamports,
     none,
-    pipe,
-    sendAndConfirmTransactionFactory,
     sequentialInstructionPlan,
-    setTransactionMessageFeePayerSigner,
-    setTransactionMessageLifetimeUsingBlockhash,
-    signTransactionMessageWithSigners,
     some,
 } from '@solana/kit';
-import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
 import { TransactionMetadata, litesvm } from '@solana/kit-plugin-litesvm';
 import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
 import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
@@ -75,56 +63,21 @@ export const createTestClient = () => {
 // does not execute proof verification, so those tests must run against a local
 // `solana-test-validator` (started by `make test-js-clients-js`).
 //
-// The planner and executor are overridden so that no compute-unit-limit
-// instruction is added to any transaction. The default RPC planner reserves
-// ~40 bytes for a provisory compute-unit limit and the default RPC executor
-// estimates and sets a real one before sending; either is enough to push the
-// largest proof-verification transaction (the batched range proof, which must
-// share a transaction with its context-state account creation) past the
-// transaction size limit. Omitting it is safe: a versioned transaction with no
-// compute-unit limit still receives the per-instruction default budget.
+// Resource-limit estimation is disabled (`estimateResourceLimits: false`).
+// The inline range-proof transactions (e.g. the transfer `BatchedRangeProofU128`)
+// carry the proof in the verify instruction data and already sit within a few
+// bytes of the transaction size limit, so they cannot also accommodate the
+// provisory `SetComputeUnitLimit` instruction the planner would otherwise
+// reserve. Disabling estimation keeps those transactions sendable; the proofs
+// verify within the default compute budget.
 export const createValidatorClient = () => {
-    return (
-        createClient()
-            .use(generatedSigner())
-            .use(solanaLocalRpc())
-            .use(airdropSigner(lamports(1_000_000_000n)))
-            .use(client =>
-                extendClient(client, {
-                    // A planner that builds a bare versioned message with no
-                    // provisory compute-unit-limit instruction.
-                    transactionPlanner: createTransactionPlanner({
-                        createTransactionMessage: () =>
-                            pipe(createTransactionMessage({ version: 0 }), tx =>
-                                setTransactionMessageFeePayerSigner(client.payer, tx),
-                            ),
-                    }),
-                    // An executor that sets the blockhash, signs and sends — but
-                    // never estimates or sets a compute-unit limit (unlike the
-                    // default RPC executor, which would re-add the instruction at
-                    // execution time, after planning validated the size).
-                    transactionPlanExecutor: createTransactionPlanExecutor({
-                        executeTransactionMessage: async (_context, message) => {
-                            const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
-                            const transaction = await pipe(
-                                setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, message),
-                                tx => signTransactionMessageWithSigners(tx),
-                            );
-                            assertIsSendableTransaction(transaction);
-                            assertIsTransactionWithBlockhashLifetime(transaction);
-                            await sendAndConfirmTransactionFactory(client)(transaction, { commitment: 'confirmed' });
-                            return transaction;
-                        },
-                    }),
-                }),
-            )
-            // Re-wire `sendTransaction(s)` so they capture the client with the
-            // overridden planner and executor above.
-            .use(planAndSendTransactions())
-            .use(systemProgram())
-            .use(token2022Program())
-            .use(associatedTokenProgram())
-    );
+    return createClient()
+        .use(generatedSigner())
+        .use(solanaLocalRpc({ transactionConfig: { estimateResourceLimits: false } }))
+        .use(airdropSigner(lamports(1_000_000_000n)))
+        .use(systemProgram())
+        .use(token2022Program())
+        .use(associatedTokenProgram());
 };
 
 export type LiteSvmClient = Awaited<ReturnType<typeof createTestClient>>;


### PR DESCRIPTION
The confidential-transfer proof helpers hand-encoded a `SetComputeUnitLimit` instruction and injected it into the record-backed proof plan. Setting compute-unit limits is the transaction plan executor's responsibility (it simulates and sets them before sending), so this removes the hand-rolled instruction and its constants.

The validator-backed test client previously worked around the injected instruction with a bespoke planner and executor that never set a compute-unit limit. Those overrides are replaced with the standard `solanaLocalRpc` client configured with `estimateResourceLimits: false`, which is required because the inline range-proof transactions sit within a few bytes of the transaction size limit and cannot accommodate a provisory compute-unit-limit instruction. The proofs verify within the default compute budget.

## Follow-up

This surfaced a latent, pre-existing issue orthogonal to this change: a client calling `getConfidentialTransferInstructionPlan` with the default estimation-on `solanaRpc()` executor would hit `MESSAGE_CANNOT_ACCOMMODATE_PLAN` on the inline `BatchedRangeProofU128` transaction, because the provisory compute-unit-limit instruction does not fit. Worth investigating separately (e.g. routing inline proofs through record accounts).