### PR TITLE
deps: Bump tlv-account-resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10843,6 +10843,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-list-view"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e598e5d5f99fcc4ff25c4677465743a9b2d7e42fcc9492b982f04fbefab792"
+dependencies = [
+ "bytemuck",
+ "num-derive 0.4.2",
+ "num-traits",
+ "num_enum",
+ "solana-program-error",
+ "solana-zero-copy",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "spl-memo-interface"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10854,9 +10869,9 @@ dependencies = [
 
 [[package]]
 name = "spl-pod"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9c6e142cdf1e7e77f480053ec9f0ce989890768ddf91f619b50f39d1b456f5"
+checksum = "4efaa79ec81a614ae4263c92481ba1444d01e5e1efcdaf92b7f48a5b1b3e282d"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -10922,9 +10937,9 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6927f613c9d7ce20835d3cefb602137cab2518e383a047c0eaa58054a60644c8"
+checksum = "4378fa824c41a21856eb5347fbff48bc613456179de02ba51f667bce9acb18f6"
 dependencies = [
  "bytemuck",
  "num-derive 0.4.2",
@@ -10935,8 +10950,8 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 3.0.0",
  "spl-discriminator",
+ "spl-list-view",
  "spl-pod",
- "spl-program-error",
  "spl-type-length-value",
  "thiserror 2.0.20",
 ]

--- a/clients/rust-legacy/Cargo.toml
+++ b/clients/rust-legacy/Cargo.toml
@@ -71,6 +71,6 @@ solana-program-test = { version = "4.0.0-rc.0", features = ["agave-unstable-api"
 solana-sdk = "3.0.0"
 solana-sdk-ids = "3.1.0"
 spl-instruction-padding-interface = "1.0.0"
-spl-tlv-account-resolution = "0.11.0"
+spl-tlv-account-resolution = "0.11.3"
 spl-token-client = { path = ".", features = ["dev-context-only-utils"] }
 test-case = "3.3"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -55,7 +55,7 @@ mollusk-svm = "0.12"
 proptest = "1.11"
 serial_test = "4.0.1"
 solana-account = "3.2.0"
-spl-tlv-account-resolution = { version = "0.11.1" }
+spl-tlv-account-resolution = { version = "0.11.3" }
 test-case = "3.3.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 


### PR DESCRIPTION
#### Problem

The latest published version of tlv-account-resolution reduces allocations and CU consumption, but the program isn't using it.

#### Summary of changes

Bump the dependency to make sure we get the benefits.