### PR TITLE
docs: fix client generation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ using the following commands.
 
 ```sh
 pnpm install # only need to run this once
-pnpm generate:clients
+make generate-clients
 ```
 
 ## Managing clients


### PR DESCRIPTION
The "Generating clients" section of the README documents:

```sh
pnpm install # only need to run this once
pnpm generate:clients
```

However `pnpm generate:clients` does not work: the root `package.json` has no `scripts` section, so there is no `generate:clients` script to run. The client generator is defined as a Makefile target instead:

```makefile
generate-clients:
	pnpm codama run --all $(ARGS)
```

So `make generate-clients` is the working command. This updates the README to use it.
