### PR TITLE
Add clear signing display metadata to the IDL

### DIFF
--- a/idl.json
+++ b/idl.json
@@ -3573,7 +3573,7 @@
                 "display": {
                     "kind": "instructionDisplayNode",
                     "intent": "Set transfer fee",
-                    "interpolatedIntent": "Set the transfer fee of ${accounts.mint} to ${data.transferFeeBasisPoints}"
+                    "interpolatedIntent": "Set the transfer fee of ${accounts.mint} to ${data.transferFeeBasisPoints} with a maximum of ${data.maximumFee}"
                 },
                 "provides": [
                     {
@@ -14142,7 +14142,7 @@
                     "display": {
                         "kind": "instructionDisplayNode",
                         "intent": "Create associated token account",
-                        "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+                        "interpolatedIntent": "Create the associated token account of ${accounts.owner} for mint ${accounts.mint}"
                     },
                     "accounts": [
                         {
@@ -14281,7 +14281,7 @@
                     "display": {
                         "kind": "instructionDisplayNode",
                         "intent": "Create associated token account",
-                        "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+                        "interpolatedIntent": "Create the associated token account of ${accounts.owner} for mint ${accounts.mint}"
                     },
                     "accounts": [
                         {

--- a/idl.json
+++ b/idl.json
@@ -362,6 +362,11 @@
         "instructions": [
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize mint",
+                    "interpolatedIntent": "Initialize mint ${accounts.mint} with ${data.decimals} decimals"
+                },
                 "name": "initializeMint",
                 "docs": [
                     "Initializes a new mint and optionally deposits all the newly minted",
@@ -384,6 +389,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rent",
                         "isWritable": false,
                         "isSigner": false,
@@ -398,6 +407,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -460,6 +473,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize token account",
+                    "interpolatedIntent": "Initialize token account ${accounts.account} for mint ${accounts.mint}"
+                },
                 "name": "initializeAccount",
                 "docs": [
                     "Initializes a new account to hold tokens. If this account is associated",
@@ -477,6 +495,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -501,6 +523,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rent",
                         "isWritable": false,
                         "isSigner": false,
@@ -515,6 +541,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -539,6 +569,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize multisig",
+                    "interpolatedIntent": "Initialize multisig ${accounts.multisig} requiring ${data.m} signatures"
+                },
                 "name": "initializeMultisig",
                 "docs": [
                     "Initializes a multisignature account with N provided signers.",
@@ -565,6 +600,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rent",
                         "isWritable": false,
                         "isSigner": false,
@@ -579,6 +618,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -594,6 +637,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Required Signatures"
+                        },
                         "name": "m",
                         "docs": ["The number of signers (M) required to validate this multisignature account."],
                         "type": {
@@ -606,6 +653,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Signers"
+                        },
                         "docs": [],
                         "value": {
                             "kind": "argumentValueNode",
@@ -623,6 +674,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer tokens",
+                    "interpolatedIntent": "Transfer ${data.amount} from ${accounts.source} to ${accounts.destination}"
+                },
                 "name": "transfer",
                 "docs": [
                     "Transfers tokens from one account to another either directly or via a delegate.",
@@ -633,6 +689,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -641,6 +701,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -662,6 +726,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -681,6 +749,13 @@
                         "docs": ["The amount of tokens to transfer."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "base units"
+                                }
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -689,6 +764,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -708,6 +787,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Approve delegate",
+                    "interpolatedIntent": "Approve ${accounts.delegate} to spend ${data.amount} from ${accounts.source}"
+                },
                 "name": "approve",
                 "docs": [
                     "Approves a delegate. A delegate is given the authority over tokens on",
@@ -717,6 +801,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -743,6 +831,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -762,6 +854,13 @@
                         "docs": ["The amount of tokens the delegate is approved for."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "base units"
+                                }
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -770,6 +869,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -789,12 +892,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Revoke delegate",
+                    "interpolatedIntent": "Revoke the delegate of ${accounts.source}"
+                },
                 "name": "revoke",
                 "docs": ["Revokes the delegate's authority."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -813,6 +925,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -830,6 +946,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -849,12 +969,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set authority",
+                    "interpolatedIntent": "Change an authority of ${accounts.owned}"
+                },
                 "name": "setAuthority",
                 "docs": ["Sets a new authority of a mint or account."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Account"
+                        },
                         "name": "owned",
                         "isWritable": true,
                         "isSigner": false,
@@ -875,6 +1004,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -918,6 +1051,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -937,12 +1074,32 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Mint tokens",
+                    "interpolatedIntent": "Mint ${data.amount} ${accounts.mint} to ${accounts.token}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "account": "mint",
+                            "kind": "accountFieldValueNode",
+                            "path": "decimals"
+                        }
+                    }
+                ],
                 "name": "mintTo",
                 "docs": ["Mints new tokens to an account. The native mint does not support minting."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "accountLink": {
+                            "kind": "accountLinkNode",
+                            "name": "mint"
+                        },
                         "name": "mint",
                         "isWritable": true,
                         "isSigner": false,
@@ -951,6 +1108,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -969,6 +1130,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -988,6 +1153,13 @@
                         "docs": ["The amount of new tokens to mint."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -996,6 +1168,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1015,6 +1191,22 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Burn tokens",
+                    "interpolatedIntent": "Burn ${data.amount} ${accounts.mint} from ${accounts.account}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "account": "mint",
+                            "kind": "accountFieldValueNode",
+                            "path": "decimals"
+                        }
+                    }
+                ],
                 "name": "burn",
                 "docs": [
                     "Burns tokens by removing them from an account. `Burn` does not support",
@@ -1024,6 +1216,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1032,6 +1228,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "accountLink": {
+                            "kind": "accountLinkNode",
+                            "name": "mint"
+                        },
                         "name": "mint",
                         "isWritable": true,
                         "isSigner": false,
@@ -1053,6 +1253,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": ["The amount of tokens to burn."],
@@ -1072,6 +1276,13 @@
                         "docs": [],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -1080,6 +1291,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1099,6 +1314,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Close token account",
+                    "interpolatedIntent": "Close ${accounts.account} and send its balance to ${accounts.destination}"
+                },
                 "name": "closeAccount",
                 "docs": [
                     "Close an account by transferring all its SOL to the destination account.",
@@ -1108,6 +1328,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1116,6 +1340,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Recipient"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -1134,6 +1362,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1151,6 +1383,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1170,12 +1406,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Freeze token account",
+                    "interpolatedIntent": "Freeze ${accounts.account}"
+                },
                 "name": "freezeAccount",
                 "docs": ["Freeze an Initialized account using the Mint's freeze_authority (if set)."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1202,6 +1447,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1219,6 +1468,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1238,12 +1491,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Thaw token account",
+                    "interpolatedIntent": "Thaw ${accounts.account}"
+                },
                 "name": "thawAccount",
                 "docs": ["Thaw a Frozen account using the Mint's freeze_authority (if set)."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1270,6 +1532,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1287,6 +1553,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1306,6 +1576,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer tokens",
+                    "interpolatedIntent": "Transfer ${data.amount} ${accounts.mint} from ${accounts.source} to ${accounts.destination}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "transferChecked",
                 "docs": [
                     "Transfers tokens from one account to another either directly or via a",
@@ -1320,6 +1605,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -1336,6 +1625,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -1357,6 +1650,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1376,12 +1673,23 @@
                         "docs": ["The amount of tokens to transfer."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -1394,6 +1702,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1413,6 +1725,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Approve delegate",
+                    "interpolatedIntent": "Approve ${accounts.delegate} to spend ${data.amount} ${accounts.mint} from ${accounts.source}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "approveChecked",
                 "docs": [
                     "Approves a delegate. A delegate is given the authority over tokens on",
@@ -1426,6 +1753,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -1460,6 +1791,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1479,12 +1814,23 @@
                         "docs": ["The amount of tokens the delegate is approved for."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -1497,6 +1843,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1516,6 +1866,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Mint tokens",
+                    "interpolatedIntent": "Mint ${data.amount} ${accounts.mint} to ${accounts.token}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "mintToChecked",
                 "docs": [
                     "Mints new tokens to an account. The native mint does not support minting.",
@@ -1536,6 +1901,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -1554,6 +1923,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1573,12 +1946,23 @@
                         "docs": ["The amount of new tokens to mint."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -1591,6 +1975,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1610,6 +1998,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Burn tokens",
+                    "interpolatedIntent": "Burn ${data.amount} ${accounts.mint} from ${accounts.account}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "burnChecked",
                 "docs": [
                     "Burns tokens by removing them from an account. `BurnChecked` does not",
@@ -1623,6 +2026,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1652,6 +2059,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1671,12 +2082,23 @@
                         "docs": ["The amount of tokens to burn."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -1689,6 +2111,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -1708,6 +2134,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize token account",
+                    "interpolatedIntent": "Initialize token account ${accounts.account} for mint ${accounts.mint}"
+                },
                 "name": "initializeAccount2",
                 "docs": [
                     "Like InitializeAccount, but the owner pubkey is passed via instruction",
@@ -1719,6 +2150,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1735,6 +2170,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rent",
                         "isWritable": false,
                         "isSigner": false,
@@ -1749,6 +2188,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1781,6 +2224,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Sync wrapped SOL",
+                    "interpolatedIntent": "Sync the wrapped SOL balance of ${accounts.account}"
+                },
                 "name": "syncNative",
                 "docs": [
                     "Given a wrapped / native token account (a token account containing SOL)",
@@ -1793,6 +2241,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1801,6 +2253,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rent",
                         "isWritable": false,
                         "isSigner": false,
@@ -1815,6 +2271,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1839,12 +2299,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize token account",
+                    "interpolatedIntent": "Initialize token account ${accounts.account} for mint ${accounts.mint}"
+                },
                 "name": "initializeAccount3",
                 "docs": ["Like InitializeAccount2, but does not require the Rent sysvar to be provided."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -1863,6 +2332,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1895,6 +2368,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize multisig",
+                    "interpolatedIntent": "Initialize multisig ${accounts.multisig} requiring ${data.m} signatures"
+                },
                 "name": "initializeMultisig2",
                 "docs": ["Like InitializeMultisig, but does not require the Rent sysvar to be provided."],
                 "optionalAccountStrategy": "programId",
@@ -1911,6 +2389,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -1926,6 +2408,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Required Signatures"
+                        },
                         "name": "m",
                         "docs": ["The number of signers (M) required to validate this multisignature account."],
                         "type": {
@@ -1938,6 +2424,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Signers"
+                        },
                         "docs": [],
                         "value": {
                             "kind": "argumentValueNode",
@@ -1955,6 +2445,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize mint",
+                    "interpolatedIntent": "Initialize mint ${accounts.mint} with ${data.decimals} decimals"
+                },
                 "name": "initializeMint2",
                 "docs": ["Like [`InitializeMint`], but does not require the Rent sysvar to be provided."],
                 "optionalAccountStrategy": "programId",
@@ -1971,6 +2466,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2033,6 +2532,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Get account data size",
+                    "interpolatedIntent": "Get the account size for mint ${accounts.mint}"
+                },
                 "name": "getAccountDataSize",
                 "docs": [
                     "Gets the required size of an account for the given mint as a",
@@ -2055,6 +2559,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2079,6 +2587,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize immutable owner",
+                    "interpolatedIntent": "Make the owner of ${accounts.account} immutable"
+                },
                 "name": "initializeImmutableOwner",
                 "docs": [
                     "Initialize the Immutable Owner extension for the given token account",
@@ -2093,6 +2606,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -2103,6 +2620,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2127,6 +2648,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Convert amount to UI amount"
+                },
                 "name": "amountToUiAmount",
                 "docs": [
                     "Convert an Amount of tokens to a UiAmount `string`, using the given",
@@ -2152,6 +2677,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2171,6 +2700,13 @@
                         "docs": ["The amount of tokens to reformat."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "base units"
+                                }
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -2186,6 +2722,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Convert UI amount to amount"
+                },
                 "name": "uiAmountToAmount",
                 "docs": [
                     "Convert a UiAmount of tokens to a little-endian `u64` raw Amount, using",
@@ -2209,6 +2749,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2224,6 +2768,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "UI Amount"
+                        },
                         "name": "uiAmount",
                         "docs": ["The ui_amount of tokens to reformat."],
                         "type": {
@@ -2242,6 +2790,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set mint close authority",
+                    "interpolatedIntent": "Set the close authority of mint ${accounts.mint}"
+                },
                 "name": "initializeMintCloseAuthority",
                 "docs": [
                     "Initialize the close account authority on a new mint.",
@@ -2266,6 +2819,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2307,6 +2864,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize transfer fee",
+                    "interpolatedIntent": "Initialize the transfer fee of ${accounts.mint} at ${data.transferFeeBasisPoints}"
+                },
                 "name": "initializeTransferFeeConfig",
                 "docs": [
                     "Initialize the transfer fee on a new mint.",
@@ -2331,6 +2893,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2346,6 +2912,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2395,12 +2965,27 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Fee"
+                        },
                         "name": "transferFeeBasisPoints",
                         "docs": [
                             "Amount of transfer collected as fees, expressed as basis points of the transfer amount."
                         ],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "numberValueNode",
+                                    "number": 2
+                                },
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "%"
+                                }
+                            },
                             "format": "u16",
                             "endian": "le"
                         }
@@ -2431,6 +3016,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer tokens with fee",
+                    "interpolatedIntent": "Transfer ${data.amount} ${accounts.mint} from ${accounts.source} to ${accounts.destination} with a fee of ${data.fee}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "transferCheckedWithFee",
                 "docs": [
                     "Transfer, providing expected mint information and fees.",
@@ -2443,6 +3043,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -2459,6 +3063,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -2480,6 +3088,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2495,6 +3107,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2514,12 +3130,23 @@
                         "docs": ["The amount of tokens to transfer."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -2538,6 +3165,13 @@
                         ],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -2546,6 +3180,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -2570,6 +3208,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw withheld fees",
+                    "interpolatedIntent": "Withdraw withheld fees from mint ${accounts.mint} to ${accounts.feeReceiver}"
+                },
                 "name": "withdrawWithheldTokensFromMint",
                 "docs": [
                     "Transfer all withheld tokens in the mint to an account. Signed by the",
@@ -2587,6 +3230,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Fee Receiver"
+                        },
                         "name": "feeReceiver",
                         "isWritable": true,
                         "isSigner": false,
@@ -2611,6 +3258,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2626,6 +3277,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2643,6 +3298,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -2667,6 +3326,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw withheld fees",
+                    "interpolatedIntent": "Withdraw withheld fees to ${accounts.feeReceiver}"
+                },
                 "name": "withdrawWithheldTokensFromAccounts",
                 "docs": [
                     "Transfer all withheld tokens to an account. Signed by the mint's",
@@ -2684,6 +3348,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Fee Receiver"
+                        },
                         "name": "feeReceiver",
                         "isWritable": true,
                         "isSigner": false,
@@ -2708,6 +3376,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2723,6 +3395,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2738,6 +3414,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "numTokenAccounts",
                         "docs": ["Number of token accounts harvested."],
                         "type": {
@@ -2750,6 +3430,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -2760,6 +3444,10 @@
                     },
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Source Accounts"
+                        },
                         "isOptional": false,
                         "isWritable": true,
                         "isSigner": false,
@@ -2785,6 +3473,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Harvest withheld fees",
+                    "interpolatedIntent": "Harvest withheld fees to mint ${accounts.mint}"
+                },
                 "name": "harvestWithheldTokensToMint",
                 "docs": [
                     "Permissionless instruction to transfer all withheld tokens to the mint.",
@@ -2808,6 +3501,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2823,6 +3520,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2840,6 +3541,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Source Accounts"
+                        },
                         "isOptional": false,
                         "isWritable": true,
                         "isSigner": false,
@@ -2865,6 +3570,22 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set transfer fee",
+                    "interpolatedIntent": "Set the transfer fee of ${accounts.mint} to ${data.transferFeeBasisPoints}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "account": "mint",
+                            "kind": "accountFieldValueNode",
+                            "path": "decimals"
+                        }
+                    }
+                ],
                 "name": "setTransferFee",
                 "docs": [
                     "Set transfer fee. Only supported for mints that include the",
@@ -2874,6 +3595,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "accountLink": {
+                            "kind": "accountLinkNode",
+                            "name": "mint"
+                        },
                         "name": "mint",
                         "isWritable": true,
                         "isSigner": false,
@@ -2895,6 +3620,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2910,6 +3639,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -2925,12 +3658,27 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Fee"
+                        },
                         "name": "transferFeeBasisPoints",
                         "docs": [
                             "Amount of transfer collected as fees, expressed as basis points of the transfer amount."
                         ],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "numberValueNode",
