### PR TITLE
fix(js-legacy): decode the correct signers in WithdrawWithheldTokensFromAccounts

### DIFF
--- a/clients/js-legacy/src/extensions/transferFee/instructions.ts
+++ b/clients/js-legacy/src/extensions/transferFee/instructions.ts
@@ -677,7 +677,7 @@ export function decodeWithdrawWithheldTokensFromAccountsInstructionUnchecked({
         keys[0],
         keys[1],
         keys[2],
-        keys.slice(3, 3 + numTokenAccounts),
+        keys.slice(3, keys.length - numTokenAccounts),
         keys.slice(-1 * numTokenAccounts),
     ];
     return {

--- a/clients/js-legacy/test/unit/transferfee.test.ts
+++ b/clients/js-legacy/test/unit/transferfee.test.ts
@@ -3,7 +3,9 @@ import {
     calculateEpochFee,
     ONE_IN_BASIS_POINTS,
     createInitializeTransferFeeConfigInstruction,
+    createWithdrawWithheldTokensFromAccountsInstruction,
     decodeInitializeTransferFeeConfigInstruction,
+    decodeWithdrawWithheldTokensFromAccountsInstruction,
     TOKEN_2022_PROGRAM_ID,
 } from '../../src';
 import { expect } from 'chai';
@@ -72,6 +74,44 @@ describe('transferFee', () => {
             expect(decoded.data.withdrawWithheldAuthority).to.eql(null);
             expect(decoded.data.transferFeeBasisPoints).to.eql(100);
             expect(decoded.data.maximumFee).to.eql(100n);
+        });
+    });
+
+    describe('encoding/decoding `WithdrawWithheldTokensFromAccounts` instructions', () => {
+        const mint = Keypair.generate().publicKey;
+        const destination = Keypair.generate().publicKey;
+        const authority = Keypair.generate().publicKey;
+        const source0 = Keypair.generate().publicKey;
+        const source1 = Keypair.generate().publicKey;
+
+        it('should decode with a single authority and no multisig signers', () => {
+            const instruction = createWithdrawWithheldTokensFromAccountsInstruction(
+                mint,
+                destination,
+                authority,
+                [],
+                [source0, source1],
+            );
+            const decoded = decodeWithdrawWithheldTokensFromAccountsInstruction(instruction, TOKEN_2022_PROGRAM_ID);
+            expect(decoded.data.numTokenAccounts).to.eql(2);
+            expect(decoded.keys.signers?.map(meta => meta.pubkey)).to.eql([]);
+            expect(decoded.keys.sources?.map(meta => meta.pubkey)).to.eql([source0, source1]);
+        });
+
+        it('should decode all multisig signers with multiple sources', () => {
+            const signer0 = Keypair.generate().publicKey;
+            const signer1 = Keypair.generate().publicKey;
+            const signer2 = Keypair.generate().publicKey;
+            const instruction = createWithdrawWithheldTokensFromAccountsInstruction(
+                mint,
+                destination,
+                authority,
+                [signer0, signer1, signer2],
+                [source0, source1],
+            );
+            const decoded = decodeWithdrawWithheldTokensFromAccountsInstruction(instruction, TOKEN_2022_PROGRAM_ID);
+            expect(decoded.keys.signers?.map(meta => meta.pubkey)).to.eql([signer0, signer1, signer2]);
+            expect(decoded.keys.sources?.map(meta => meta.pubkey)).to.eql([source0, source1]);
         });
     });
 


### PR DESCRIPTION
## What

`decodeWithdrawWithheldTokensFromAccountsInstruction` returns the wrong `signers` accounts. With no multisig signers it reports the source accounts as signers, and with multisig signers it truncates them to the number of sources.

## Why

The decoder sizes the `signers` slice with `numTokenAccounts`, which the encoder sets to `sources.length`:

```ts
signers: keys.slice(3, 3 + numTokenAccounts),
```

`createWithdrawWithheldTokensFromAccountsInstruction` lays out the keys as `[mint, destination, authority, ...signers, ...sources]` (it calls `addSigners`, then pushes the sources) and encodes `numTokenAccounts = sources.length`. So the signers run from index `3` up to `keys.length - numTokenAccounts`, not `3 + numTokenAccounts`. The two only coincide when the signer count equals the source count.

With 2 source accounts:
- 0 signers: `signers` decodes as the 2 source accounts instead of `[]`.
- 3 signers: `signers` decodes as the first 2, dropping the third.

## Change

- Slice `signers` up to `keys.length - numTokenAccounts` so it covers exactly the multisig signers.
- Add round-trip tests that build the instruction with the encoder and assert the decoded signers and sources, for both the single-authority and the multisig case.

## Verification

Ran in `clients/js-legacy`: `pnpm run build`, `pnpm run lint`, `pnpm run format`, and `mocha test/unit` all pass. The new tests fail on the current code and pass with the fix.
