### PR TITLE
Replace the published engines field with devEngines in the JS client

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -82,7 +82,11 @@
             "optional": true
         }
     },
-    "engines": {
-        "node": ">=24.0.0"
+    "devEngines": {
+        "runtime": {
+            "name": "node",
+            "version": ">=24.0.0",
+            "onFail": "error"
+        }
     }
 }


### PR DESCRIPTION
This PR removes the `engines` field from the published JS client manifest and declares the Node 24 dev-tooling floor via `devEngines.runtime` instead. `engines` constrains consumers rather than contributors — Yarn Classic hard-fails installing the client into any project running Node < 24 (see solana-program/token#176) — while the client's actual runtime floor is simply inherited from `@solana/kit`. `devEngines` only applies to this repository's own development and is enforced by npm ≥ 10.9.