### PR TITLE
Rename the token-2022 program node to its canonical camelCase name

### DIFF
--- a/clients/js/src/generated/programs/token2022.ts
+++ b/clients/js/src/generated/programs/token2022.ts
@@ -470,7 +470,7 @@ export function identifyToken2022Account(account: { data: ReadonlyUint8Array } |
     }
     throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT, {
         accountData: data,
-        programName: 'token-2022',
+        programName: 'token2022',
     });
 }
 
@@ -937,7 +937,7 @@ export function identifyToken2022Instruction(
     }
     throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_INSTRUCTION, {
         instructionData: data,
-        programName: 'token-2022',
+        programName: 'token2022',
     });
 }
 
@@ -1814,7 +1814,7 @@ export function parseToken2022Instruction<TProgram extends string>(
         default:
             throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_INSTRUCTION_TYPE, {
                 instructionType: instructionType as string,
-                programName: 'token-2022',
+                programName: 'token2022',
             });
     }
 }

--- a/codama.mjs
+++ b/codama.mjs
@@ -8,6 +8,15 @@ export default {
                 'clients/js',
                 {
                     kitImportStrategy: 'rootOnly',
+                    // The program was historically named `token-2022` in the IDL, which gave the
+                    // generated `TOKEN_2022_*` identifiers. Codama normalises names to camelCase
+                    // (`token2022`), so the public identifiers are pinned here to keep the API stable.
+                    nameTransformers: {
+                        programAddressConstant: (name, { snakeCase }) =>
+                            `${snakeCase(name === 'token2022' ? 'token_2022' : name).toUpperCase()}_PROGRAM_ADDRESS`,
+                        programErrorConstantPrefix: (name, { snakeCase }) =>
+                            `${snakeCase(name === 'token2022' ? 'token_2022' : name).toUpperCase()}_ERROR__`,
+                    },
                     syncPackageJson: true,
                     prettierOptions: {
                         arrowParens: 'avoid',

--- a/idl.json
+++ b/idl.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "program": {
         "kind": "programNode",
-        "name": "token-2022",
+        "name": "token2022",
         "publicKey": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
         "version": "3.0.1",
         "docs": [],


### PR DESCRIPTION
This PR renames the program node in `idl.json` from `token-2022` to `token2022`, the camelCase form every Codama node constructor normalises to.

Codama expects node names to be camelCase and enforces it in its constructors: `programNode()` and `programLinkNode()` both apply `camelCase` to the name they are given. A program named `token-2022` therefore silently changes to `token2022` as soon as any transformer visitor rebuilds the tree, which renames every `TOKEN_2022_*` identifier in the generated client, and a `programLinkNode` targeting it can never resolve because the link is normalised while the program is not. Neither has bitten yet because the IDL has no program links and `before` has been empty, but it blocks the use of standard Codama visitors in this repo.

To keep the public API stable, the JS renderer's `nameTransformers` pin `TOKEN_2022_PROGRAM_ADDRESS` and the `TOKEN_2022_ERROR__*` prefix for this program while leaving the default derivation in place for `associatedToken`. The only generated change is the `programName` string carried by three `SolanaError`s, which now reads `token2022`, consistent with `associatedToken`.