### PR TITLE
fix(js): encode Uninitialized extension with its TLV length prefix

### DIFF
--- a/clients/js/src/generated/types/extension.ts
+++ b/clients/js/src/generated/types/extension.ts
@@ -32,8 +32,6 @@ import {
     getU32Encoder,
     getU64Decoder,
     getU64Encoder,
-    getUnitDecoder,
-    getUnitEncoder,
     getUtf8Decoder,
     getUtf8Encoder,
     type Address,
@@ -523,7 +521,7 @@ export type ExtensionArgs =
 export function getExtensionEncoder(): Encoder<ExtensionArgs> {
     return getDiscriminatedUnionEncoder(
         [
-            ['Uninitialized', getUnitEncoder()],
+            ['Uninitialized', addEncoderSizePrefix(getStructEncoder([]), getU16Encoder())],
             [
                 'TransferFeeConfig',
                 addEncoderSizePrefix(
@@ -778,7 +776,7 @@ export function getExtensionEncoder(): Encoder<ExtensionArgs> {
 export function getExtensionDecoder(): Decoder<Extension> {
     return getDiscriminatedUnionDecoder(
         [
-            ['Uninitialized', getUnitDecoder()],
+            ['Uninitialized', addDecoderSizePrefix(getStructDecoder([]), getU16Decoder())],
             [
                 'TransferFeeConfig',
                 addDecoderSizePrefix(
@@ -1037,6 +1035,7 @@ export function getExtensionCodec(): Codec<ExtensionArgs, Extension> {
 // Data Enum Helpers.
 export function extension(
     kind: 'Uninitialized',
+    data: GetDiscriminatedUnionVariantContent<ExtensionArgs, '__kind', 'Uninitialized'>,
 ): GetDiscriminatedUnionVariant<ExtensionArgs, '__kind', 'Uninitialized'>;
 export function extension(
     kind: 'TransferFeeConfig',

--- a/clients/js/test/accounts/mint.test.ts
+++ b/clients/js/test/accounts/mint.test.ts
@@ -1,7 +1,7 @@
-import { getBase64Encoder, none, some } from '@solana/kit';
+import { address, getBase64Encoder, none, some } from '@solana/kit';
 import { expect, it } from 'vitest';
 
-import { AccountState, Mint, getMintDecoder } from '../../src';
+import { AccountState, Mint, getMintDecoder, getMintEncoder } from '../../src';
 
 it('decodes a mint account with extensions', () => {
     // Given an encoded mega mint account.
@@ -105,4 +105,35 @@ it('decodes a mint account with extensions', () => {
             },
         ]),
     });
+});
+
+// Mint accounts can legally be allocated with more space than their extensions
+// require. The unused tail is filled with `Uninitialized` TLV entries, each of
+// which is `type(2) + length(2) = 4` bytes on chain. The decoder must consume
+// that tail via its `remainder` extension array, so any number of free bytes
+// that is a multiple of 4 must decode cleanly rather than throwing.
+it.each([
+    [0, 0],
+    [4, 1],
+    [8, 2],
+    [12, 3],
+])('decodes a mint account with %i bytes of unused extension space', (freeBytes, paddingEntries) => {
+    // Given a base mint account followed by an unused extension region.
+    const base = getMintEncoder().encode({
+        mintAuthority: some(address('FdrdFuo1RQ9LrQ3FRfQUE7RigyANe5kFNLyMhCYk1xgJ')),
+        supply: 0n,
+        decimals: 9,
+        isInitialized: true,
+        freezeAuthority: none(),
+        extensions: some([]),
+    });
+    const data = new Uint8Array(base.length + freeBytes);
+    data.set(base, 0);
+
+    // When we decode it, then it does not throw and the unused region is read as
+    // `Uninitialized` padding entries, one per 4-byte TLV header.
+    const decodedData = getMintDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(
+        some(Array.from({ length: paddingEntries }, () => ({ __kind: 'Uninitialized' }))),
+    );
 });

--- a/clients/js/test/accounts/token.test.ts
+++ b/clients/js/test/accounts/token.test.ts
@@ -1,7 +1,7 @@
-import { getBase16Encoder, getBase64Encoder, none, some } from '@solana/kit';
+import { address, getBase16Encoder, getBase64Encoder, none, some } from '@solana/kit';
 import { expect, it } from 'vitest';
 
-import { AccountState, Token, getTokenDecoder } from '../../src';
+import { AccountState, Token, getTokenDecoder, getTokenEncoder } from '../../src';
 
 it('decodes a token account with extensions', () => {
     // Given an encoded mega token account.
@@ -52,4 +52,39 @@ it('decodes a token account with extensions', () => {
             },
         ]),
     });
+});
+
+// Token accounts can legally be allocated with more space than their extensions
+// require (e.g. `InitializeAccount3` only checks `required <= actual`). The
+// unused tail is filled with `Uninitialized` TLV entries, each of which is
+// `type(2) + length(2) = 4` bytes on chain. The decoder must consume that tail
+// via its `remainder` extension array, so any number of free bytes that is a
+// multiple of 4 must decode cleanly rather than throwing.
+it.each([
+    [0, 0],
+    [4, 1],
+    [8, 2],
+    [12, 3],
+])('decodes a token account with %i bytes of unused extension space', (freeBytes, paddingEntries) => {
+    // Given a base token account followed by an unused extension region.
+    const base = getTokenEncoder().encode({
+        mint: address('5gSwsLGzyCwgwPJSnxjsQCaFeE19ZFaibHMLky9TDFim'),
+        owner: address('FdrdFuo1RQ9LrQ3FRfQUE7RigyANe5kFNLyMhCYk1xgJ'),
+        amount: 0n,
+        delegate: none(),
+        state: AccountState.Initialized,
+        isNative: none(),
+        delegatedAmount: 0n,
+        closeAuthority: none(),
+        extensions: some([]),
+    });
+    const data = new Uint8Array(base.length + freeBytes);
+    data.set(base, 0);
+
+    // When we decode it, then it does not throw and the unused region is read as
+    // `Uninitialized` padding entries, one per 4-byte TLV header.
+    const decodedData = getTokenDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(
+        some(Array.from({ length: paddingEntries }, () => ({ __kind: 'Uninitialized' }))),
+    );
 });

--- a/idl.json
+++ b/idl.json
@@ -12456,8 +12456,20 @@
                     "kind": "enumTypeNode",
                     "variants": [
                         {
-                            "kind": "enumEmptyVariantTypeNode",
-                            "name": "uninitialized"
+                            "kind": "enumStructVariantTypeNode",
+                            "name": "uninitialized",
+                            "struct": {
+                                "kind": "sizePrefixTypeNode",
+                                "type": {
+                                    "kind": "structTypeNode",
+                                    "fields": []
+                                },
+                                "prefix": {
+                                    "kind": "numberTypeNode",
+                                    "format": "u16",
+                                    "endian": "le"
+                                }
+                            }
                         },
                         {
                             "kind": "enumStructVariantTypeNode",


### PR DESCRIPTION
This PR fixes the `Uninitialized` extension codec so it carries its on-chain TLV length field.

The generated `Extension` codec encoded `Uninitialized` without the u16 length prefix that every other variant carries, so it round-tripped as 2 bytes where the on-chain format is 4 (`type(2) + length(2)`). Because `Token` and `Mint` decode their extensions as a `remainder` array, the decoder must consume the free space after an account's last extension, walking it as `Uninitialized` entries. At 2 bytes per entry, an odd number of free bytes left one byte over and `decodeToken`/`decodeMint` threw. Any account allocated with spare extension room (a legal and common shape) therefore failed to decode about half the time, even though the program and `@solana/spl-token` read it fine.

The fix updates the `uninitialized` variant in `idl.json` to wrap an empty struct in a u16 `sizePrefixTypeNode`, matching its siblings (`immutableOwner`, `nonTransferable`, `pausableAccount`), and regenerates the JS client. `Uninitialized` now encodes and decodes as 4 bytes, so the decoder advances correctly through unused space. Regression tests cover decoding `Token` and `Mint` accounts with 0/4/8/12 bytes of unused extension space.

Fixes #1448.