### PR TITLE
Fix 'destinaion' typo in test comment

### DIFF
--- a/clients/rust-legacy/tests/confidential_transfer_fee.rs
+++ b/clients/rust-legacy/tests/confidential_transfer_fee.rs
@@ -1256,7 +1256,7 @@ async fn test_withdraw_withheld_tokens_with_max_pending_counter() {
         .await
         .unwrap();
 
-    // Saturate destinaion pending counter
+    // Saturate destination pending counter
     token
         .mint_to(
             &fee_collector_account.pubkey(),


### PR DESCRIPTION
Minor typo in a test comment: `destinaion` should be `destination` (clients/rust-legacy/tests/confidential_transfer_fee.rs). No code change.
