### PR TITLE
Update ignored RustSec advisories in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ audit:
 			--ignore RUSTSEC-2026-0099 \
 			--ignore RUSTSEC-2026-0104 \
 			--ignore RUSTSEC-2026-0190 \
-
+			--ignore RUSTSEC-2026-0253 \
+			--ignore RUSTSEC-2026-0255 \
 			$(ARGS)
 
 spellcheck:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ audit:
 			--ignore RUSTSEC-2026-0098 \
 			--ignore RUSTSEC-2026-0099 \
 			--ignore RUSTSEC-2026-0104 \
-			--ignore RUSTSEC-2026-0258 \
+			--ignore RUSTSEC-2026-0190 \
+
 			$(ARGS)
 
 spellcheck:


### PR DESCRIPTION
Replaced RUSTSEC-2026-0258 with RUSTSEC-2026-0190 in Makefile.