### PR TITLE
Add record-backed variants of the confidential transfer and withdraw plans

### DIFF
--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -228,6 +228,12 @@ export type GetConfidentialTransferWithRecordInstructionPlanInput = GetConfident
 export type GetConfidentialTransferWithFeeInstructionPlanInput = GetConfidentialTransferInstructionPlanInput & {
     mintAccount: Mint;
     currentEpoch: number | bigint;
+    /** Funds the record account that stages the range proof. Defaults to `payer`. */
+    recordPayer?: TransactionSigner;
+    /** Signs the record account's write and close. Defaults to an ephemeral signer. */
+    recordAuthority?: TransactionSigner;
+    /** Receives the record account's reclaimed rent on close. Defaults to the record payer. */
+    recordRentReceiver?: Address;
 };
 
 function getTokenProgramAddress(programAddress?: Address) {
@@ -694,6 +700,7 @@ type ConfidentialWithdrawProofData = {
     equalityProofData: CiphertextCommitmentEqualityProofData;
     rangeProofData: BatchedRangeProofU64Data;
     newAvailableBalance: bigint;
+    amount: bigint;
 };
 
 function buildConfidentialWithdrawProofData(
@@ -724,7 +731,7 @@ function buildConfidentialWithdrawProofData(
         [remainingBalanceOpening],
     );
 
-    return { equalityProofData, rangeProofData, newAvailableBalance };
+    return { equalityProofData, rangeProofData, newAvailableBalance, amount };
 }
 
 function assembleConfidentialWithdrawPlan(
@@ -742,7 +749,7 @@ function assembleConfidentialWithdrawPlan(
                 equalityRecord: equalityProofPlan.address,
                 rangeRecord: rangeProofPlan.address,
                 authority: input.authority,
-                amount: BigInt(input.amount),
+                amount: proofData.amount,
                 decimals: input.decimals,
                 newDecryptableAvailableBalance: input.aesKey.encrypt(proofData.newAvailableBalance).toBytes(),
                 equalityProofInstructionOffset: 0,
@@ -1338,7 +1345,9 @@ export async function getConfidentialTransferWithFeeInstructionPlan(
             input.payer,
             input.rpc,
             input.payer,
-            input.payer,
+            input.recordPayer ?? input.payer,
+            input.recordAuthority,
+            input.recordRentReceiver,
         ),
     ]);
 

--- a/clients/js/src/confidentialTransferHelpers.ts
+++ b/clients/js/src/confidentialTransferHelpers.ts
@@ -19,7 +19,6 @@ import {
 import {
     Address,
     Instruction,
-    KeyPairSigner,
     TransactionSigner,
     generateKeyPairSigner,
     getAddressEncoder,
@@ -100,34 +99,6 @@ type TransferFee = TransferFeeConfigExtension['olderTransferFee'];
 type ProofDataInput = Uint8Array | { account: Address; offset: number };
 type ContextStateProofPlan = Readonly<{ address: Address; setup: InstructionPlan; cleanup: InstructionPlan }>;
 
-type ContextStateProofMode = {
-    /**
-     * The strategy used to provide zero-knowledge proofs to the program.
-     *
-     * Currently, only `context-state` is supported, where each proof is verified
-     * into a dedicated context-state account before the instruction is executed.
-     * Additional modes — such as `instruction-data`, where proofs are provided
-     * inline within the same transaction — may be supported in the future.
-     */
-    proofMode?: 'context-state';
-    payer: TransactionSigner;
-    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
-};
-
-type ConfidentialTransferContextStateProofMode = {
-    /**
-     * The strategy used to provide zero-knowledge proofs to the program.
-     *
-     * Currently, only `context-state` is supported, where each proof is verified
-     * into a dedicated context-state account before the instruction is executed.
-     * Additional modes — such as `instruction-data`, where proofs are provided
-     * inline within the same transaction — may be supported in the future.
-     */
-    proofMode?: 'context-state';
-    payer: TransactionSigner;
-    rpc: Rpc<GetMinimumBalanceForRentExemptionApi & GetAccountInfoApi>;
-};
-
 export type GetCreateConfidentialTransferAccountInstructionPlanInput = {
     payer: TransactionSigner;
     owner: Address | TransactionSigner;
@@ -175,7 +146,7 @@ export type ConfidentialTransferBalance = {
     actualPendingBalanceCreditCounter: bigint;
 };
 
-type GetConfidentialWithdrawInstructionPlanBaseInput = {
+export type GetConfidentialWithdrawInstructionPlanInput = {
     token: Address;
     mint: Address;
     tokenAccount: Token;
@@ -186,10 +157,19 @@ type GetConfidentialWithdrawInstructionPlanBaseInput = {
     aesKey: AeKey;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
 };
 
-export type GetConfidentialWithdrawInstructionPlanInput = GetConfidentialWithdrawInstructionPlanBaseInput &
-    ContextStateProofMode;
+/** Input for {@link getConfidentialWithdrawWithRecordInstructionPlan}. */
+export type GetConfidentialWithdrawWithRecordInstructionPlanInput = GetConfidentialWithdrawInstructionPlanInput & {
+    /** Funds the record account that stages the range proof. Defaults to `payer`. */
+    recordPayer?: TransactionSigner;
+    /** Signs the record account's write and close. Defaults to an ephemeral signer. */
+    recordAuthority?: TransactionSigner;
+    /** Receives the record account's reclaimed rent on close. Defaults to the record payer. */
+    recordRentReceiver?: Address;
+};
 
 export type GetEmptyConfidentialTransferAccountInstructionPlanInput = {
     token: Address;
@@ -198,9 +178,11 @@ export type GetEmptyConfidentialTransferAccountInstructionPlanInput = {
     elgamalKeypair: ElGamalKeypair;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
-} & ContextStateProofMode;
+    payer: TransactionSigner;
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi>;
+};
 
-type GetConfidentialTransferInstructionPlanBaseInput = {
+export type GetConfidentialTransferInstructionPlanInput = {
     sourceToken: Address;
     mint: Address;
     /**
@@ -224,25 +206,29 @@ type GetConfidentialTransferInstructionPlanBaseInput = {
     aesKey: AeKey;
     multiSigners?: Array<TransactionSigner>;
     programAddress?: Address;
+    payer: TransactionSigner;
+    // The transfer helpers may need to read the mint account to resolve the
+    // auditor ElGamal key, so the RPC must support account reads as well.
+    rpc: Rpc<GetMinimumBalanceForRentExemptionApi & GetAccountInfoApi>;
 } & (
     | { destinationTokenAccount: Token; destinationElgamalPubkey?: Address }
     | { destinationElgamalPubkey: Address; destinationTokenAccount?: never }
 );
 
-export type GetConfidentialTransferInstructionPlanInput = GetConfidentialTransferInstructionPlanBaseInput &
-    ConfidentialTransferContextStateProofMode;
+/** Input for {@link getConfidentialTransferWithRecordInstructionPlan}. */
+export type GetConfidentialTransferWithRecordInstructionPlanInput = GetConfidentialTransferInstructionPlanInput & {
+    /** Funds the record account that stages the range proof. Defaults to `payer`. */
+    recordPayer?: TransactionSigner;
+    /** Signs the record account's write and close. Defaults to an ephemeral signer. */
+    recordAuthority?: TransactionSigner;
+    /** Receives the record account's reclaimed rent on close. Defaults to the record payer. */
+    recordRentReceiver?: Address;
+};
 
-type GetConfidentialTransferWithFeeInstructionPlanBaseInput = GetConfidentialTransferInstructionPlanBaseInput & {
+export type GetConfidentialTransferWithFeeInstructionPlanInput = GetConfidentialTransferInstructionPlanInput & {
     mintAccount: Mint;
     currentEpoch: number | bigint;
 };
-
-type RecordBackedContextStateProofMode = Omit<ConfidentialTransferContextStateProofMode, 'payer'> & {
-    payer: KeyPairSigner;
-};
-
-export type GetConfidentialTransferWithFeeInstructionPlanInput =
-    GetConfidentialTransferWithFeeInstructionPlanBaseInput & RecordBackedContextStateProofMode;
 
 function getTokenProgramAddress(programAddress?: Address) {
     return programAddress ?? TOKEN_2022_PROGRAM_ADDRESS;
@@ -440,6 +426,13 @@ function calculateTransferWithFeeAmounts(transferAmount: bigint, transferFeeBasi
  * and verifies the proof into it (these two instructions must share a
  * transaction). The cleanup plan closes the context-state account to recover
  * its rent.
+ *
+ * When `recordPayer` is provided, the proof is staged in an SPL Record account
+ * (created, written and closed by the setup/cleanup plans) rather than passed
+ * inline in the verify instruction data. `recordAuthority` signs the record's
+ * write and close (defaulting to an ephemeral generated signer), and the
+ * record's reclaimed rent is sent to `recordRentReceiver` (defaulting to the
+ * record payer, so whoever funded the account is reimbursed).
  */
 async function buildContextStateProofPlan(
     proofData: ReadonlyUint8Array,
@@ -452,12 +445,15 @@ async function buildContextStateProofPlan(
     payer: TransactionSigner,
     rpc: Rpc<GetMinimumBalanceForRentExemptionApi>,
     contextStateAuthority: TransactionSigner = payer,
-    recordPayer?: KeyPairSigner,
+    recordPayer?: TransactionSigner,
+    recordAuthority?: TransactionSigner,
+    recordRentReceiver?: Address,
 ): Promise<ContextStateProofPlan> {
     const contextAccount = await generateKeyPairSigner();
     const proofDataBytes = new Uint8Array(proofData);
     if (recordPayer) {
-        const recordAuthority = await generateKeyPairSigner();
+        const resolvedRecordAuthority = recordAuthority ?? (await generateKeyPairSigner());
+        const resolvedRecordRentReceiver = recordRentReceiver ?? recordPayer.address;
         const recordKeypair = await generateKeyPairSigner();
         const recordClient = {
             getMinimumBalance: (space: number) => rpc.getMinimumBalanceForRentExemption(BigInt(space)).send(),
@@ -465,7 +461,7 @@ async function buildContextStateProofPlan(
         const createRecordPlan = await getCreateRecordInstructionPlan(recordClient, {
             payer: recordPayer,
             newRecord: recordKeypair,
-            authority: recordAuthority.address,
+            authority: resolvedRecordAuthority.address,
             dataLength: BigInt(proofDataBytes.length),
         });
         const verifyInstructions = await verifyAction({
@@ -483,7 +479,7 @@ async function buildContextStateProofPlan(
                 createRecordPlan,
                 getWriteInstructionPlan({
                     recordAccount: recordKeypair.address,
-                    authority: recordAuthority,
+                    authority: resolvedRecordAuthority,
                     data: proofDataBytes,
                 }),
                 nonDivisibleSequentialInstructionPlan(verifyInstructions),
@@ -496,8 +492,8 @@ async function buildContextStateProofPlan(
                 }),
                 getCloseAccountInstruction({
                     recordAccount: recordKeypair.address,
-                    authority: recordAuthority,
-                    receiver: payer.address,
+                    authority: resolvedRecordAuthority,
+                    receiver: resolvedRecordRentReceiver,
                 }),
             ]),
         };
@@ -692,14 +688,17 @@ export async function getEmptyConfidentialTransferAccountInstructionPlan(
     ]);
 }
 
-/**
- * Returns an instruction plan that moves tokens from the encrypted
- * available balance back to the plaintext balance. Generates and verifies
- * the equality and batched range proofs via context-state accounts.
- */
-export async function getConfidentialWithdrawInstructionPlan(
+// The proof data and instruction fields for a confidential withdraw, derived
+// from the input independently of how each proof is delivered on-chain.
+type ConfidentialWithdrawProofData = {
+    equalityProofData: CiphertextCommitmentEqualityProofData;
+    rangeProofData: BatchedRangeProofU64Data;
+    newAvailableBalance: bigint;
+};
+
+function buildConfidentialWithdrawProofData(
     input: GetConfidentialWithdrawInstructionPlanInput,
-): Promise<InstructionPlan> {
+): ConfidentialWithdrawProofData {
     const account = getRequiredConfidentialTransferAccountExtension(input.tokenAccount);
     const amount = BigInt(input.amount);
     assertNonNegativeAmount(amount);
@@ -725,16 +724,15 @@ export async function getConfidentialWithdrawInstructionPlan(
         [remainingBalanceOpening],
     );
 
-    const [equalityProofPlan, rangeProofPlan] = await Promise.all([
-        buildContextStateProofPlan(
-            equalityProofData.toBytes(),
-            verifyCiphertextCommitmentEquality,
-            input.payer,
-            input.rpc,
-        ),
-        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU64, input.payer, input.rpc),
-    ]);
+    return { equalityProofData, rangeProofData, newAvailableBalance };
+}
 
+function assembleConfidentialWithdrawPlan(
+    input: GetConfidentialWithdrawInstructionPlanInput,
+    proofData: ConfidentialWithdrawProofData,
+    proofPlans: { equalityProofPlan: ContextStateProofPlan; rangeProofPlan: ContextStateProofPlan },
+): InstructionPlan {
+    const { equalityProofPlan, rangeProofPlan } = proofPlans;
     return sequentialInstructionPlan([
         parallelInstructionPlan([equalityProofPlan.setup, rangeProofPlan.setup]),
         getConfidentialWithdrawInstruction(
@@ -744,9 +742,9 @@ export async function getConfidentialWithdrawInstructionPlan(
                 equalityRecord: equalityProofPlan.address,
                 rangeRecord: rangeProofPlan.address,
                 authority: input.authority,
-                amount,
+                amount: BigInt(input.amount),
                 decimals: input.decimals,
-                newDecryptableAvailableBalance: input.aesKey.encrypt(newAvailableBalance).toBytes(),
+                newDecryptableAvailableBalance: input.aesKey.encrypt(proofData.newAvailableBalance).toBytes(),
                 equalityProofInstructionOffset: 0,
                 rangeProofInstructionOffset: 0,
                 multiSigners: input.multiSigners,
@@ -758,14 +756,90 @@ export async function getConfidentialWithdrawInstructionPlan(
 }
 
 /**
- * Returns an instruction plan that confidentially transfers tokens between
- * two accounts. Splits the amount into lo/hi halves and verifies the three
- * required proofs (equality, grouped-ciphertext validity, batched range)
- * via context-state accounts.
+ * Returns an instruction plan that moves tokens from the encrypted
+ * available balance back to the plaintext balance. Generates and verifies
+ * the equality and batched range proofs via context-state accounts.
+ *
+ * The range proof is provided inline in the verify instruction data. This keeps
+ * the flow to a minimal number of transactions, but the range-proof transaction
+ * sits close to the transaction size limit and cannot accommodate an extra
+ * compute-unit-limit instruction. Callers that send with a transaction plan
+ * executor which sets compute-unit limits (e.g. by simulating) should either
+ * disable that estimation or use {@link getConfidentialWithdrawWithRecordInstructionPlan},
+ * which stages the range proof in a record account first.
  */
-export async function getConfidentialTransferInstructionPlan(
-    input: GetConfidentialTransferInstructionPlanInput,
+export async function getConfidentialWithdrawInstructionPlan(
+    input: GetConfidentialWithdrawInstructionPlanInput,
 ): Promise<InstructionPlan> {
+    const proofData = buildConfidentialWithdrawProofData(input);
+    const [equalityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            proofData.equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            proofData.rangeProofData.toBytes(),
+            verifyBatchedRangeProofU64,
+            input.payer,
+            input.rpc,
+        ),
+    ]);
+    return assembleConfidentialWithdrawPlan(input, proofData, { equalityProofPlan, rangeProofPlan });
+}
+
+/**
+ * Like {@link getConfidentialWithdrawInstructionPlan}, but stages the batched
+ * range proof in an SPL Record account before verifying it, rather than passing
+ * it inline in the verify instruction data.
+ *
+ * This shrinks the range-proof verification transaction so it leaves room for a
+ * compute-unit-limit instruction, at the cost of extra transactions to create,
+ * write and close the record account. Prefer this variant when sending with the
+ * default transaction plan executor, which reserves a compute-unit-limit
+ * instruction that would otherwise push the inline transaction over the size
+ * limit.
+ */
+export async function getConfidentialWithdrawWithRecordInstructionPlan(
+    input: GetConfidentialWithdrawWithRecordInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const proofData = buildConfidentialWithdrawProofData(input);
+    const [equalityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            proofData.equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            proofData.rangeProofData.toBytes(),
+            verifyBatchedRangeProofU64,
+            input.payer,
+            input.rpc,
+            input.payer,
+            input.recordPayer ?? input.payer,
+            input.recordAuthority,
+            input.recordRentReceiver,
+        ),
+    ]);
+    return assembleConfidentialWithdrawPlan(input, proofData, { equalityProofPlan, rangeProofPlan });
+}
+
+// The proof data and instruction fields for a confidential transfer, derived
+// from the input independently of how each proof is delivered on-chain.
+type ConfidentialTransferProofData = {
+    equalityProofData: CiphertextCommitmentEqualityProofData;
+    ciphertextValidityProofData: BatchedGroupedCiphertext3HandlesValidityProofData;
+    rangeProofData: BatchedRangeProofU128Data;
+    transferAmountAuditorCiphertextLo: ReadonlyUint8Array;
+    transferAmountAuditorCiphertextHi: ReadonlyUint8Array;
+    newAvailableBalance: bigint;
+};
+
+async function buildConfidentialTransferProofData(
+    input: GetConfidentialTransferInstructionPlanInput,
+): Promise<ConfidentialTransferProofData> {
     const sourceAccount = getRequiredConfidentialTransferAccountExtension(input.sourceTokenAccount);
     const amount = BigInt(input.amount);
     assertNonNegativeAmount(amount);
@@ -849,22 +923,26 @@ export async function getConfidentialTransferInstructionPlan(
         [newAvailableBalanceOpening, openingLo, openingHi, paddingOpening],
     );
 
-    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
-        buildContextStateProofPlan(
-            equalityProofData.toBytes(),
-            verifyCiphertextCommitmentEquality,
-            input.payer,
-            input.rpc,
-        ),
-        buildContextStateProofPlan(
-            ciphertextValidityProofData.toBytes(),
-            verifyBatchedGroupedCiphertext3HandlesValidity,
-            input.payer,
-            input.rpc,
-        ),
-        buildContextStateProofPlan(rangeProofData.toBytes(), verifyBatchedRangeProofU128, input.payer, input.rpc),
-    ]);
+    return {
+        equalityProofData,
+        ciphertextValidityProofData,
+        rangeProofData,
+        transferAmountAuditorCiphertextLo,
+        transferAmountAuditorCiphertextHi,
+        newAvailableBalance,
+    };
+}
 
+function assembleConfidentialTransferPlan(
+    input: GetConfidentialTransferInstructionPlanInput,
+    proofData: ConfidentialTransferProofData,
+    proofPlans: {
+        equalityProofPlan: ContextStateProofPlan;
+        ciphertextValidityProofPlan: ContextStateProofPlan;
+        rangeProofPlan: ContextStateProofPlan;
+    },
+): InstructionPlan {
+    const { equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan } = proofPlans;
     return sequentialInstructionPlan([
         parallelInstructionPlan([equalityProofPlan.setup, ciphertextValidityProofPlan.setup, rangeProofPlan.setup]),
         getConfidentialTransferInstruction(
@@ -876,9 +954,9 @@ export async function getConfidentialTransferInstructionPlan(
                 ciphertextValidityRecord: ciphertextValidityProofPlan.address,
                 rangeRecord: rangeProofPlan.address,
                 authority: input.authority,
-                newSourceDecryptableAvailableBalance: input.aesKey.encrypt(newAvailableBalance).toBytes(),
-                transferAmountAuditorCiphertextLo,
-                transferAmountAuditorCiphertextHi,
+                newSourceDecryptableAvailableBalance: input.aesKey.encrypt(proofData.newAvailableBalance).toBytes(),
+                transferAmountAuditorCiphertextLo: proofData.transferAmountAuditorCiphertextLo,
+                transferAmountAuditorCiphertextHi: proofData.transferAmountAuditorCiphertextHi,
                 equalityProofInstructionOffset: 0,
                 ciphertextValidityProofInstructionOffset: 0,
                 rangeProofInstructionOffset: 0,
@@ -892,6 +970,98 @@ export async function getConfidentialTransferInstructionPlan(
             rangeProofPlan.cleanup,
         ]),
     ]);
+}
+
+/**
+ * Returns an instruction plan that confidentially transfers tokens between
+ * two accounts. Splits the amount into lo/hi halves and verifies the three
+ * required proofs (equality, grouped-ciphertext validity, batched range)
+ * via context-state accounts.
+ *
+ * The range proof is provided inline in the verify instruction data. This keeps
+ * the flow to a minimal number of transactions, but the range-proof transaction
+ * sits close to the transaction size limit and cannot accommodate an extra
+ * compute-unit-limit instruction. Callers that send with a transaction plan
+ * executor which sets compute-unit limits (e.g. by simulating) should either
+ * disable that estimation or use {@link getConfidentialTransferWithRecordInstructionPlan},
+ * which stages the range proof in a record account first.
+ */
+export async function getConfidentialTransferInstructionPlan(
+    input: GetConfidentialTransferInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const proofData = await buildConfidentialTransferProofData(input);
+    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            proofData.equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            proofData.ciphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            proofData.rangeProofData.toBytes(),
+            verifyBatchedRangeProofU128,
+            input.payer,
+            input.rpc,
+        ),
+    ]);
+    return assembleConfidentialTransferPlan(input, proofData, {
+        equalityProofPlan,
+        ciphertextValidityProofPlan,
+        rangeProofPlan,
+    });
+}
+
+/**
+ * Like {@link getConfidentialTransferInstructionPlan}, but stages the batched
+ * range proof in an SPL Record account before verifying it, rather than passing
+ * it inline in the verify instruction data.
+ *
+ * This shrinks the range-proof verification transaction so it leaves room for a
+ * compute-unit-limit instruction, at the cost of extra transactions to create,
+ * write and close the record account. Prefer this variant when sending with the
+ * default transaction plan executor, which reserves a compute-unit-limit
+ * instruction that would otherwise push the inline transaction over the size
+ * limit.
+ */
+export async function getConfidentialTransferWithRecordInstructionPlan(
+    input: GetConfidentialTransferWithRecordInstructionPlanInput,
+): Promise<InstructionPlan> {
+    const proofData = await buildConfidentialTransferProofData(input);
+    const [equalityProofPlan, ciphertextValidityProofPlan, rangeProofPlan] = await Promise.all([
+        buildContextStateProofPlan(
+            proofData.equalityProofData.toBytes(),
+            verifyCiphertextCommitmentEquality,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            proofData.ciphertextValidityProofData.toBytes(),
+            verifyBatchedGroupedCiphertext3HandlesValidity,
+            input.payer,
+            input.rpc,
+        ),
+        buildContextStateProofPlan(
+            proofData.rangeProofData.toBytes(),
+            verifyBatchedRangeProofU128,
+            input.payer,
+            input.rpc,
+            input.payer,
+            input.recordPayer ?? input.payer,
+            input.recordAuthority,
+            input.recordRentReceiver,
+        ),
+    ]);
+    return assembleConfidentialTransferPlan(input, proofData, {
+        equalityProofPlan,
+        ciphertextValidityProofPlan,
+        rangeProofPlan,
+    });
 }
 
 /**

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -58,22 +58,28 @@ export const createTestClient = () => {
         .use(associatedTokenProgram());
 };
 
-// A validator-backed client for the few confidential-transfer tests that
-// verify zero-knowledge proofs. LiteSVM's builtin ZK ElGamal Proof program
-// does not execute proof verification, so those tests must run against a local
+// A validator-backed client for the confidential-transfer tests that verify
+// zero-knowledge proofs. LiteSVM's builtin ZK ElGamal Proof program does not
+// execute proof verification, so those tests must run against a local
 // `solana-test-validator` (started by `make test-js-clients-js`).
 //
-// Resource-limit estimation is disabled (`estimateResourceLimits: false`).
-// The inline range-proof transactions (e.g. the transfer `BatchedRangeProofU128`)
-// carry the proof in the verify instruction data and already sit within a few
+// `estimateResourceLimits` is passed straight through to `solanaLocalRpc`, so
+// leaving it unset matches the plugin default (`true`): the planner reserves a
+// provisory `SetComputeUnitLimit` instruction and the executor simulates each
+// transaction to set the estimated limit before sending, mirroring what a
+// typical consumer gets. The record-backed proof helpers are exercised under
+// this default.
+//
+// Set it to `false` for tests that send an inline range proof (e.g. the transfer
+// `BatchedRangeProofU128` or the withdraw `BatchedRangeProofU64`): those verify
+// transactions carry the proof in their instruction data and sit within a few
 // bytes of the transaction size limit, so they cannot also accommodate the
-// provisory `SetComputeUnitLimit` instruction the planner would otherwise
-// reserve. Disabling estimation keeps those transactions sendable; the proofs
-// verify within the default compute budget.
-export const createValidatorClient = () => {
+// provisory compute-unit-limit instruction. They verify within the default
+// compute budget without it.
+export const createValidatorClient = ({ estimateResourceLimits }: { estimateResourceLimits?: boolean } = {}) => {
     return createClient()
         .use(generatedSigner())
-        .use(solanaLocalRpc({ transactionConfig: { estimateResourceLimits: false } }))
+        .use(solanaLocalRpc({ transactionConfig: { estimateResourceLimits } }))
         .use(airdropSigner(lamports(1_000_000_000n)))
         .use(systemProgram())
         .use(token2022Program())

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferInstructionPlan.test.ts
@@ -23,7 +23,7 @@ function getElGamalPubkeyAddress() {
 
 it('transfers tokens confidentially between two accounts', async () => {
     // Given a funded source account and an empty destination account.
-    const client = await createValidatorClient();
+    const client = await createValidatorClient({ estimateResourceLimits: false });
     const payer = client.payer;
     const [sourceOwner, destinationOwner] = await Promise.all([
         generateKeyPairSignerWithSol(client),
@@ -71,7 +71,7 @@ it('transfers tokens confidentially between two accounts', async () => {
 
 it('fetches the mint auditor ElGamal pubkey when omitted', async () => {
     // Given a confidential transfer mint configured with an auditor.
-    const client = await createValidatorClient();
+    const client = await createValidatorClient({ estimateResourceLimits: false });
     const payer = client.payer;
     const [sourceOwner, destinationOwner] = await Promise.all([
         generateKeyPairSignerWithSol(client),
@@ -124,7 +124,7 @@ it('fetches the mint auditor ElGamal pubkey when omitted', async () => {
 
 it('uses a provided mint account to resolve the auditor ElGamal pubkey', async () => {
     // Given a confidential transfer mint configured with an auditor.
-    const client = await createValidatorClient();
+    const client = await createValidatorClient({ estimateResourceLimits: false });
     const payer = client.payer;
     const [sourceOwner, destinationOwner] = await Promise.all([
         generateKeyPairSignerWithSol(client),

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithRecordInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialTransferWithRecordInstructionPlan.test.ts
@@ -1,0 +1,117 @@
+import { expect, it } from 'vitest';
+
+import { fetchToken } from '../../../src';
+import { getConfidentialTransferWithRecordInstructionPlan } from '../../../src/confidential';
+import {
+    createConfidentialMint,
+    createConfidentialTokenAccount,
+    createConfidentialTokenAccountWithBalance,
+    createValidatorClient,
+    fetchAssociatedToken,
+    generateKeyPairSignerWithSol,
+    getTokenExtension,
+} from '../../_setup';
+
+it('transfers tokens confidentially with the range proof staged in a record account', async () => {
+    // Given a client with the default resource-limit estimation, so the planner
+    // reserves a provisory compute-unit-limit instruction on every transaction.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const [sourceOwner, destinationOwner] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
+    const decimals = 2;
+    const source = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner: sourceOwner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const destination = await createConfidentialTokenAccount({ client, payer, owner: destinationOwner, mint });
+
+    // When the source confidentially transfers part of its balance to the destination.
+    // The record-backed range proof keeps the verify transaction small enough to also
+    // carry the compute-unit-limit instruction the executor sets from its estimate.
+    const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }] = await Promise.all([
+        fetchToken(client.rpc, source.token),
+        fetchToken(client.rpc, destination.token),
+    ]);
+    await client.sendTransactions(
+        await getConfidentialTransferWithRecordInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            sourceToken: source.token,
+            mint,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            authority: sourceOwner,
+            amount: 600n,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+        }),
+    );
+
+    // Then the destination account received a confidential credit in its pending balance.
+    const updatedDestination = await fetchAssociatedToken(client, destinationOwner.address, mint);
+    const destinationConfidential = getTokenExtension(updatedDestination, 'ConfidentialTransferAccount');
+    expect(destinationConfidential.pendingBalanceCreditCounter).toBe(1n);
+});
+
+it('reimburses a distinct record payer for the staged range-proof rent', async () => {
+    // Given a separate signer that funds the record account, distinct from the fee payer.
+    const client = await createValidatorClient();
+    const payer = client.payer;
+    const [sourceOwner, destinationOwner, recordPayer] = await Promise.all([
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+        generateKeyPairSignerWithSol(client),
+    ]);
+    const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
+    const decimals = 2;
+    const source = await createConfidentialTokenAccountWithBalance({
+        client,
+        payer,
+        owner: sourceOwner,
+        mint,
+        mintAuthority,
+        decimals,
+        amount: 1000n,
+    });
+    const destination = await createConfidentialTokenAccount({ client, payer, owner: destinationOwner, mint });
+
+    const recordPayerBalanceBefore = (await client.rpc.getBalance(recordPayer.address).send()).value;
+
+    // When the transfer stages its range proof in a record account funded by `recordPayer`.
+    const [{ data: sourceTokenAccount }, { data: destinationTokenAccount }] = await Promise.all([
+        fetchToken(client.rpc, source.token),
+        fetchToken(client.rpc, destination.token),
+    ]);
+    await client.sendTransactions(
+        await getConfidentialTransferWithRecordInstructionPlan({
+            payer,
+            rpc: client.rpc,
+            sourceToken: source.token,
+            mint,
+            destinationToken: destination.token,
+            sourceTokenAccount,
+            destinationTokenAccount,
+            authority: sourceOwner,
+            amount: 600n,
+            sourceElgamalKeypair: source.elgamalKeypair,
+            aesKey: source.aesKey,
+            recordPayer,
+        }),
+    );
+
+    // Then the record payer is fully reimbursed when the record account is closed: it
+    // funds the rent on create and receives it back on close (defaulting to the record
+    // payer), and it never pays transaction fees, so its balance is unchanged.
+    const recordPayerBalanceAfter = (await client.rpc.getBalance(recordPayer.address).send()).value;
+    expect(recordPayerBalanceAfter).toBe(recordPayerBalanceBefore);
+});

--- a/clients/js/test/extensions/confidentialTransfer/getConfidentialWithdrawWithRecordInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getConfidentialWithdrawWithRecordInstructionPlan.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from 'vitest';
 
 import { fetchToken } from '../../../src';
-import { getConfidentialWithdrawInstructionPlan } from '../../../src/confidential';
+import { getConfidentialWithdrawWithRecordInstructionPlan } from '../../../src/confidential';
 import {
     createConfidentialMint,
     createConfidentialTokenAccountWithBalance,
@@ -9,9 +9,10 @@ import {
     generateKeyPairSignerWithSol,
 } from '../../_setup';
 
-it('withdraws tokens from a confidential balance', async () => {
-    // Given a confidential token account funded with an available confidential balance.
-    const client = await createValidatorClient({ estimateResourceLimits: false });
+it('withdraws tokens from a confidential balance with the range proof staged in a record account', async () => {
+    // Given a client with the default resource-limit estimation, so the planner
+    // reserves a provisory compute-unit-limit instruction on every transaction.
+    const client = await createValidatorClient();
     const payer = client.payer;
     const owner = await generateKeyPairSignerWithSol(client);
     const { mint, mintAuthority } = await createConfidentialMint({ client, payer });
@@ -27,9 +28,11 @@ it('withdraws tokens from a confidential balance', async () => {
     });
 
     // When we withdraw part of the confidential balance back to the public balance.
+    // The record-backed range proof keeps the verify transaction small enough to also
+    // carry the compute-unit-limit instruction the executor sets from its estimate.
     const { data: tokenAccount } = await fetchToken(client.rpc, account.token);
     await client.sendTransactions(
-        await getConfidentialWithdrawInstructionPlan({
+        await getConfidentialWithdrawWithRecordInstructionPlan({
             payer,
             rpc: client.rpc,
             token: account.token,

--- a/clients/js/test/extensions/confidentialTransfer/getEmptyConfidentialTransferAccountInstructionPlan.test.ts
+++ b/clients/js/test/extensions/confidentialTransfer/getEmptyConfidentialTransferAccountInstructionPlan.test.ts
@@ -16,7 +16,7 @@ import {
 
 it('empties a zero confidential available balance for account closing', async () => {
     // Given a confidential token account whose confidential balance was fully withdrawn.
-    const client = await createValidatorClient();
+    const client = await createValidatorClient({ estimateResourceLimits: false });
     const payer = client.payer;
     const owner = await generateKeyPairSignerWithSol(client);
     const { mint, mintAuthority } = await createConfidentialMint({ client, payer });


### PR DESCRIPTION
This PR adds `getConfidentialTransferWithRecordInstructionPlan` and `getConfidentialWithdrawWithRecordInstructionPlan`, which stage their batched range proof in an SPL Record account before verification rather than passing it inline in the verify instruction data. The inline range-proof transactions sit within a few bytes of the transaction size limit and cannot accommodate the `SetComputeUnitLimit` instruction that the default `solanaRpc` executor reserves; the record-backed variants shrink the verify transaction so it fits, at the cost of extra transactions to create, write and close the record account. The existing inline helpers remain for callers that manage their own compute-unit configuration.

The record helpers expose `recordPayer`, `recordAuthority` and `recordRentReceiver` inputs (all `TransactionSigner`/`Address`, defaulting sensibly), and fix a latent bug where a record account's reclaimed rent was sent to the main payer rather than the account's funder.

Along the way this flattens the confidential-transfer input types to one flat `Input` type per helper, removes a dead `proofMode` field, relaxes the over-constrained `KeyPairSigner` record payer to `TransactionSigner`, and refactors the transfer and withdraw plan builders into delivery-agnostic `buildProofData` + `assemblePlan` helpers so the inline and record-backed helpers compose shared pieces without knowing about each other.

Both delivery strategies are tested against a validator: inline plans with resource-limit estimation disabled, and record-backed plans under the default (estimation-on) executor a typical consumer uses.