+                                    "number": 2
+                                },
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "%"
+                                }
+                            },
                             "format": "u16",
                             "endian": "le"
                         }
@@ -2941,6 +3689,13 @@
                         "docs": ["Maximum fee assessed on transfers."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -2949,6 +3704,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -2973,6 +3732,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize confidential transfers",
+                    "interpolatedIntent": "Initialize confidential transfers for mint ${accounts.mint}"
+                },
                 "name": "initializeConfidentialTransferMint",
                 "docs": [
                     "Initializes confidential transfers for a mint.",
@@ -2999,6 +3763,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3014,6 +3782,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3059,6 +3831,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "auditorElgamalPubkey",
                         "docs": ["New authority to decode any transfer amount in a confidential transfer."],
                         "type": {
@@ -3084,6 +3860,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Update confidential transfers",
+                    "interpolatedIntent": "Update confidential transfers for mint ${accounts.mint}"
+                },
                 "name": "updateConfidentialTransferMint",
                 "docs": [
                     "Updates the confidential transfer mint configuration for a mint.",
@@ -3113,6 +3894,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3128,6 +3913,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3159,6 +3948,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "auditorElgamalPubkey",
                         "docs": ["New authority to decode any transfer amount in a confidential transfer."],
                         "type": {
@@ -3184,6 +3977,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Configure confidential account",
+                    "interpolatedIntent": "Configure ${accounts.token} for confidential transfers"
+                },
                 "name": "configureConfidentialTransferAccount",
                 "docs": [
                     "Configures confidential transfers for a token account.",
@@ -3208,6 +4006,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -3224,6 +4026,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvarOrContextState",
                         "isWritable": false,
                         "isSigner": false,
@@ -3251,6 +4057,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3266,6 +4076,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3281,6 +4095,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "decryptableZeroBalance",
                         "docs": ["The decryptable balance (always 0) once the configure account succeeds."],
                         "type": {
@@ -3303,6 +4121,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "proofInstructionOffset",
                         "docs": [
                             "Relative location of the `ProofInstruction::ZeroCiphertextProof`",
@@ -3320,6 +4142,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -3344,6 +4170,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Approve confidential account",
+                    "interpolatedIntent": "Approve ${accounts.token} for confidential transfers"
+                },
                 "name": "approveConfidentialTransferAccount",
                 "docs": [
                     "Approves a token account for confidential transfers.",
@@ -3358,6 +4189,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -3384,6 +4219,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3399,6 +4238,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3428,6 +4271,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Empty confidential balance",
+                    "interpolatedIntent": "Empty the confidential balance of ${accounts.token}"
+                },
                 "name": "emptyConfidentialTransferAccount",
                 "docs": [
                     "Empty the available balance in a confidential token account.",
@@ -3454,6 +4302,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -3462,6 +4314,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvarOrContextState",
                         "isWritable": false,
                         "isSigner": false,
@@ -3489,6 +4345,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3504,6 +4364,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3519,6 +4383,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "proofInstructionOffset",
                         "docs": [
                             "Relative location of the `ProofInstruction::VerifyCloseAccount`",
@@ -3535,6 +4403,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -3559,6 +4431,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Deposit confidential tokens",
+                    "interpolatedIntent": "Deposit ${data.amount} ${accounts.mint} into the confidential balance of ${accounts.token}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "confidentialDeposit",
                 "docs": [
                     "Deposit SPL Tokens into the pending balance of a confidential token",
@@ -3575,6 +4462,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -3601,6 +4492,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3616,6 +4511,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3635,12 +4534,23 @@
                         "docs": ["The amount of tokens to deposit."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -3653,6 +4563,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -3677,6 +4591,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw confidential tokens",
+                    "interpolatedIntent": "Withdraw ${data.amount} ${accounts.mint} from the confidential balance of ${accounts.token}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "confidentialWithdraw",
                 "docs": [
                     "Withdraw SPL Tokens from the available balance of a confidential token",
@@ -3698,6 +4627,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -3714,6 +4647,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvar",
                         "isWritable": false,
                         "isSigner": false,
@@ -3752,6 +4689,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3767,6 +4708,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3786,12 +4731,23 @@
                         "docs": ["The amount of tokens to withdraw."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -3802,6 +4758,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableAvailableBalance",
                         "docs": ["The new decryptable balance if the withdrawal succeeds."],
                         "type": {
@@ -3811,6 +4771,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "equalityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -3826,6 +4790,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rangeProofInstructionOffset",
                         "docs": [
                             "Relative location of the `ProofInstruction::BatchedRangeProofU64`",
@@ -3842,6 +4810,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -3866,6 +4838,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer confidential tokens",
+                    "interpolatedIntent": "Transfer confidential tokens from ${accounts.sourceToken} to ${accounts.destinationToken}"
+                },
                 "name": "confidentialTransfer",
                 "docs": [
                     "Transfer tokens confidentially.",
@@ -3886,6 +4863,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "sourceToken",
                         "isWritable": true,
                         "isSigner": false,
@@ -3902,6 +4883,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destinationToken",
                         "isWritable": true,
                         "isSigner": false,
@@ -3910,6 +4895,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvar",
                         "isWritable": false,
                         "isSigner": false,
@@ -3956,6 +4945,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3971,6 +4964,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -3986,6 +4983,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newSourceDecryptableAvailableBalance",
                         "docs": ["The new source decryptable balance if the transfer succeeds."],
                         "type": {
@@ -3995,6 +4996,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferAmountAuditorCiphertextLo",
                         "docs": ["The transfer amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -4004,6 +5009,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferAmountAuditorCiphertextHi",
                         "docs": ["The transfer amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -4013,6 +5022,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "equalityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -4028,6 +5041,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "ciphertextValidityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -4043,6 +5060,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rangeProofInstructionOffset",
                         "docs": [
                             "Relative location of the `ProofInstruction::BatchedRangeProofU128Data`",
@@ -4059,6 +5080,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4083,6 +5108,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Apply pending balance",
+                    "interpolatedIntent": "Apply the pending confidential balance of ${accounts.token}"
+                },
                 "name": "applyConfidentialPendingBalance",
                 "docs": [
                     "Applies the pending balance to the available balance, based on the",
@@ -4101,6 +5131,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -4119,6 +5153,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4134,6 +5172,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4162,6 +5204,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableAvailableBalance",
                         "docs": ["The new decryptable balance if the pending balance is applied", "successfully"],
                         "type": {
@@ -4173,6 +5219,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4197,12 +5247,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Enable confidential credits",
+                    "interpolatedIntent": "Enable confidential credits for ${accounts.token}"
+                },
                 "name": "enableConfidentialCredits",
                 "docs": ["Configure a confidential extension account to accept incoming", "confidential transfers."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -4221,6 +5280,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4236,6 +5299,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4253,6 +5320,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4277,6 +5348,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Disable confidential credits",
+                    "interpolatedIntent": "Disable confidential credits for ${accounts.token}"
+                },
                 "name": "disableConfidentialCredits",
                 "docs": [
                     "Configure a confidential extension account to reject any incoming",
@@ -4292,6 +5368,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -4310,6 +5390,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4325,6 +5409,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4342,6 +5430,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4366,6 +5458,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Enable non-confidential credits",
+                    "interpolatedIntent": "Enable non-confidential credits for ${accounts.token}"
+                },
                 "name": "enableNonConfidentialCredits",
                 "docs": [
                     "Configure an account with the confidential extension to accept incoming",
@@ -4375,6 +5472,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -4393,6 +5494,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4408,6 +5513,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4425,6 +5534,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4449,6 +5562,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Disable non-confidential credits",
+                    "interpolatedIntent": "Disable non-confidential credits for ${accounts.token}"
+                },
                 "name": "disableNonConfidentialCredits",
                 "docs": [
                     "Configure an account with the confidential extension to reject any",
@@ -4461,6 +5579,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -4479,6 +5601,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4494,6 +5620,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4511,6 +5641,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4535,6 +5669,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer confidential tokens",
+                    "interpolatedIntent": "Transfer confidential tokens from ${accounts.sourceToken} to ${accounts.destinationToken}"
+                },
                 "name": "confidentialTransferWithFee",
                 "docs": [
                     "Transfer tokens confidentially with fee.",
@@ -4560,6 +5699,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "sourceToken",
                         "isWritable": true,
                         "isSigner": false,
@@ -4576,6 +5719,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destinationToken",
                         "isWritable": true,
                         "isSigner": false,
@@ -4584,6 +5731,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvar",
                         "isWritable": false,
                         "isSigner": false,
@@ -4649,6 +5800,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4664,6 +5819,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4679,6 +5838,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newSourceDecryptableAvailableBalance",
                         "docs": ["The new source decryptable balance if the transfer succeeds."],
                         "type": {
@@ -4688,6 +5851,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferAmountAuditorCiphertextLo",
                         "docs": ["The transfer amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -4697,6 +5864,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferAmountAuditorCiphertextHi",
                         "docs": ["The transfer amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -4706,6 +5877,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "equalityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -4721,6 +5896,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferAmountCiphertextValidityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -4737,6 +5916,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "feeSigmaProofInstructionOffset",
                         "docs": [
                             "Relative location of the `ProofInstruction::VerifyPercentageWithFee`",
@@ -4752,6 +5935,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "feeCiphertextValidityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -4768,6 +5955,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rangeProofInstructionOffset",
                         "docs": [
                             "Relative location of the `ProofInstruction::BatchedRangeProofU256Data`",
@@ -4785,6 +5976,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -4809,6 +6004,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Configure confidential account",
+                    "interpolatedIntent": "Configure ${accounts.token} for confidential transfers"
+                },
                 "name": "configureConfidentialTransferAccountWithRegistry",
                 "docs": [
                     "Configures confidential transfers for a token account.",
@@ -4832,6 +6032,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -4864,6 +6068,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "systemProgram",
                         "isWritable": false,
                         "isSigner": false,
@@ -4874,6 +6082,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4889,6 +6101,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4918,6 +6134,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set default account state",
+                    "interpolatedIntent": "Set the default account state of ${accounts.mint}"
+                },
                 "name": "initializeDefaultAccountState",
                 "docs": [
                     "Initialize a new mint with the default state for new Accounts.",
@@ -4943,6 +6164,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4958,6 +6183,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "defaultAccountStateDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -4973,6 +6202,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Default State"
+                        },
                         "name": "state",
                         "docs": ["The state each new token account should start with."],
                         "type": {
@@ -4996,6 +6229,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set default account state",
+                    "interpolatedIntent": "Set the default account state of ${accounts.mint}"
+                },
                 "name": "updateDefaultAccountState",
                 "docs": [
                     "Update the default state for new Accounts. Only supported for mints that",
@@ -5023,6 +6261,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5038,6 +6280,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "defaultAccountStateDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5053,6 +6299,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Default State"
+                        },
                         "name": "state",
                         "docs": ["The state each new token account should start with."],
                         "type": {
@@ -5064,6 +6314,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5088,6 +6342,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Reallocate token account",
+                    "interpolatedIntent": "Reallocate ${accounts.token} for new extensions"
+                },
                 "name": "reallocate",
                 "docs": [
                     "Check to see if a token account is large enough for a list of",
@@ -5098,6 +6357,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -5114,6 +6377,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "systemProgram",
                         "isWritable": false,
                         "isSigner": false,
@@ -5136,6 +6403,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5151,6 +6422,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Extensions"
+                        },
                         "name": "newExtensionTypes",
                         "docs": ["New extension types to include in the reallocated account."],
                         "type": {
@@ -5168,6 +6443,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5187,6 +6466,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Enable memo transfers",
+                    "interpolatedIntent": "Enable memo transfers for ${accounts.token}"
+                },
                 "name": "enableMemoTransfers",
                 "docs": [
                     "Require memos for transfers into this Account. Adds the MemoTransfer",
@@ -5196,6 +6480,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -5214,6 +6502,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5229,6 +6521,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "memoTransfersDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5246,6 +6542,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5270,6 +6570,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Disable memo transfers",
+                    "interpolatedIntent": "Disable memo transfers for ${accounts.token}"
+                },
                 "name": "disableMemoTransfers",
                 "docs": [
                     "Stop requiring memos for transfers into this Account.",
@@ -5281,6 +6586,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -5299,6 +6608,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5314,6 +6627,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "memoTransfersDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5331,6 +6648,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5355,6 +6676,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Create native mint",
+                    "interpolatedIntent": "Create the native SOL mint"
+                },
                 "name": "createNativeMint",
                 "docs": [
                     "Creates the native mint.",
@@ -5383,6 +6709,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "systemProgram",
                         "isWritable": false,
                         "isSigner": false,
@@ -5397,6 +6727,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5422,6 +6756,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Make tokens non-transferable",
+                    "interpolatedIntent": "Make tokens of mint ${accounts.mint} non-transferable"
+                },
                 "name": "initializeNonTransferableMint",
                 "docs": [
                     "Initialize the non transferable extension for the given mint account",
@@ -5442,6 +6781,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5466,6 +6809,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize interest-bearing mint",
+                    "interpolatedIntent": "Initialize the interest rate of ${accounts.mint} at ${data.rate}"
+                },
                 "name": "initializeInterestBearingMint",
                 "docs": [
                     "Initialize a new mint with the `InterestBearing` extension.",
@@ -5491,6 +6839,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5506,6 +6858,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "interestBearingMintDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5532,10 +6888,25 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Interest Rate"
+                        },
                         "name": "rate",
                         "docs": ["The initial interest rate"],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "numberValueNode",
+                                    "number": 2
+                                },
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "%"
+                                }
+                            },
                             "format": "i16",
                             "endian": "le"
                         }
@@ -5556,6 +6927,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set interest rate",
+                    "interpolatedIntent": "Set the interest rate of ${accounts.mint} to ${data.rate}"
+                },
                 "name": "updateRateInterestBearingMint",
                 "docs": [
                     "Update the interest rate. Only supported for mints that include the",
@@ -5583,6 +6959,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5598,6 +6978,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "interestBearingMintDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5613,10 +6997,25 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Interest Rate"
+                        },
                         "name": "rate",
                         "docs": ["The interest rate to update."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "numberValueNode",
+                                    "number": 2
+                                },
+                                "kind": "amountNumberDisplayNode",
+                                "unit": {
+                                    "kind": "stringValueNode",
+                                    "string": "%"
+                                }
+                            },
                             "format": "i16",
                             "endian": "le"
                         }
@@ -5625,6 +7024,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5649,6 +7052,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Enable CPI guard",
+                    "interpolatedIntent": "Enable CPI guard for ${accounts.token}"
+                },
                 "name": "enableCpiGuard",
                 "docs": [
                     "Lock certain token operations from taking place within CPI for this Account, namely:",
@@ -5663,6 +7071,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -5681,6 +7093,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5696,6 +7112,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "cpiGuardDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5713,6 +7133,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5737,6 +7161,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Disable CPI guard",
+                    "interpolatedIntent": "Disable CPI guard for ${accounts.token}"
+                },
                 "name": "disableCpiGuard",
                 "docs": [
                     "Allow all token operations to happen via CPI as normal.",
@@ -5747,6 +7176,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -5765,6 +7198,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5780,6 +7217,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "cpiGuardDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5797,6 +7238,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -5821,6 +7266,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set permanent delegate",
+                    "interpolatedIntent": "Set ${data.delegate} as permanent delegate of mint ${accounts.mint}"
+                },
                 "name": "initializePermanentDelegate",
                 "docs": [
                     "Initialize the permanent delegate on a new mint.",
@@ -5845,6 +7295,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5877,6 +7331,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set transfer hook",
+                    "interpolatedIntent": "Set the transfer hook of mint ${accounts.mint}"
+                },
                 "name": "initializeTransferHook",
                 "docs": [
                     "Initialize a new mint with a transfer hook program.",
@@ -5901,6 +7360,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5916,6 +7379,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferHookDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -5942,6 +7409,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Hook Program"
+                        },
                         "name": "programId",
                         "docs": ["The program id that performs logic during transfers"],
                         "type": {
@@ -5967,6 +7438,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set transfer hook",
+                    "interpolatedIntent": "Set the transfer hook of mint ${accounts.mint}"
+                },
                 "name": "updateTransferHook",
                 "docs": [
                     "Update the transfer hook program id. Only supported for mints that",
@@ -5999,6 +7475,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6014,6 +7494,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "transferHookDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6029,6 +7513,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Hook Program"
+                        },
                         "name": "programId",
                         "docs": ["The program id that performs logic during transfers"],
                         "type": {
@@ -6042,6 +7530,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6066,6 +7558,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize confidential fees",
+                    "interpolatedIntent": "Initialize confidential fees for mint ${accounts.mint}"
+                },
                 "name": "initializeConfidentialTransferFee",
                 "docs": [
                     "Initializes confidential transfer fees for a mint.",
@@ -6089,6 +7586,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6104,6 +7605,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6130,6 +7635,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "withdrawWithheldAuthorityElGamalPubkey",
                         "docs": ["Withheld fees from accounts must be encrypted with this ElGamal key"],
                         "type": {
@@ -6152,6 +7661,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw withheld confidential fees",
+                    "interpolatedIntent": "Withdraw withheld confidential fees from mint ${accounts.mint} to ${accounts.destination}"
+                },
                 "name": "withdrawWithheldTokensFromMintForConfidentialTransferFee",
                 "docs": [
                     "Transfer all withheld confidential tokens in the mint to an account.",
@@ -6175,6 +7689,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -6183,6 +7701,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvarOrContextState",
                         "isWritable": false,
                         "isSigner": false,
@@ -6206,6 +7728,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6221,6 +7747,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6236,6 +7766,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "proofInstructionOffset",
                         "docs": ["Proof instruction offset"],
                         "type": {
@@ -6246,6 +7780,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableAvailableBalance",
                         "docs": ["The new decryptable balance in the destination token account"],
                         "type": {
@@ -6257,6 +7795,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6281,6 +7823,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw withheld confidential fees",
+                    "interpolatedIntent": "Withdraw withheld confidential fees to ${accounts.destination}"
+                },
                 "name": "withdrawWithheldTokensFromAccountsForConfidentialTransferFee",
                 "docs": [
                     "Transfer all withheld tokens to an account. Signed by the mint's withdraw withheld",
@@ -6301,6 +7848,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -6309,6 +7860,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvarOrContextState",
                         "isWritable": false,
                         "isSigner": false,
@@ -6332,6 +7887,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6347,6 +7906,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6362,6 +7925,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "numTokenAccounts",
                         "docs": ["Number of token accounts harvested"],
                         "type": {
@@ -6372,6 +7939,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "proofInstructionOffset",
                         "docs": ["Proof instruction offset"],
                         "type": {
@@ -6382,6 +7953,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableAvailableBalance",
                         "docs": ["The new decryptable balance in the destination token account"],
                         "type": {
@@ -6393,6 +7968,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6417,6 +7996,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Harvest withheld confidential fees",
+                    "interpolatedIntent": "Harvest withheld confidential fees to mint ${accounts.mint}"
+                },
                 "name": "harvestWithheldTokensToMintForConfidentialTransferFee",
                 "docs": [
                     "Permissionless instruction to transfer all withheld confidential tokens to the mint.",
@@ -6440,6 +8024,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6455,6 +8043,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6472,6 +8064,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Source Accounts"
+                        },
                         "isOptional": true,
                         "isSigner": false,
                         "isWritable": true,
@@ -6497,6 +8093,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Enable harvest to mint",
+                    "interpolatedIntent": "Enable harvest to mint for ${accounts.mint}"
+                },
                 "name": "enableHarvestToMint",
                 "docs": ["Configure a confidential transfer fee mint to accept harvested confidential fees."],
                 "optionalAccountStrategy": "programId",
@@ -6521,6 +8122,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6536,6 +8141,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6553,6 +8162,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6577,6 +8190,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Disable harvest to mint",
+                    "interpolatedIntent": "Disable harvest to mint for ${accounts.mint}"
+                },
                 "name": "disableHarvestToMint",
                 "docs": ["Configure a confidential transfer fee mint to reject any harvested confidential fees."],
                 "optionalAccountStrategy": "programId",
@@ -6601,6 +8219,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6616,6 +8238,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialTransferFeeDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6633,6 +8259,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6657,6 +8287,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw excess SOL",
+                    "interpolatedIntent": "Withdraw excess SOL from ${accounts.source} to ${accounts.destination}"
+                },
                 "name": "withdrawExcessLamports",
                 "docs": [
                     "This instruction is to be used to rescue SOLs sent to any TokenProgram",
@@ -6667,6 +8302,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -6675,6 +8314,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -6693,6 +8336,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6710,6 +8357,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6729,6 +8380,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set metadata pointer",
+                    "interpolatedIntent": "Set the metadata pointer of mint ${accounts.mint}"
+                },
                 "name": "initializeMetadataPointer",
                 "docs": [
                     "Initialize a new mint with a metadata pointer",
@@ -6754,6 +8410,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6769,6 +8429,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "metadataPointerDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6820,6 +8484,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set metadata pointer",
+                    "interpolatedIntent": "Set the metadata pointer of mint ${accounts.mint}"
+                },
                 "name": "updateMetadataPointer",
                 "docs": [
                     "Update the metadata pointer address. Only supported for mints that",
@@ -6847,6 +8516,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6862,6 +8535,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "metadataPointerDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6890,6 +8567,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -6914,6 +8595,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set group pointer",
+                    "interpolatedIntent": "Set the group pointer of mint ${accounts.mint}"
+                },
                 "name": "initializeGroupPointer",
                 "docs": [
                     "Initialize a new mint with a group pointer",
@@ -6939,6 +8625,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -6954,6 +8644,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "groupPointerDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7005,6 +8699,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set group pointer",
+                    "interpolatedIntent": "Set the group pointer of mint ${accounts.mint}"
+                },
                 "name": "updateGroupPointer",
                 "docs": [
                     "Update the group pointer address. Only supported for mints that",
@@ -7032,6 +8731,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7047,6 +8750,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "groupPointerDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7075,6 +8782,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -7099,6 +8810,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set member pointer",
+                    "interpolatedIntent": "Set the member pointer of mint ${accounts.mint}"
+                },
                 "name": "initializeGroupMemberPointer",
                 "docs": [
                     "Initialize a new mint with a group member pointer",
@@ -7124,6 +8840,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7139,6 +8859,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "groupMemberPointerDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7190,6 +8914,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set member pointer",
+                    "interpolatedIntent": "Set the member pointer of mint ${accounts.mint}"
+                },
                 "name": "updateGroupMemberPointer",
                 "docs": [
                     "Update the group member pointer address. Only supported for mints that",
@@ -7217,6 +8946,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7232,6 +8965,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "groupMemberPointerDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7260,6 +8997,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -7284,6 +9025,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize confidential mint/burn",
+                    "interpolatedIntent": "Initialize confidential mint and burn for mint ${accounts.mint}"
+                },
                 "name": "initializeConfidentialMintBurn",
                 "docs": [
                     "Initializes confidential mints and burns for a mint.",
@@ -7310,6 +9056,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7325,6 +9075,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialMintBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7340,6 +9094,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "supplyElgamalPubkey",
                         "docs": ["The ElGamal pubkey used to encrypt the confidential supply."],
                         "type": {
@@ -7348,6 +9106,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "decryptableSupply",
                         "docs": ["The initial 0 supply encrypted with the supply aes key."],
                         "type": {
@@ -7371,6 +9133,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Rotate supply key",
+                    "interpolatedIntent": "Rotate the confidential supply key of mint ${accounts.mint}"
+                },
                 "name": "rotateSupplyElgamalPubkey",
                 "docs": [
                     "Rotates the ElGamal pubkey used to encrypt confidential supply.",
@@ -7390,6 +9157,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvarOrContextState",
                         "isWritable": false,
                         "isSigner": false,
@@ -7417,6 +9188,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7432,6 +9207,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialMintBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7447,6 +9226,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newSupplyElgamalPubkey",
                         "docs": ["The new ElGamal pubkey for supply encryption."],
                         "type": {
@@ -7455,6 +9238,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "proofInstructionOffset",
                         "docs": [
                             "The location of the",
@@ -7473,6 +9260,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -7497,6 +9288,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Update decryptable supply",
+                    "interpolatedIntent": "Update the decryptable supply of mint ${accounts.mint}"
+                },
                 "name": "updateConfidentialMintBurnDecryptableSupply",
                 "docs": ["Updates the decryptable supply of the mint."],
                 "optionalAccountStrategy": "programId",
@@ -7521,6 +9317,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7536,6 +9336,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialMintBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7551,6 +9355,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableSupply",
                         "docs": ["The new decryptable supply."],
                         "type": {
@@ -7562,6 +9370,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -7586,6 +9398,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Mint confidential tokens",
+                    "interpolatedIntent": "Mint confidential tokens to ${accounts.token}"
+                },
                 "name": "confidentialMint",
                 "docs": [
                     "Mints tokens to a confidential balance.",
@@ -7606,6 +9423,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -7622,6 +9443,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvar",
                         "isWritable": false,
                         "isSigner": false,
@@ -7677,6 +9502,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7692,6 +9521,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialMintBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7707,6 +9540,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableSupply",
                         "docs": ["The new decryptable supply if the mint succeeds."],
                         "type": {
@@ -7716,6 +9553,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "mintAmountAuditorCiphertextLo",
                         "docs": ["The mint amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -7725,6 +9566,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "mintAmountAuditorCiphertextHi",
                         "docs": ["The mint amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -7734,6 +9579,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "equalityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -7749,6 +9598,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "ciphertextValidityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -7764,6 +9617,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rangeProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -7781,6 +9638,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -7805,6 +9666,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Burn confidential tokens",
+                    "interpolatedIntent": "Burn confidential tokens from ${accounts.token}"
+                },
                 "name": "confidentialBurn",
                 "docs": [
                     "Burns tokens from a confidential balance.",
@@ -7825,6 +9691,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -7841,6 +9711,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvar",
                         "isWritable": false,
                         "isSigner": false,
@@ -7896,6 +9770,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7911,6 +9789,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialMintBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -7926,6 +9808,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableAvailableBalance",
                         "docs": ["The new decryptable balance of the burner if the burn succeeds."],
                         "type": {
@@ -7935,6 +9821,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "burnAmountAuditorCiphertextLo",
                         "docs": ["The burn amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -7944,6 +9834,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "burnAmountAuditorCiphertextHi",
                         "docs": ["The burn amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -7953,6 +9847,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "equalityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -7968,6 +9866,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "ciphertextValidityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -7983,6 +9885,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rangeProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -8000,6 +9906,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -8024,6 +9934,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Apply pending burn",
+                    "interpolatedIntent": "Apply the pending confidential burn of mint ${accounts.mint}"
+                },
                 "name": "applyConfidentialPendingBurn",
                 "docs": ["Applies the pending burn amount to the confidential supply."],
                 "optionalAccountStrategy": "programId",
@@ -8048,6 +9963,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8063,6 +9982,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "confidentialMintBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8080,6 +10003,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -8104,6 +10031,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize UI multiplier",
+                    "interpolatedIntent": "Initialize the multiplier of ${accounts.mint} at ${data.multiplier}"
+                },
                 "name": "initializeScaledUiAmountMint",
                 "docs": [
                     "Initialize a new mint with the `ScaledUiAmount` extension.",
@@ -8128,6 +10060,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8143,6 +10079,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "scaledUiAmountMintDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8193,6 +10133,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set UI multiplier",
+                    "interpolatedIntent": "Set the multiplier of ${accounts.mint} to ${data.multiplier}"
+                },
                 "name": "updateMultiplierScaledUiMint",
                 "docs": [
                     "Update the multiplier. Only supported for mints that include the",
@@ -8221,6 +10166,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8236,6 +10185,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "scaledUiAmountMintDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8261,10 +10214,17 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Effective From"
+                        },
                         "name": "effectiveTimestamp",
                         "docs": ["The timestamp at which the new multiplier will take effect"],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "kind": "dateTimeNumberDisplayNode"
+                            },
                             "format": "i64",
                             "endian": "le"
                         }
@@ -8273,6 +10233,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -8297,6 +10261,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize pausable config",
+                    "interpolatedIntent": "Make mint ${accounts.mint} pausable"
+                },
                 "name": "initializePausableConfig",
                 "docs": [
                     "Initialize a new mint with the `Pausable` extension.",
@@ -8317,6 +10286,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8332,6 +10305,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "pausableDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8372,6 +10349,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Pause token",
+                    "interpolatedIntent": "Pause all activity for mint ${accounts.mint}"
+                },
                 "name": "pause",
                 "docs": ["Pause the mint.", "", "Fails if the mint is not pausable."],
                 "optionalAccountStrategy": "programId",
@@ -8396,6 +10378,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8411,6 +10397,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "pausableDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8440,6 +10430,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Resume token",
+                    "interpolatedIntent": "Resume activity for mint ${accounts.mint}"
+                },
                 "name": "resume",
                 "docs": ["Resume the mint.", "", "Fails if the mint is not pausable."],
                 "optionalAccountStrategy": "programId",
@@ -8464,6 +10459,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8479,6 +10478,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "pausableDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8508,6 +10511,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize token metadata",
+                    "interpolatedIntent": "Initialize metadata for mint ${accounts.mint}"
+                },
                 "name": "initializeTokenMetadata",
                 "docs": [
                     "Initializes a TLV entry with the basic token-metadata fields.",
@@ -8554,6 +10562,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8606,6 +10618,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "URI"
+                        },
                         "name": "uri",
                         "docs": ["URI pointing to more metadata (image, video, etc.)."],
                         "type": {
@@ -8632,6 +10648,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Update token metadata"
+                },
                 "name": "updateTokenMetadataField",
                 "docs": [
                     "Updates a field in a token-metadata account.",
@@ -8669,6 +10689,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8722,6 +10746,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Remove metadata key"
+                },
                 "name": "removeTokenMetadataKey",
                 "docs": [
                     "Removes a key-value pair in a token-metadata account.",
@@ -8754,6 +10782,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8818,6 +10850,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set metadata update authority"
+                },
                 "name": "updateTokenMetadataUpdateAuthority",
                 "docs": ["Updates the token-metadata authority."],
                 "optionalAccountStrategy": "programId",
@@ -8842,6 +10878,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8880,6 +10920,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Emit token metadata"
+                },
                 "name": "emitTokenMetadata",
                 "docs": [
                     "Emits the token-metadata as return data",
@@ -8906,6 +10950,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -8975,6 +11023,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize token group",
+                    "interpolatedIntent": "Initialize token group ${accounts.group} for mint ${accounts.mint}"
+                },
                 "name": "initializeTokenGroup",
                 "docs": ["Initialize a new `Group`", "", "Assumes one has already initialized a mint for the group."],
                 "optionalAccountStrategy": "programId",
@@ -9007,6 +11060,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9055,6 +11112,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set group max size",
+                    "interpolatedIntent": "Set the maximum size of group ${accounts.group} to ${data.maxSize}"
+                },
                 "name": "updateTokenGroupMaxSize",
                 "docs": ["Update the max size of a `Group`."],
                 "optionalAccountStrategy": "programId",
@@ -9079,6 +11141,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9116,6 +11182,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Set group update authority"
+                },
                 "name": "updateTokenGroupUpdateAuthority",
                 "docs": ["Update the authority of a `Group`."],
                 "optionalAccountStrategy": "programId",
@@ -9140,6 +11210,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9178,6 +11252,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Add group member",
+                    "interpolatedIntent": "Add ${accounts.member} to group ${accounts.group}"
+                },
                 "name": "initializeTokenGroupMember",
                 "docs": [
                     "Initialize a new `Member` of a `Group`",
@@ -9189,6 +11268,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Member"
+                        },
                         "name": "member",
                         "isWritable": true,
                         "isSigner": false,
@@ -9231,6 +11314,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9258,12 +11345,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Unwrap SOL",
+                    "interpolatedIntent": "Unwrap SOL from ${accounts.source} to ${accounts.destination}"
+                },
                 "name": "unwrapLamports",
                 "docs": ["Transfer lamports from a native SOL account to a destination account."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "From"
+                        },
                         "name": "source",
                         "isWritable": true,
                         "isSigner": false,
@@ -9272,6 +11368,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "To"
+                        },
                         "name": "destination",
                         "isWritable": true,
                         "isSigner": false,
@@ -9293,6 +11393,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9315,6 +11419,17 @@
                             "fixed": false,
                             "item": {
                                 "kind": "numberTypeNode",
+                                "display": {
+                                    "decimals": {
+                                        "kind": "numberValueNode",
+                                        "number": 9
+                                    },
+                                    "kind": "amountNumberDisplayNode",
+                                    "unit": {
+                                        "kind": "stringValueNode",
+                                        "string": "SOL"
+                                    }
+                                },
                                 "format": "u64",
                                 "endian": "le"
                             },
@@ -9329,6 +11444,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -9348,6 +11467,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize permissioned burn",
+                    "interpolatedIntent": "Set ${data.authority} as burn authority of mint ${accounts.mint}"
+                },
                 "name": "initializePermissionedBurn",
                 "docs": [
                     "Require permissioned burn for the given mint account.",
@@ -9368,6 +11492,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9383,6 +11511,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "permissionedBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9420,12 +11552,32 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Burn tokens",
+                    "interpolatedIntent": "Burn ${data.amount} ${accounts.mint} from ${accounts.account}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "account": "mint",
+                            "kind": "accountFieldValueNode",
+                            "path": "decimals"
+                        }
+                    }
+                ],
                 "name": "permissionedBurn",
                 "docs": ["Burn tokens when the mint has the permissioned burn extension enabled."],
                 "optionalAccountStrategy": "programId",
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -9434,6 +11586,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "accountLink": {
+                            "kind": "accountLinkNode",
+                            "name": "mint"
+                        },
                         "name": "mint",
                         "isWritable": true,
                         "isSigner": false,
@@ -9442,6 +11598,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Burn Authority"
+                        },
                         "name": "permissionedBurnAuthority",
                         "isWritable": false,
                         "isSigner": true,
@@ -9463,6 +11623,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9478,6 +11642,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "permissionedBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9497,6 +11665,13 @@
                         "docs": ["The amount of tokens to burn."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
@@ -9505,6 +11680,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -9529,6 +11708,21 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Burn tokens",
+                    "interpolatedIntent": "Burn ${data.amount} ${accounts.mint} from ${accounts.account}"
+                },
+                "provides": [
+                    {
+                        "kind": "providedNode",
+                        "name": "decimals",
+                        "node": {
+                            "kind": "argumentValueNode",
+                            "name": "decimals"
+                        }
+                    }
+                ],
                 "name": "permissionedBurnChecked",
                 "docs": [
                     "Burn tokens with expected decimals when the mint has the permissioned burn extension enabled."
@@ -9537,6 +11731,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "account",
                         "isWritable": true,
                         "isSigner": false,
@@ -9553,6 +11751,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Burn Authority"
+                        },
                         "name": "permissionedBurnAuthority",
                         "isWritable": false,
                         "isSigner": true,
@@ -9574,6 +11776,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9589,6 +11795,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "permissionedBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9608,12 +11818,23 @@
                         "docs": ["The amount of tokens to burn."],
                         "type": {
                             "kind": "numberTypeNode",
+                            "display": {
+                                "decimals": {
+                                    "kind": "injectedValueNode",
+                                    "key": "decimals"
+                                },
+                                "kind": "amountNumberDisplayNode"
+                            },
                             "format": "u64",
                             "endian": "le"
                         }
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "whenInjected"
+                        },
                         "name": "decimals",
                         "docs": ["Expected number of base 10 digits to the right of the decimal place."],
                         "type": {
@@ -9626,6 +11847,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -9650,6 +11875,11 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Burn confidential tokens",
+                    "interpolatedIntent": "Burn confidential tokens from ${accounts.token}"
+                },
                 "name": "permissionedConfidentialBurn",
                 "docs": [
                     "Burn tokens from a confidential balance when the mint has the",
@@ -9671,6 +11901,10 @@
                 "accounts": [
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Token Account"
+                        },
                         "name": "token",
                         "isWritable": true,
                         "isSigner": false,
@@ -9687,6 +11921,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "instructionsSysvar",
                         "isWritable": false,
                         "isSigner": false,
@@ -9732,6 +11970,10 @@
                     },
                     {
                         "kind": "instructionAccountNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Burn Authority"
+                        },
                         "name": "permissionedBurnAuthority",
                         "isWritable": false,
                         "isSigner": true,
@@ -9750,6 +11992,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9765,6 +12011,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "permissionedBurnDiscriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9780,6 +12030,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "newDecryptableAvailableBalance",
                         "docs": ["The new decryptable balance of the burner if the burn succeeds."],
                         "type": {
@@ -9789,6 +12043,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "burnAmountAuditorCiphertextLo",
                         "docs": ["The burn amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -9798,6 +12056,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "burnAmountAuditorCiphertextHi",
                         "docs": ["The burn amount encrypted under the auditor ElGamal public key."],
                         "type": {
@@ -9807,6 +12069,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "equalityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -9822,6 +12088,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "ciphertextValidityProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -9837,6 +12107,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "rangeProofInstructionOffset",
                         "docs": [
                             "Relative location of the",
@@ -9854,6 +12128,10 @@
                 "remainingAccounts": [
                     {
                         "kind": "instructionRemainingAccountsNode",
+                        "display": {
+                            "kind": "instructionAccountDisplayNode",
+                            "label": "Multisig Signers"
+                        },
                         "isOptional": true,
                         "isSigner": true,
                         "docs": [],
@@ -9878,6 +12156,10 @@
             },
             {
                 "kind": "instructionNode",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Batch instructions"
+                },
                 "name": "batch",
                 "docs": [
                     "Executes a batch of instructions. The instructions to be executed are",
@@ -9906,6 +12188,10 @@
                 "arguments": [
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "skip": "always"
+                        },
                         "name": "discriminator",
                         "defaultValueStrategy": "omitted",
                         "docs": [],
@@ -9921,6 +12207,10 @@
                     },
                     {
                         "kind": "instructionArgumentNode",
+                        "display": {
+                            "kind": "structFieldDisplayNode",
+                            "label": "Batched Instructions"
+                        },
                         "name": "data",
                         "docs": ["Instruction data for batch instructions."],
                         "type": {
@@ -11849,6 +14139,11 @@
             "instructions": [
                 {
                     "kind": "instructionNode",
+                    "display": {
+                        "kind": "instructionDisplayNode",
+                        "intent": "Create associated token account",
+                        "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+                    },
                     "accounts": [
                         {
                             "kind": "instructionAccountNode",
@@ -11861,6 +14156,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Token Account"
+                            },
                             "name": "ata",
                             "isWritable": true,
                             "isSigner": false,
@@ -11918,6 +14217,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "skip": "always"
+                            },
                             "name": "systemProgram",
                             "isWritable": false,
                             "isSigner": false,
@@ -11944,6 +14247,10 @@
                     "arguments": [
                         {
                             "kind": "instructionArgumentNode",
+                            "display": {
+                                "kind": "structFieldDisplayNode",
+                                "skip": "always"
+                            },
                             "name": "discriminator",
                             "type": {
                                 "kind": "numberTypeNode",
@@ -11971,6 +14278,11 @@
                 },
                 {
                     "kind": "instructionNode",
+                    "display": {
+                        "kind": "instructionDisplayNode",
+                        "intent": "Create associated token account",
+                        "interpolatedIntent": "Create associated token account ${accounts.ata} for ${accounts.owner}"
+                    },
                     "accounts": [
                         {
                             "kind": "instructionAccountNode",
@@ -11983,6 +14295,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Token Account"
+                            },
                             "name": "ata",
                             "isWritable": true,
                             "isSigner": false,
@@ -12040,6 +14356,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "skip": "always"
+                            },
                             "name": "systemProgram",
                             "isWritable": false,
                             "isSigner": false,
@@ -12066,6 +14386,10 @@
                     "arguments": [
                         {
                             "kind": "instructionArgumentNode",
+                            "display": {
+                                "kind": "structFieldDisplayNode",
+                                "skip": "always"
+                            },
                             "name": "discriminator",
                             "type": {
                                 "kind": "numberTypeNode",
@@ -12094,9 +14418,18 @@
                 },
                 {
                     "kind": "instructionNode",
+                    "display": {
+                        "kind": "instructionDisplayNode",
+                        "intent": "Recover nested token account",
+                        "interpolatedIntent": "Recover nested token account ${accounts.nestedAssociatedAccountAddress} to ${accounts.destinationAssociatedAccountAddress}"
+                    },
                     "accounts": [
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Nested Token Account"
+                            },
                             "name": "nestedAssociatedAccountAddress",
                             "isWritable": true,
                             "isSigner": false,
@@ -12140,6 +14473,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Nested Mint"
+                            },
                             "name": "nestedTokenMintAddress",
                             "isWritable": false,
                             "isSigner": false,
@@ -12148,6 +14485,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Destination Token Account"
+                            },
                             "name": "destinationAssociatedAccountAddress",
                             "isWritable": true,
                             "isSigner": false,
@@ -12189,6 +14530,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Owner Token Account"
+                            },
                             "name": "ownerAssociatedAccountAddress",
                             "isWritable": false,
                             "isSigner": false,
@@ -12230,6 +14575,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Owner Mint"
+                            },
                             "name": "ownerTokenMintAddress",
                             "isWritable": false,
                             "isSigner": false,
@@ -12238,6 +14587,10 @@
                         },
                         {
                             "kind": "instructionAccountNode",
+                            "display": {
+                                "kind": "instructionAccountDisplayNode",
+                                "label": "Wallet"
+                            },
                             "name": "walletAddress",
                             "isWritable": true,
                             "isSigner": true,
@@ -12260,6 +14613,10 @@
                     "arguments": [
                         {
                             "kind": "instructionArgumentNode",
+                            "display": {
+                                "kind": "structFieldDisplayNode",
+                                "skip": "always"
+                            },
                             "name": "discriminator",
                             "type": {
                                 "kind": "numberTypeNode",


### PR DESCRIPTION
This PR enriches the Codama IDL with display metadata for clear signing, per [sRFC 39](https://github.com/solana-foundation/SRFCs/discussions/4). All 103 instructions (25 base + 75 extension + 3 associated-token-account) gain intents, interpolated intents and labels.

Highlights:

- Token amounts scale through the provide/inject graph: checked variants provide `decimals` from their own argument (fully offline); `mintTo`/`burn`/`setTransferFee` provide it from the mint account (`accountFieldValueNode` + `accountLink`), degrading gracefully to raw.
- Transfer fees and interest rates render as percentages (`decimals: 2`, unit `%`).
- The scaled-UI-amount `effectiveTimestamp` renders as a date-time.
- Confidential-transfer ciphertexts, ElGamal keys and proof offsets are hidden (`skip: "always"`) — encrypted bytes are noise on a signing screen.
- Discriminators, sub-discriminators, sysvars and fixed programs are hidden from the fallback list.

Sample renders via `@codama/dynamic-instructions`:

```
Transfer 1.5 EPjFW… from CiDwV… to DRpbC… with a fee of 0.001
Set the transfer fee of EPjFW… to 0.5 %
Set the interest rate of EPjFW… to 2.5 %
Deposit 1.5 EPjFW… into the confidential balance of HN7cA…
```

Clients were regenerated and are unaffected: renderers pass display metadata through untouched.