### PR TITLE
Ignore RUSTSEC-2026-0258 in cargo audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ audit:
 			--ignore RUSTSEC-2026-0098 \
 			--ignore RUSTSEC-2026-0099 \
 			--ignore RUSTSEC-2026-0104 \
+			--ignore RUSTSEC-2026-0258 \
 			$(ARGS)
 
 spellcheck:


### PR DESCRIPTION
This PR adds RUSTSEC-2026-0258 (h2 unbounded empty DATA frames, low severity) to the cargo audit ignore list, fixing the currently-failing Audit CI job. The vulnerable h2 0.3.26 is a transitive dependency via hyper 0.14 → axum 0.6 → tonic 0.9 → solana-storage-bigtable under solana-test-validator, and the only patched line is h2 >= 0.4.16, which cannot be reached without a hyper 1.x upgrade through that whole chain.

Same decision made on Agave 4.3 branch: https://github.com/anza-xyz/agave/pull/14752 