### PR TITLE
feat!: Standardize confidential key derivation on the main wallet

### DIFF
--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -31,6 +31,11 @@ function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
  * Derives an ElGamal keypair following the `solana-conf-bal/v1` standard: the
  * signer signs a domain-separated message and the resulting Ed25519 signature
  * is fed into the WASM ZK SDK's `ConfidentialKeys` to derive the keypair.
+ *
+ * The standard derivation binds confidential-transfer keys to the main wallet
+ * only: leave `publicSeed` at its empty default so one wallet maps to one
+ * ElGamal keypair across all mints and token accounts. Only pass a custom
+ * seed for non-standard, application-specific keying schemes.
  */
 export async function deriveElGamalKeypair({
     signer,
@@ -48,9 +53,11 @@ export async function deriveElGamalKeypair({
 }
 
 /**
- * Derives an ElGamal keypair bound to an `(owner, mint)` pair. The seed
- * is `concat(ownerBytes, mintBytes)`, which is stable across token-account
- * close-and-reopen and prevents key reuse across mints.
+ * Derives an ElGamal keypair bound to an `(owner, mint)` pair, with a seed of
+ * `concat(ownerBytes, mintBytes)`.
+ *
+ * @deprecated The standard derivation binds keys to the main wallet only.
+ * Use `deriveElGamalKeypair({ signer })` with the default empty seed instead.
  */
 export async function deriveElGamalKeypairForOwnerMint({
     signer,
@@ -68,6 +75,10 @@ export async function deriveElGamalKeypairForOwnerMint({
  * Derives an AES-128 authenticated-encryption key following the
  * `solana-conf-bal/v1` standard: the signer signs a domain-separated message
  * and the resulting signature is fed into the WASM ZK SDK's `ConfidentialKeys`.
+ *
+ * The standard derivation binds the key to the main wallet only: leave
+ * `publicSeed` at its empty default so one wallet maps to one AES key across
+ * all mints and token accounts.
  */
 export async function deriveAeKey({
     signer,
@@ -85,8 +96,8 @@ export async function deriveAeKey({
 /**
  * Derives an AES key scoped to an `(owner, mint)` pair.
  *
- * See `deriveElGamalKeypairForOwnerMint` for why this is the right binding
- * for confidential token accounts.
+ * @deprecated The standard derivation binds keys to the main wallet only.
+ * Use `deriveAeKey({ signer })` with the default empty seed instead.
  */
 export async function deriveAeKeyForOwnerMint({
     signer,

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -36,6 +36,18 @@ function decodeConfidentialKeys(keys: ConfidentialKeys): DerivedConfidentialKeys
     return { aeKey, elgamalKeypair: { elgamalPubkey, secretKey } };
 }
 
+function assertSeedPresent(publicSeed: ReadonlyUint8Array, caller: string): void {
+    // TypeScript requires the property, but at runtime `new Uint8Array(null)`
+    // and `new Uint8Array(undefined)` both produce an empty array, silently
+    // deriving the standard wallet-level keys instead of the intended scoped
+    // ones. An explicitly supplied empty array is still accepted.
+    if (publicSeed == null) {
+        throw new Error(
+            `${caller} requires an explicit publicSeed; for the standard wallet-level keys use deriveConfidentialKeys`,
+        );
+    }
+}
+
 function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
     return getTupleEncoder([getAddressEncoder(), getAddressEncoder()]).encode([owner, mint]);
 }
@@ -52,8 +64,13 @@ function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
  * derives for the same wallet. There is no seed to pass, so two standard
  * clients cannot accidentally derive different keys.
  *
- * Signing once also guarantees the two keys belong together, even with
- * non-deterministic signers, and costs a single wallet approval.
+ * Signing once guarantees the two keys belong together within this call, and
+ * costs a single wallet approval. Reproducing the same keys later additionally
+ * requires the signer to produce canonical deterministic Ed25519 signatures
+ * (RFC 8032) over these exact message bytes: a randomized signer returns a
+ * different valid signature on the next call and derives different keys,
+ * leaving balances encrypted under the first pair unrecoverable unless that
+ * key material was preserved.
  *
  * Wallets should expose this signature through a dedicated derivation flow
  * and refuse generic `signMessage` requests starting with
@@ -86,6 +103,7 @@ export async function deriveElGamalKeypairWithSeed({
     publicSeed: ReadonlyUint8Array;
     signer: MessagePartialSigner;
 }): Promise<DerivedElGamalKeypair> {
+    assertSeedPresent(publicSeed, 'deriveElGamalKeypairWithSeed');
     const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
     return decodeConfidentialKeys(ConfidentialKeys.fromSignature(signature)).elgamalKeypair;
@@ -105,6 +123,7 @@ export async function deriveAeKeyWithSeed({
     publicSeed: ReadonlyUint8Array;
     signer: MessagePartialSigner;
 }): Promise<Uint8Array> {
+    assertSeedPresent(publicSeed, 'deriveAeKeyWithSeed');
     const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
     return decodeConfidentialKeys(ConfidentialKeys.fromSignature(signature)).aeKey;

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -41,7 +41,7 @@ function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
 }
 
 /**
- * THE standard confidential-balances key derivation: the signer signs the
+ * The standard confidential-balances key derivation: the signer signs the
  * constant `solana-conf-bal/v1` message exactly once, and both the ElGamal
  * keypair and the AES-128 authenticated-encryption key are derived from that
  * single Ed25519 signature via the WASM ZK SDK.
@@ -71,7 +71,7 @@ export async function deriveConfidentialKeys({
 }
 
 /**
- * NON-STANDARD, seed-scoped derivation of an ElGamal keypair: the signer signs
+ * Non-standard, seed-scoped derivation of an ElGamal keypair: the signer signs
  * `solana-conf-bal/v1 || publicSeed`.
  *
  * Use this only for schemes that genuinely need keys scoped more finely than
@@ -92,7 +92,7 @@ export async function deriveElGamalKeypairWithSeed({
 }
 
 /**
- * NON-STANDARD, seed-scoped derivation of an AES-128 authenticated-encryption
+ * Non-standard, seed-scoped derivation of an AES-128 authenticated-encryption
  * key: the signer signs `solana-conf-bal/v1 || publicSeed`.
  *
  * See `deriveElGamalKeypairWithSeed` for when a seed is appropriate; for the
@@ -114,11 +114,9 @@ export async function deriveAeKeyWithSeed({
  * Derives an ElGamal keypair bound to an `(owner, mint)` pair, with a seed of
  * `concat(ownerBytes, mintBytes)`.
  *
- * @deprecated The standard derivation binds keys to the main wallet only; use
- * `deriveConfidentialKeys({ signer })`. Keep using this helper only to access
- * confidential accounts that were already configured with owner-mint keys
- * (shipped in 0.16.x), and migrate those balances to standard keys before
- * dropping it.
+ * @deprecated Use `deriveConfidentialKeys({ signer })`, the standard
+ * wallet-level derivation. This helper remains only for decrypting and
+ * migrating balances on accounts configured with owner-mint keys.
  */
 export async function deriveElGamalKeypairForOwnerMint({
     signer,
@@ -135,11 +133,9 @@ export async function deriveElGamalKeypairForOwnerMint({
 /**
  * Derives an AES key scoped to an `(owner, mint)` pair.
  *
- * @deprecated The standard derivation binds keys to the main wallet only; use
- * `deriveConfidentialKeys({ signer })`. Keep using this helper only to access
- * confidential accounts that were already configured with owner-mint keys
- * (shipped in 0.16.x), and migrate those balances to standard keys before
- * dropping it.
+ * @deprecated Use `deriveConfidentialKeys({ signer })`, the standard
+ * wallet-level derivation. This helper remains only for decrypting and
+ * migrating balances on accounts configured with owner-mint keys.
  */
 export async function deriveAeKeyForOwnerMint({
     signer,

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -115,8 +115,8 @@ export async function deriveAeKeyWithSeed({
  * `concat(ownerBytes, mintBytes)`.
  *
  * @deprecated Use `deriveConfidentialKeys({ signer })`, the standard
- * wallet-level derivation. This helper remains only for decrypting and
- * migrating balances on accounts configured with owner-mint keys.
+ * wallet-level derivation. Use this helper only to decrypt and migrate
+ * balances on accounts configured with owner-mint keys.
  */
 export async function deriveElGamalKeypairForOwnerMint({
     signer,
@@ -134,8 +134,8 @@ export async function deriveElGamalKeypairForOwnerMint({
  * Derives an AES key scoped to an `(owner, mint)` pair.
  *
  * @deprecated Use `deriveConfidentialKeys({ signer })`, the standard
- * wallet-level derivation. This helper remains only for decrypting and
- * migrating balances on accounts configured with owner-mint keys.
+ * wallet-level derivation. Use this helper only to decrypt and migrate
+ * balances on accounts configured with owner-mint keys.
  */
 export async function deriveAeKeyForOwnerMint({
     signer,

--- a/clients/js/src/confidentialTransferKeys.ts
+++ b/clients/js/src/confidentialTransferKeys.ts
@@ -14,6 +14,11 @@ export type DerivedElGamalKeypair = Readonly<{
     secretKey: Uint8Array;
 }>;
 
+export type DerivedConfidentialKeys = Readonly<{
+    aeKey: Uint8Array;
+    elgamalKeypair: DerivedElGamalKeypair;
+}>;
+
 async function signDerivationMessage(signer: MessagePartialSigner, message: Uint8Array): Promise<Uint8Array> {
     const [signatures] = await signer.signMessages([createSignableMessage(message)]);
     const signature = signatures?.[signer.address];
@@ -23,90 +28,127 @@ async function signDerivationMessage(signer: MessagePartialSigner, message: Uint
     return new Uint8Array(signature);
 }
 
+function decodeConfidentialKeys(keys: ConfidentialKeys): DerivedConfidentialKeys {
+    const elgamal = keys.elgamal();
+    const secretKey = new Uint8Array(elgamal.secret().toBytes());
+    const elgamalPubkey = getAddressDecoder().decode(new Uint8Array(elgamal.pubkey().toBytes()));
+    const aeKey = new Uint8Array(keys.ae().toBytes());
+    return { aeKey, elgamalKeypair: { elgamalPubkey, secretKey } };
+}
+
 function ownerMintSeed(owner: Address, mint: Address): ReadonlyUint8Array {
     return getTupleEncoder([getAddressEncoder(), getAddressEncoder()]).encode([owner, mint]);
 }
 
 /**
- * Derives an ElGamal keypair following the `solana-conf-bal/v1` standard: the
- * signer signs a domain-separated message and the resulting Ed25519 signature
- * is fed into the WASM ZK SDK's `ConfidentialKeys` to derive the keypair.
+ * THE standard confidential-balances key derivation: the signer signs the
+ * constant `solana-conf-bal/v1` message exactly once, and both the ElGamal
+ * keypair and the AES-128 authenticated-encryption key are derived from that
+ * single Ed25519 signature via the WASM ZK SDK.
  *
- * The standard derivation binds confidential-transfer keys to the main wallet
- * only: leave `publicSeed` at its empty default so one wallet maps to one
- * ElGamal keypair across all mints and token accounts. Only pass a custom
- * seed for non-standard, application-specific keying schemes.
+ * The keys are bound to the wallet alone: one key pair covering all of the
+ * wallet's mints and token accounts, byte-identical to what every other
+ * standard client (Rust `solana-zk-sdk`, `@solana/zk-sdk`, the CLI, solana-go)
+ * derives for the same wallet. There is no seed to pass, so two standard
+ * clients cannot accidentally derive different keys.
+ *
+ * Signing once also guarantees the two keys belong together, even with
+ * non-deterministic signers, and costs a single wallet approval.
+ *
+ * Wallets should expose this signature through a dedicated derivation flow
+ * and refuse generic `signMessage` requests starting with
+ * `solana-conf-bal/v1`: the signature is the input key material for the
+ * wallet's confidential-balance decryption keys.
  */
-export async function deriveElGamalKeypair({
+export async function deriveConfidentialKeys({
     signer,
-    publicSeed = new Uint8Array(0),
 }: {
     signer: MessagePartialSigner;
-    publicSeed?: ReadonlyUint8Array;
+}): Promise<DerivedConfidentialKeys> {
+    const message = ConfidentialKeys.signerMessage(new Uint8Array(0));
+    const signature = await signDerivationMessage(signer, message);
+    return decodeConfidentialKeys(ConfidentialKeys.fromSignature(signature));
+}
+
+/**
+ * NON-STANDARD, seed-scoped derivation of an ElGamal keypair: the signer signs
+ * `solana-conf-bal/v1 || publicSeed`.
+ *
+ * Use this only for schemes that genuinely need keys scoped more finely than
+ * the wallet. Keys derived from a non-empty seed will NOT match the standard
+ * keys other clients derive for the same wallet; for the standard wallet-level
+ * keys use `deriveConfidentialKeys`.
+ */
+export async function deriveElGamalKeypairWithSeed({
+    signer,
+    publicSeed,
+}: {
+    publicSeed: ReadonlyUint8Array;
+    signer: MessagePartialSigner;
 }): Promise<DerivedElGamalKeypair> {
     const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
     const signature = await signDerivationMessage(signer, message);
-    const keypair = ConfidentialKeys.fromSignature(signature).elgamal();
-    const secretKey = new Uint8Array(keypair.secret().toBytes());
-    const elgamalPubkey = getAddressDecoder().decode(new Uint8Array(keypair.pubkey().toBytes()));
-    return { elgamalPubkey, secretKey };
+    return decodeConfidentialKeys(ConfidentialKeys.fromSignature(signature)).elgamalKeypair;
+}
+
+/**
+ * NON-STANDARD, seed-scoped derivation of an AES-128 authenticated-encryption
+ * key: the signer signs `solana-conf-bal/v1 || publicSeed`.
+ *
+ * See `deriveElGamalKeypairWithSeed` for when a seed is appropriate; for the
+ * standard wallet-level keys use `deriveConfidentialKeys`.
+ */
+export async function deriveAeKeyWithSeed({
+    signer,
+    publicSeed,
+}: {
+    publicSeed: ReadonlyUint8Array;
+    signer: MessagePartialSigner;
+}): Promise<Uint8Array> {
+    const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
+    const signature = await signDerivationMessage(signer, message);
+    return decodeConfidentialKeys(ConfidentialKeys.fromSignature(signature)).aeKey;
 }
 
 /**
  * Derives an ElGamal keypair bound to an `(owner, mint)` pair, with a seed of
  * `concat(ownerBytes, mintBytes)`.
  *
- * @deprecated The standard derivation binds keys to the main wallet only.
- * Use `deriveElGamalKeypair({ signer })` with the default empty seed instead.
+ * @deprecated The standard derivation binds keys to the main wallet only; use
+ * `deriveConfidentialKeys({ signer })`. Keep using this helper only to access
+ * confidential accounts that were already configured with owner-mint keys
+ * (shipped in 0.16.x), and migrate those balances to standard keys before
+ * dropping it.
  */
 export async function deriveElGamalKeypairForOwnerMint({
     signer,
     owner,
     mint,
 }: {
-    signer: MessagePartialSigner;
-    owner: Address;
     mint: Address;
-}): Promise<DerivedElGamalKeypair> {
-    return await deriveElGamalKeypair({ signer, publicSeed: ownerMintSeed(owner, mint) });
-}
-
-/**
- * Derives an AES-128 authenticated-encryption key following the
- * `solana-conf-bal/v1` standard: the signer signs a domain-separated message
- * and the resulting signature is fed into the WASM ZK SDK's `ConfidentialKeys`.
- *
- * The standard derivation binds the key to the main wallet only: leave
- * `publicSeed` at its empty default so one wallet maps to one AES key across
- * all mints and token accounts.
- */
-export async function deriveAeKey({
-    signer,
-    publicSeed = new Uint8Array(0),
-}: {
+    owner: Address;
     signer: MessagePartialSigner;
-    publicSeed?: ReadonlyUint8Array;
-}): Promise<Uint8Array> {
-    const message = ConfidentialKeys.signerMessage(new Uint8Array(publicSeed));
-    const signature = await signDerivationMessage(signer, message);
-    const aeKey = ConfidentialKeys.fromSignature(signature).ae();
-    return new Uint8Array(aeKey.toBytes());
+}): Promise<DerivedElGamalKeypair> {
+    return await deriveElGamalKeypairWithSeed({ publicSeed: ownerMintSeed(owner, mint), signer });
 }
 
 /**
  * Derives an AES key scoped to an `(owner, mint)` pair.
  *
- * @deprecated The standard derivation binds keys to the main wallet only.
- * Use `deriveAeKey({ signer })` with the default empty seed instead.
+ * @deprecated The standard derivation binds keys to the main wallet only; use
+ * `deriveConfidentialKeys({ signer })`. Keep using this helper only to access
+ * confidential accounts that were already configured with owner-mint keys
+ * (shipped in 0.16.x), and migrate those balances to standard keys before
+ * dropping it.
  */
 export async function deriveAeKeyForOwnerMint({
     signer,
     owner,
     mint,
 }: {
-    signer: MessagePartialSigner;
-    owner: Address;
     mint: Address;
+    owner: Address;
+    signer: MessagePartialSigner;
 }): Promise<Uint8Array> {
-    return await deriveAeKey({ signer, publicSeed: ownerMintSeed(owner, mint) });
+    return await deriveAeKeyWithSeed({ publicSeed: ownerMintSeed(owner, mint), signer });
 }

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -227,11 +227,7 @@ it('derives keys from a generic message signer', async () => {
 
 it('plugs derived ElGamal pubkeys directly into confidential transfer instruction builders', async () => {
     const [authority, mintSigner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
-        signer: authority,
-        owner: authority.address,
-        mint: mintSigner.address,
-    });
+    const derivedElGamal = await deriveElGamalKeypair({ signer: authority });
 
     const instruction = getInitializeConfidentialTransferMintInstruction({
         mint: mintSigner.address,

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -144,6 +144,18 @@ it('derives different keys for non-empty seeds', async () => {
     expect(standard.aeKey).not.toEqual(aeSeeded);
 });
 
+it('rejects a missing publicSeed at runtime instead of deriving standard keys', async () => {
+    const signer = await generateKeyPairSigner();
+    const missingSeed = undefined as unknown as Uint8Array;
+
+    await expect(deriveElGamalKeypairWithSeed({ publicSeed: missingSeed, signer })).rejects.toThrow(
+        /requires an explicit publicSeed/,
+    );
+    await expect(deriveAeKeyWithSeed({ publicSeed: missingSeed, signer })).rejects.toThrow(
+        /requires an explicit publicSeed/,
+    );
+});
+
 it('derives different keys for different signers', async () => {
     const [signerA, signerB] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 

--- a/clients/js/test/confidentialTransferKeys.test.ts
+++ b/clients/js/test/confidentialTransferKeys.test.ts
@@ -13,15 +13,32 @@ import {
     parseInitializeConfidentialTransferMintInstruction,
 } from '../src';
 import {
-    deriveAeKey,
     deriveAeKeyForOwnerMint,
-    deriveElGamalKeypair,
+    deriveAeKeyWithSeed,
+    deriveConfidentialKeys,
     deriveElGamalKeypairForOwnerMint,
+    deriveElGamalKeypairWithSeed,
 } from '../src/confidential';
 
 const ADDRESS_DECODER = getAddressDecoder();
 const ADDRESS_ENCODER = getAddressEncoder();
 
+// Canonical cross-SDK vector for the standard (wallet-level, no seed) path.
+// The same inputs and outputs are pinned in the solana-zk-sdk Rust tests and
+// the solana-go fixtures (kdf_vectors.json, keypair_a_empty_seed).
+const STANDARD_VECTOR_PRIVATE_KEY = new Uint8Array([
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33,
+    0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+]);
+const STANDARD_VECTOR_ELGAMAL_SECRET_KEY = new Uint8Array([
+    0xbe, 0x5c, 0xce, 0x95, 0x1f, 0x42, 0xa2, 0xa8, 0x67, 0x7d, 0x1a, 0x56, 0xf0, 0x3a, 0xae, 0x7b, 0xff, 0x79, 0x5b,
+    0x38, 0xcf, 0x1c, 0x56, 0xc8, 0xcf, 0x3a, 0x4d, 0xae, 0x7d, 0x60, 0xe2, 0x05,
+]);
+const STANDARD_VECTOR_AE_KEY = new Uint8Array([
+    0x64, 0x17, 0xee, 0xdb, 0xcb, 0xe9, 0xc6, 0x4a, 0x72, 0x39, 0x57, 0x19, 0xec, 0x98, 0xcf, 0x6b,
+]);
+
+// Vector for the non-standard seeded path.
 const RUST_VECTOR_PRIVATE_KEY = new Uint8Array([
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32,
@@ -40,83 +57,120 @@ const RUST_VECTOR_ELGAMAL_PUBKEY = new Uint8Array([
 ]);
 const RUST_VECTOR_AE_KEY = new Uint8Array([160, 210, 197, 15, 158, 3, 217, 111, 220, 216, 102, 104, 164, 25, 214, 183]);
 
-it('derives a 32-byte ElGamal secret key and a public key Address', async () => {
+it('derives a 32-byte ElGamal secret key, a public key Address and a 16-byte AES key', async () => {
     const signer = await generateKeyPairSigner();
 
-    const { elgamalPubkey, secretKey } = await deriveElGamalKeypair({ signer });
+    const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({ signer });
 
-    expect(elgamalPubkey).toBeTruthy();
-    expect(secretKey.length).toBe(32);
-    expect(ADDRESS_ENCODER.encode(elgamalPubkey).length).toBe(32);
-});
-
-it('derives a 16-byte AES key', async () => {
-    const signer = await generateKeyPairSigner();
-
-    const aeKey = await deriveAeKey({ signer });
-
+    expect(elgamalKeypair.elgamalPubkey).toBeTruthy();
+    expect(elgamalKeypair.secretKey.length).toBe(32);
+    expect(ADDRESS_ENCODER.encode(elgamalKeypair.elgamalPubkey).length).toBe(32);
     expect(aeKey.length).toBe(16);
 });
 
-it('derives deterministic ElGamal keys from the same signer and seed', async () => {
+it('derives deterministic keys from the same signer', async () => {
+    const signer = await generateKeyPairSigner();
+
+    const first = await deriveConfidentialKeys({ signer });
+    const second = await deriveConfidentialKeys({ signer });
+
+    expect(first.elgamalKeypair.secretKey).toEqual(second.elgamalKeypair.secretKey);
+    expect(first.elgamalKeypair.elgamalPubkey).toBe(second.elgamalKeypair.elgamalPubkey);
+    expect(first.aeKey).toEqual(second.aeKey);
+});
+
+it('signs exactly once for both keys', async () => {
+    const signer = await generateKeyPairSigner();
+    let signCalls = 0;
+    const countingSigner: MessagePartialSigner = {
+        address: signer.address,
+        signMessages: messages => {
+            signCalls += messages.length;
+            return signer.signMessages(messages);
+        },
+    };
+
+    await deriveConfidentialKeys({ signer: countingSigner });
+
+    expect(signCalls).toBe(1);
+});
+
+it('derives deterministic seeded ElGamal keys from the same signer and seed', async () => {
     const signer = await generateKeyPairSigner();
     const publicSeed = new Uint8Array([1, 2, 3, 4]);
 
-    const first = await deriveElGamalKeypair({ signer, publicSeed });
-    const second = await deriveElGamalKeypair({ signer, publicSeed });
+    const first = await deriveElGamalKeypairWithSeed({ publicSeed, signer });
+    const second = await deriveElGamalKeypairWithSeed({ publicSeed, signer });
 
     expect(first.secretKey).toEqual(second.secretKey);
     expect(first.elgamalPubkey).toBe(second.elgamalPubkey);
 });
 
-it('derives deterministic AES keys from the same signer and seed', async () => {
+it('derives deterministic seeded AES keys from the same signer and seed', async () => {
     const signer = await generateKeyPairSigner();
     const publicSeed = new Uint8Array([5, 6, 7, 8]);
 
-    const first = await deriveAeKey({ signer, publicSeed });
-    const second = await deriveAeKey({ signer, publicSeed });
+    const first = await deriveAeKeyWithSeed({ publicSeed, signer });
+    const second = await deriveAeKeyWithSeed({ publicSeed, signer });
 
     expect(first).toEqual(second);
 });
 
-it('derives different ElGamal keys for different seeds', async () => {
+it('matches the standard path when the seed is empty', async () => {
     const signer = await generateKeyPairSigner();
 
-    const noSeed = await deriveElGamalKeypair({ signer });
-    const withSeed = await deriveElGamalKeypair({ signer, publicSeed: new Uint8Array([1]) });
+    const standard = await deriveConfidentialKeys({ signer });
+    const [elgamalEmptySeed, aeEmptySeed] = await Promise.all([
+        deriveElGamalKeypairWithSeed({ publicSeed: new Uint8Array(0), signer }),
+        deriveAeKeyWithSeed({ publicSeed: new Uint8Array(0), signer }),
+    ]);
 
-    expect(noSeed.secretKey).not.toEqual(withSeed.secretKey);
-    expect(noSeed.elgamalPubkey).not.toBe(withSeed.elgamalPubkey);
+    expect(standard.elgamalKeypair.secretKey).toEqual(elgamalEmptySeed.secretKey);
+    expect(standard.elgamalKeypair.elgamalPubkey).toBe(elgamalEmptySeed.elgamalPubkey);
+    expect(standard.aeKey).toEqual(aeEmptySeed);
 });
 
-it('derives different AES keys for different seeds', async () => {
+it('derives different keys for non-empty seeds', async () => {
     const signer = await generateKeyPairSigner();
 
-    const noSeed = await deriveAeKey({ signer });
-    const withSeed = await deriveAeKey({ signer, publicSeed: new Uint8Array([1]) });
+    const standard = await deriveConfidentialKeys({ signer });
+    const [elgamalSeeded, aeSeeded] = await Promise.all([
+        deriveElGamalKeypairWithSeed({ publicSeed: new Uint8Array([1]), signer }),
+        deriveAeKeyWithSeed({ publicSeed: new Uint8Array([1]), signer }),
+    ]);
 
-    expect(noSeed).not.toEqual(withSeed);
+    expect(standard.elgamalKeypair.secretKey).not.toEqual(elgamalSeeded.secretKey);
+    expect(standard.elgamalKeypair.elgamalPubkey).not.toBe(elgamalSeeded.elgamalPubkey);
+    expect(standard.aeKey).not.toEqual(aeSeeded);
 });
 
 it('derives different keys for different signers', async () => {
     const [signerA, signerB] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
 
-    const [elgamalA, elgamalB] = await Promise.all([
-        deriveElGamalKeypair({ signer: signerA }),
-        deriveElGamalKeypair({ signer: signerB }),
+    const [keysA, keysB] = await Promise.all([
+        deriveConfidentialKeys({ signer: signerA }),
+        deriveConfidentialKeys({ signer: signerB }),
     ]);
-    const [aeA, aeB] = await Promise.all([deriveAeKey({ signer: signerA }), deriveAeKey({ signer: signerB })]);
 
-    expect(elgamalA.secretKey).not.toEqual(elgamalB.secretKey);
-    expect(aeA).not.toEqual(aeB);
+    expect(keysA.elgamalKeypair.secretKey).not.toEqual(keysB.elgamalKeypair.secretKey);
+    expect(keysA.aeKey).not.toEqual(keysB.aeKey);
 });
 
-it('matches the solana-conf-bal/v1 derivation vector', async () => {
+it('matches the standard cross-SDK derivation vector', async () => {
+    const signer = await createKeyPairSignerFromPrivateKeyBytes(STANDARD_VECTOR_PRIVATE_KEY);
+
+    const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({ signer });
+
+    expect(elgamalKeypair.secretKey).toEqual(STANDARD_VECTOR_ELGAMAL_SECRET_KEY);
+    expect(aeKey).toEqual(STANDARD_VECTOR_AE_KEY);
+});
+
+it('matches the solana-conf-bal/v1 seeded derivation vector', async () => {
     const signer = await createKeyPairSignerFromPrivateKeyBytes(RUST_VECTOR_PRIVATE_KEY);
 
     const [derivedElGamal, derivedAeKey] = await Promise.all([
-        deriveElGamalKeypair({ signer, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
-        deriveAeKey({ signer, publicSeed: RUST_VECTOR_PUBLIC_SEED }),
+        deriveElGamalKeypairWithSeed({ publicSeed: RUST_VECTOR_PUBLIC_SEED, signer }),
+        deriveAeKeyWithSeed({ publicSeed: RUST_VECTOR_PUBLIC_SEED, signer }),
     ]);
 
     expect(derivedElGamal.secretKey).toEqual(RUST_VECTOR_ELGAMAL_SECRET_KEY);
@@ -138,8 +192,8 @@ test('deriveElGamalKeypairForOwnerMint composes the seed as concat(owner, mint)'
     expectedSeed.set(ADDRESS_ENCODER.encode(mint), 32);
 
     const [convenience, manual] = await Promise.all([
-        deriveElGamalKeypairForOwnerMint({ signer, owner, mint }),
-        deriveElGamalKeypair({ signer, publicSeed: expectedSeed }),
+        deriveElGamalKeypairForOwnerMint({ mint, owner, signer }),
+        deriveElGamalKeypairWithSeed({ publicSeed: expectedSeed, signer }),
     ]);
 
     expect(convenience.secretKey).toEqual(manual.secretKey);
@@ -160,8 +214,8 @@ test('deriveAeKeyForOwnerMint composes the seed as concat(owner, mint)', async (
     expectedSeed.set(ADDRESS_ENCODER.encode(mint), 32);
 
     const [convenience, manual] = await Promise.all([
-        deriveAeKeyForOwnerMint({ signer, owner, mint }),
-        deriveAeKey({ signer, publicSeed: expectedSeed }),
+        deriveAeKeyForOwnerMint({ mint, owner, signer }),
+        deriveAeKeyWithSeed({ publicSeed: expectedSeed, signer }),
     ]);
 
     expect(convenience).toEqual(manual);
@@ -176,8 +230,8 @@ test('deriveElGamalKeypairForOwnerMint binds keys to (owner, mint), not just own
     const owner = signer.address;
 
     const [keysForMintA, keysForMintB] = await Promise.all([
-        deriveElGamalKeypairForOwnerMint({ signer, owner, mint: mintA.address }),
-        deriveElGamalKeypairForOwnerMint({ signer, owner, mint: mintB.address }),
+        deriveElGamalKeypairForOwnerMint({ mint: mintA.address, owner, signer }),
+        deriveElGamalKeypairForOwnerMint({ mint: mintB.address, owner, signer }),
     ]);
 
     // Different mints with the same owner must yield different keys.
@@ -194,8 +248,8 @@ test('deriveElGamalKeypairForOwnerMint binds keys to (owner, mint), not just min
     const mint = mintSigner.address;
 
     const [keysForOwnerA, keysForOwnerB] = await Promise.all([
-        deriveElGamalKeypairForOwnerMint({ signer: signerA, owner: signerA.address, mint }),
-        deriveElGamalKeypairForOwnerMint({ signer: signerB, owner: signerB.address, mint }),
+        deriveElGamalKeypairForOwnerMint({ mint, owner: signerA.address, signer: signerA }),
+        deriveElGamalKeypairForOwnerMint({ mint, owner: signerB.address, signer: signerB }),
     ]);
 
     // Different owners with the same mint must yield different keys.
@@ -209,51 +263,39 @@ it('derives keys from a generic message signer', async () => {
         address: signer.address,
         signMessages: signer.signMessages,
     };
-    const publicSeed = new Uint8Array([9, 8, 7, 6]);
 
-    const [derivedElGamal, expectedElGamal] = await Promise.all([
-        deriveElGamalKeypair({ signer: genericSigner, publicSeed }),
-        deriveElGamalKeypair({ signer, publicSeed }),
-    ]);
-    const [derivedAeKey, expectedAeKey] = await Promise.all([
-        deriveAeKey({ signer: genericSigner, publicSeed }),
-        deriveAeKey({ signer, publicSeed }),
+    const [derived, expected] = await Promise.all([
+        deriveConfidentialKeys({ signer: genericSigner }),
+        deriveConfidentialKeys({ signer }),
     ]);
 
-    expect(derivedElGamal.secretKey).toEqual(expectedElGamal.secretKey);
-    expect(derivedElGamal.elgamalPubkey).toBe(expectedElGamal.elgamalPubkey);
-    expect(derivedAeKey).toEqual(expectedAeKey);
+    expect(derived.elgamalKeypair.secretKey).toEqual(expected.elgamalKeypair.secretKey);
+    expect(derived.elgamalKeypair.elgamalPubkey).toBe(expected.elgamalKeypair.elgamalPubkey);
+    expect(derived.aeKey).toEqual(expected.aeKey);
 });
 
 it('plugs derived ElGamal pubkeys directly into confidential transfer instruction builders', async () => {
     const [authority, mintSigner] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
-    const derivedElGamal = await deriveElGamalKeypair({ signer: authority });
+    const { elgamalKeypair } = await deriveConfidentialKeys({ signer: authority });
 
     const instruction = getInitializeConfidentialTransferMintInstruction({
         mint: mintSigner.address,
         authority: some(authority.address),
         autoApproveNewAccounts: true,
-        auditorElgamalPubkey: some(derivedElGamal.elgamalPubkey),
+        auditorElgamalPubkey: some(elgamalKeypair.elgamalPubkey),
     });
     const parsed = parseInitializeConfidentialTransferMintInstruction(instruction);
 
     expect(parsed.data.authority).toEqual(some(authority.address));
     expect(parsed.data.autoApproveNewAccounts).toBe(true);
-    expect(parsed.data.auditorElgamalPubkey).toEqual(some(derivedElGamal.elgamalPubkey));
+    expect(parsed.data.auditorElgamalPubkey).toEqual(some(elgamalKeypair.elgamalPubkey));
 });
 
-it('produces a non-zero ElGamal secret key', async () => {
+it('produces non-zero keys', async () => {
     const signer = await generateKeyPairSigner();
 
-    const { secretKey } = await deriveElGamalKeypair({ signer });
+    const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({ signer });
 
-    expect(secretKey.every(b => b === 0)).toBe(false);
-});
-
-it('produces a non-zero AES key', async () => {
-    const signer = await generateKeyPairSigner();
-
-    const aeKey = await deriveAeKey({ signer });
-
+    expect(elgamalKeypair.secretKey.every(b => b === 0)).toBe(false);
     expect(aeKey.every(b => b === 0)).toBe(false);
 });

--- a/clients/rust-legacy/tests/confidential_mint_burn.rs
+++ b/clients/rust-legacy/tests/confidential_mint_burn.rs
@@ -62,8 +62,7 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
 
         let token_account = token_account_keypair.pubkey();
-        let (elgamal_keypair, aes_key) =
-            derive_confidential_keys(owner, &token_account.to_bytes()).unwrap();
+        let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"").unwrap();
 
         token
             .confidential_transfer_configure_token_account(

--- a/clients/rust-legacy/tests/confidential_transfer.rs
+++ b/clients/rust-legacy/tests/confidential_transfer.rs
@@ -158,8 +158,7 @@ async fn confidential_transfer_configure_token_account_with_option(
         )
         .await
         .unwrap();
-    let (elgamal_keypair, aes_key) =
-        derive_confidential_keys(&alice, &alice_account_keypair.pubkey().to_bytes()).unwrap();
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&alice, b"").unwrap();
 
     let alice_meta = ConfidentialTokenAccountMeta {
         token_account: alice_account_keypair.pubkey(),
@@ -2665,8 +2664,7 @@ async fn confidential_transfer_configure_token_account_with_registry() {
     ctx.banks_client.process_transaction(tx).await.unwrap();
 
     // update ElGamal registry
-    let (new_elgamal_keypair, _) =
-        derive_confidential_keys(&alice, &alice_account_keypair.pubkey().to_bytes()).unwrap();
+    let (new_elgamal_keypair, _) = derive_confidential_keys(&alice, b"").unwrap();
     let proof_data = build_pubkey_validity_proof_data(&new_elgamal_keypair).unwrap();
     let proof_location = ProofLocation::InstructionOffset(1.try_into().unwrap(), &proof_data);
 

--- a/clients/rust-legacy/tests/confidential_transfer_fee.rs
+++ b/clients/rust-legacy/tests/confidential_transfer_fee.rs
@@ -79,8 +79,7 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
         let token_account = token_account_keypair.pubkey();
 
-        let (elgamal_keypair, aes_key) =
-            derive_confidential_keys(owner, &token_account.to_bytes()).unwrap();
+        let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"").unwrap();
 
         token
             .confidential_transfer_configure_token_account(
@@ -1238,9 +1237,7 @@ async fn test_withdraw_withheld_tokens_with_max_pending_counter() {
         .await
         .unwrap();
 
-    let (fc_elgamal, fc_aes) =
-        derive_confidential_keys(&fee_collector, &fee_collector_account.pubkey().to_bytes())
-            .unwrap();
+    let (fc_elgamal, fc_aes) = derive_confidential_keys(&fee_collector, b"").unwrap();
 
     // Configure with max_pending_balance_credit_counter = 1
     token

--- a/clients/rust-legacy/tests/program_test.rs
+++ b/clients/rust-legacy/tests/program_test.rs
@@ -219,8 +219,7 @@ impl ConfidentialTokenAccountMeta {
             .unwrap();
         let token_account = token_account_keypair.pubkey();
 
-        let (elgamal_keypair, aes_key) =
-            derive_confidential_keys(owner, &token_account.to_bytes()).unwrap();
+        let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"").unwrap();
 
         token
             .confidential_transfer_configure_token_account(


### PR DESCRIPTION
## Summary

Standardizes confidential-transfer key derivation on the main wallet and enforces it in the API instead of leaving it as a convention callers must remember.

- New standard entry point deriveConfidentialKeys({ signer }): one signature over the constant solana-conf-bal/v1 message, both the ElGamal keypair and the AE key derived from that single signature. No seed parameter, so two standard clients can't accidentally derive different keys; sign-once also guarantees the two keys belong together (even with non-deterministic signers) and costs one wallet approval instead of two.
- Breaking rename (fine in 0.x): deriveElGamalKeypair / deriveAeKey drop the optional-empty-seed shape and become deriveElGamalKeypairWithSeed / deriveAeKeyWithSeed with a required publicSeed, reserved for non-standard scoped schemes. The ForOwnerMint helpers stay deprecated rather than removed: anyone who configured accounts with owner-mint keys on 0.16.x still needs them to decrypt and migrate those balances.
- Tests pin the standard path to the cross-SDK empty-seed vector shared with the Rust solana-zk-sdk tests and solana-go's kdf_vectors.json, so derivation drift in any implementation fails that repo's CI. The seeded path keeps its existing Rust vector.
- rust-legacy tests seed from the wallet (b"") instead of the token account, matching what the CLI already derives. They keep the released zk-sdk 7.0.1 seeded call for now; a follow-up bumps them to the no-seed derive_confidential_keys(signer) once solana-program/zk-elgamal-proof#533 ships in a zk-sdk release.

Companion PRs: solana-program/zk-elgamal-proof#533, solana-foundation/solana-go#495, solana-foundation/solana-com#2045.

Closes ECO-504