### PR TITLE
Decode token and mint extensions the way the program reads them

### DIFF
--- a/clients/js/src/generated/accounts/mint.ts
+++ b/clients/js/src/generated/accounts/mint.ts
@@ -15,8 +15,6 @@ import {
     fetchEncodedAccounts,
     getAddressDecoder,
     getAddressEncoder,
-    getArrayDecoder,
-    getArrayEncoder,
     getBooleanDecoder,
     getBooleanEncoder,
     getConstantDecoder,
@@ -47,7 +45,7 @@ import {
     type Option,
     type OptionOrNullable,
 } from '@solana/kit';
-import { getExtensionDecoder, getExtensionEncoder, type Extension, type ExtensionArgs } from '../types';
+import { getExtensionsDecoder, getExtensionsEncoder, type Extensions, type ExtensionsArgs } from '../../hooked';
 
 export type Mint = {
     /**
@@ -65,7 +63,7 @@ export type Mint = {
     /** Optional authority to freeze token accounts. */
     freezeAuthority: Option<Address>;
     /** The extensions activated on the mint account. */
-    extensions: Option<Array<Extension>>;
+    extensions: Option<Extensions>;
 };
 
 export type MintArgs = {
@@ -84,7 +82,7 @@ export type MintArgs = {
     /** Optional authority to freeze token accounts. */
     freezeAuthority: OptionOrNullable<Address>;
     /** The extensions activated on the mint account. */
-    extensions: OptionOrNullable<Array<ExtensionArgs>>;
+    extensions: OptionOrNullable<ExtensionsArgs>;
 };
 
 /** Gets the encoder for {@link MintArgs} account data. */
@@ -98,7 +96,7 @@ export function getMintEncoder(): Encoder<MintArgs> {
         [
             'extensions',
             getOptionEncoder(
-                getHiddenPrefixEncoder(getArrayEncoder(getExtensionEncoder(), { size: 'remainder' }), [
+                getHiddenPrefixEncoder(getExtensionsEncoder(), [
                     getConstantEncoder(padLeftEncoder(getU8Encoder(), 83).encode(1)),
                 ]),
                 { prefix: null },
@@ -118,7 +116,7 @@ export function getMintDecoder(): Decoder<Mint> {
         [
             'extensions',
             getOptionDecoder(
-                getHiddenPrefixDecoder(getArrayDecoder(getExtensionDecoder(), { size: 'remainder' }), [
+                getHiddenPrefixDecoder(getExtensionsDecoder(), [
                     getConstantDecoder(padLeftEncoder(getU8Encoder(), 83).encode(1)),
                 ]),
                 { prefix: null },

--- a/clients/js/src/generated/accounts/token.ts
+++ b/clients/js/src/generated/accounts/token.ts
@@ -15,8 +15,6 @@ import {
     fetchEncodedAccounts,
     getAddressDecoder,
     getAddressEncoder,
-    getArrayDecoder,
-    getArrayEncoder,
     getConstantDecoder,
     getConstantEncoder,
     getHiddenPrefixDecoder,
@@ -43,16 +41,8 @@ import {
     type Option,
     type OptionOrNullable,
 } from '@solana/kit';
-import {
-    getAccountStateDecoder,
-    getAccountStateEncoder,
-    getExtensionDecoder,
-    getExtensionEncoder,
-    type AccountState,
-    type AccountStateArgs,
-    type Extension,
-    type ExtensionArgs,
-} from '../types';
+import { getExtensionsDecoder, getExtensionsEncoder, type Extensions, type ExtensionsArgs } from '../../hooked';
+import { getAccountStateDecoder, getAccountStateEncoder, type AccountState, type AccountStateArgs } from '../types';
 
 export type Token = {
     /** The mint associated with this account. */
@@ -80,7 +70,7 @@ export type Token = {
     /** Optional authority to close the account. */
     closeAuthority: Option<Address>;
     /** The extensions activated on the token account. */
-    extensions: Option<Array<Extension>>;
+    extensions: Option<Extensions>;
 };
 
 export type TokenArgs = {
@@ -109,7 +99,7 @@ export type TokenArgs = {
     /** Optional authority to close the account. */
     closeAuthority: OptionOrNullable<Address>;
     /** The extensions activated on the token account. */
-    extensions: OptionOrNullable<Array<ExtensionArgs>>;
+    extensions: OptionOrNullable<ExtensionsArgs>;
 };
 
 /** Gets the encoder for {@link TokenArgs} account data. */
@@ -126,9 +116,7 @@ export function getTokenEncoder(): Encoder<TokenArgs> {
         [
             'extensions',
             getOptionEncoder(
-                getHiddenPrefixEncoder(getArrayEncoder(getExtensionEncoder(), { size: 'remainder' }), [
-                    getConstantEncoder(getU8Encoder().encode(2)),
-                ]),
+                getHiddenPrefixEncoder(getExtensionsEncoder(), [getConstantEncoder(getU8Encoder().encode(2))]),
                 { prefix: null },
             ),
         ],
@@ -149,9 +137,7 @@ export function getTokenDecoder(): Decoder<Token> {
         [
             'extensions',
             getOptionDecoder(
-                getHiddenPrefixDecoder(getArrayDecoder(getExtensionDecoder(), { size: 'remainder' }), [
-                    getConstantDecoder(getU8Encoder().encode(2)),
-                ]),
+                getHiddenPrefixDecoder(getExtensionsDecoder(), [getConstantDecoder(getU8Encoder().encode(2))]),
                 { prefix: null },
             ),
         ],

--- a/clients/js/src/generated/instructions/createAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/createAssociatedToken.ts
@@ -165,11 +165,14 @@ export async function getCreateAssociatedTokenInstructionAsync<
             'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
     }
     if (!accounts.ata.value) {
-        accounts.ata.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.ata.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.systemProgram.value) {
         accounts.systemProgram.value =

--- a/clients/js/src/generated/instructions/createAssociatedTokenIdempotent.ts
+++ b/clients/js/src/generated/instructions/createAssociatedTokenIdempotent.ts
@@ -165,11 +165,14 @@ export async function getCreateAssociatedTokenIdempotentInstructionAsync<
             'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
     }
     if (!accounts.ata.value) {
-        accounts.ata.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
-        });
+        accounts.ata.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('owner', accounts.owner.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount('mint', accounts.mint.value),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.systemProgram.value) {
         accounts.systemProgram.value =

--- a/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
+++ b/clients/js/src/generated/instructions/recoverNestedAssociatedToken.ts
@@ -187,37 +187,46 @@ export async function getRecoverNestedAssociatedTokenInstructionAsync<
             'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb' as Address<'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'>;
     }
     if (!accounts.ownerAssociatedAccountAddress.value) {
-        accounts.ownerAssociatedAccountAddress.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount(
-                'ownerTokenMintAddress',
-                accounts.ownerTokenMintAddress.value,
-            ),
-        });
+        accounts.ownerAssociatedAccountAddress.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount(
+                    'ownerTokenMintAddress',
+                    accounts.ownerTokenMintAddress.value,
+                ),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.nestedAssociatedAccountAddress.value) {
-        accounts.nestedAssociatedAccountAddress.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount(
-                'ownerAssociatedAccountAddress',
-                accounts.ownerAssociatedAccountAddress.value,
-            ),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount(
-                'nestedTokenMintAddress',
-                accounts.nestedTokenMintAddress.value,
-            ),
-        });
+        accounts.nestedAssociatedAccountAddress.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount(
+                    'ownerAssociatedAccountAddress',
+                    accounts.ownerAssociatedAccountAddress.value,
+                ),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount(
+                    'nestedTokenMintAddress',
+                    accounts.nestedTokenMintAddress.value,
+                ),
+            },
+            { programAddress },
+        );
     }
     if (!accounts.destinationAssociatedAccountAddress.value) {
-        accounts.destinationAssociatedAccountAddress.value = await findAssociatedTokenPda({
-            owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
-            tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
-            mint: getAddressFromResolvedInstructionAccount(
-                'nestedTokenMintAddress',
-                accounts.nestedTokenMintAddress.value,
-            ),
-        });
+        accounts.destinationAssociatedAccountAddress.value = await findAssociatedTokenPda(
+            {
+                owner: getAddressFromResolvedInstructionAccount('walletAddress', accounts.walletAddress.value),
+                tokenProgram: getAddressFromResolvedInstructionAccount('tokenProgram', accounts.tokenProgram.value),
+                mint: getAddressFromResolvedInstructionAccount(
+                    'nestedTokenMintAddress',
+                    accounts.nestedTokenMintAddress.value,
+                ),
+            },
+            { programAddress },
+        );
     }
 
     const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/clients/js/src/getMintSize.ts
+++ b/clients/js/src/getMintSize.ts
@@ -1,12 +1,13 @@
-import { getArrayEncoder, getConstantEncoder, getHiddenPrefixEncoder, getU8Encoder, padLeftEncoder } from '@solana/kit';
+import { getConstantEncoder, getHiddenPrefixEncoder, getU8Encoder, padLeftEncoder } from '@solana/kit';
 
-import { ExtensionArgs, getExtensionEncoder } from './generated';
+import { ExtensionArgs } from './generated';
+import { getExtensionsEncoder } from './hooked';
 
 const MINT_BASE_SIZE = 82;
 
 export function getMintSize(extensions?: ExtensionArgs[]): number {
     if (extensions == null) return MINT_BASE_SIZE;
-    const tvlEncoder = getHiddenPrefixEncoder(getArrayEncoder(getExtensionEncoder(), { size: 'remainder' }), [
+    const tvlEncoder = getHiddenPrefixEncoder(getExtensionsEncoder(), [
         getConstantEncoder(padLeftEncoder(getU8Encoder(), 83).encode(1)),
     ]);
     return MINT_BASE_SIZE + tvlEncoder.encode(extensions).length;

--- a/clients/js/src/getTokenSize.ts
+++ b/clients/js/src/getTokenSize.ts
@@ -1,13 +1,12 @@
-import { getArrayEncoder, getConstantEncoder, getHiddenPrefixEncoder, getU8Encoder } from '@solana/kit';
+import { getConstantEncoder, getHiddenPrefixEncoder, getU8Encoder } from '@solana/kit';
 
-import { ExtensionArgs, getExtensionEncoder } from './generated';
+import { ExtensionArgs } from './generated';
+import { getExtensionsEncoder } from './hooked';
 
 const TOKEN_BASE_SIZE = 165;
 
 export function getTokenSize(extensions?: ExtensionArgs[]): number {
     if (extensions == null) return TOKEN_BASE_SIZE;
-    const tvlEncoder = getHiddenPrefixEncoder(getArrayEncoder(getExtensionEncoder(), { size: 'remainder' }), [
-        getConstantEncoder(getU8Encoder().encode(2)),
-    ]);
+    const tvlEncoder = getHiddenPrefixEncoder(getExtensionsEncoder(), [getConstantEncoder(getU8Encoder().encode(2))]);
     return TOKEN_BASE_SIZE + tvlEncoder.encode(extensions).length;
 }

--- a/clients/js/src/hooked/extensions.ts
+++ b/clients/js/src/hooked/extensions.ts
@@ -1,0 +1,77 @@
+import {
+    combineCodec,
+    createDecoder,
+    getArrayEncoder,
+    getU16Decoder,
+    type Codec,
+    type Decoder,
+    type Encoder,
+} from '@solana/kit';
+
+import { getExtensionDecoder, getExtensionEncoder, type Extension, type ExtensionArgs } from '../generated/types';
+
+/**
+ * The list of extensions stored in the TLV region of a `Mint` or `Token` account.
+ */
+export type Extensions = Array<Extension>;
+
+/**
+ * The list of extensions accepted when encoding the TLV region of a `Mint` or `Token` account.
+ */
+export type ExtensionsArgs = Array<ExtensionArgs>;
+
+// Number of bytes used by the `type` header of a TLV entry (`ExtensionType` is a `u16`).
+const EXTENSION_TYPE_SIZE = 2;
+
+// Discriminator of the `Uninitialized` extension type, used as padding at the end of the TLV region.
+const UNINITIALIZED_EXTENSION_TYPE = 0;
+
+/**
+ * Encodes the extensions of a `Mint` or `Token` account as consecutive TLV entries.
+ *
+ * The encoder adds no padding of its own; the program appends `Uninitialized` padding
+ * when needed (e.g. to avoid colliding with the `Multisig` account length). An explicit
+ * `{ __kind: 'Uninitialized' }` entry still encodes as a two-byte header.
+ */
+export function getExtensionsEncoder(): Encoder<ExtensionsArgs> {
+    return getArrayEncoder(getExtensionEncoder(), { size: 'remainder' });
+}
+
+/**
+ * Decodes the extensions of a `Mint` or `Token` account from its TLV region.
+ *
+ * Mirrors the program's `try_for_each_tlv_extension_type`: entries are read one after the
+ * other until an `Uninitialized` (type `0`) header is found or fewer than two bytes remain.
+ * Anything after that point is unused space and is ignored, so accounts allocated with
+ * spare room (of any size, including odd or two-byte multisig padding) decode correctly.
+ *
+ * `Uninitialized` padding entries are never included in the decoded list.
+ *
+ * The TLV region is expected to extend to the end of the buffer: the decoder consumes any
+ * trailing bytes, so it must be the last field of the enclosing struct.
+ */
+export function getExtensionsDecoder(): Decoder<Extensions> {
+    const extensionDecoder = getExtensionDecoder();
+    const extensionTypeDecoder = getU16Decoder();
+    return createDecoder({
+        read: (bytes, offset) => {
+            const extensions: Extensions = [];
+            while (offset + EXTENSION_TYPE_SIZE <= bytes.length) {
+                const [extensionType] = extensionTypeDecoder.read(bytes, offset);
+                if (extensionType === UNINITIALIZED_EXTENSION_TYPE) break;
+                const [extension, nextOffset] = extensionDecoder.read(bytes, offset);
+                extensions.push(extension);
+                offset = nextOffset;
+            }
+            // Consume the remaining (unused) bytes so the enclosing codecs see the whole region as read.
+            return [extensions, bytes.length];
+        },
+    });
+}
+
+/**
+ * Codec for the extensions of a `Mint` or `Token` account.
+ */
+export function getExtensionsCodec(): Codec<ExtensionsArgs, Extensions> {
+    return combineCodec(getExtensionsEncoder(), getExtensionsDecoder());
+}

--- a/clients/js/src/hooked/index.ts
+++ b/clients/js/src/hooked/index.ts
@@ -1,0 +1,1 @@
+export * from './extensions';

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,4 +1,5 @@
 export * from './generated';
+export * from './hooked';
 
 // Generated overrides (must be re-exported explicitly).
 export {

--- a/clients/js/test/accounts/mint.test.ts
+++ b/clients/js/test/accounts/mint.test.ts
@@ -1,7 +1,7 @@
-import { getBase64Encoder, none, some } from '@solana/kit';
+import { address, getBase64Encoder, none, some } from '@solana/kit';
 import { expect, it } from 'vitest';
 
-import { AccountState, Mint, getMintDecoder } from '../../src';
+import { AccountState, type ExtensionArgs, Mint, getMintDecoder, getMintEncoder } from '../../src';
 
 it('decodes a mint account with extensions', () => {
     // Given an encoded mega mint account.
@@ -105,4 +105,46 @@ it('decodes a mint account with extensions', () => {
             },
         ]),
     });
+});
+
+// Mint accounts can legally be allocated with more space than their extensions
+// require (the program pads mints by 2 bytes when they would otherwise be the
+// size of a multisig). The program stops reading the TLV region at the first
+// `Uninitialized` (type 0) header or when fewer than 2 bytes remain, so the
+// unused tail can have any length. The decoder must mirror that and never
+// surface the padding.
+const encodeMintWithUnusedSpace = (extensions: ExtensionArgs[], freeBytes: number) => {
+    const base = getMintEncoder().encode({
+        mintAuthority: some(address('FdrdFuo1RQ9LrQ3FRfQUE7RigyANe5kFNLyMhCYk1xgJ')),
+        supply: 0n,
+        decimals: 9,
+        isInitialized: true,
+        freezeAuthority: none(),
+        extensions: some(extensions),
+    });
+    const data = new Uint8Array(base.length + freeBytes);
+    data.set(base, 0);
+    return data;
+};
+
+it.each([1, 2, 5, 6, 8])('decodes a mint account with no extensions and %i bytes of unused space', freeBytes => {
+    // Given a mint account whose extension region is entirely unused.
+    const data = encodeMintWithUnusedSpace([], freeBytes);
+
+    // When we decode it, then it does not throw and no extensions are reported.
+    const decodedData = getMintDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(some([]));
+});
+
+it.each([1, 2, 5, 6, 8])('decodes a mint account with extensions followed by %i bytes of unused space', freeBytes => {
+    // Given a mint account with real extensions followed by unused space.
+    const extensions: ExtensionArgs[] = [
+        { __kind: 'NonTransferable' },
+        { __kind: 'PermanentDelegate', delegate: address('5gSwsLGzyCwgwPJSnxjsQCaFeE19ZFaibHMLky9TDFim') },
+    ];
+    const data = encodeMintWithUnusedSpace(extensions, freeBytes);
+
+    // When we decode it, then only the real extensions are reported.
+    const decodedData = getMintDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(some(extensions));
 });

--- a/clients/js/test/accounts/token.test.ts
+++ b/clients/js/test/accounts/token.test.ts
@@ -1,7 +1,7 @@
-import { getBase16Encoder, getBase64Encoder, none, some } from '@solana/kit';
+import { address, getBase16Encoder, getBase64Encoder, none, some } from '@solana/kit';
 import { expect, it } from 'vitest';
 
-import { AccountState, Token, getTokenDecoder } from '../../src';
+import { AccountState, type ExtensionArgs, Token, getTokenDecoder, getTokenEncoder } from '../../src';
 
 it('decodes a token account with extensions', () => {
     // Given an encoded mega token account.
@@ -52,4 +52,60 @@ it('decodes a token account with extensions', () => {
             },
         ]),
     });
+});
+
+// Token accounts can legally be allocated with more space than their extensions
+// require (e.g. `InitializeAccount3` only checks `required <= actual`, and the
+// program pads accounts by 2 bytes when they would otherwise be the size of a
+// multisig). The program stops reading the TLV region at the first `Uninitialized`
+// (type 0) header or when fewer than 2 bytes remain, so the unused tail can have
+// any length. The decoder must mirror that and never surface the padding.
+const encodeTokenWithUnusedSpace = (extensions: ExtensionArgs[], freeBytes: number) => {
+    const base = getTokenEncoder().encode({
+        mint: address('5gSwsLGzyCwgwPJSnxjsQCaFeE19ZFaibHMLky9TDFim'),
+        owner: address('FdrdFuo1RQ9LrQ3FRfQUE7RigyANe5kFNLyMhCYk1xgJ'),
+        amount: 0n,
+        delegate: none(),
+        state: AccountState.Initialized,
+        isNative: none(),
+        delegatedAmount: 0n,
+        closeAuthority: none(),
+        extensions: some(extensions),
+    });
+    const data = new Uint8Array(base.length + freeBytes);
+    data.set(base, 0);
+    return data;
+};
+
+it.each([1, 2, 5, 6, 8])('decodes a token account with no extensions and %i bytes of unused space', freeBytes => {
+    // Given a token account whose extension region is entirely unused.
+    const data = encodeTokenWithUnusedSpace([], freeBytes);
+
+    // When we decode it, then it does not throw and no extensions are reported.
+    const decodedData = getTokenDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(some([]));
+});
+
+it.each([1, 2, 5, 6, 8])('decodes a token account with extensions followed by %i bytes of unused space', freeBytes => {
+    // Given a token account with real extensions followed by unused space.
+    const extensions: ExtensionArgs[] = [
+        { __kind: 'ImmutableOwner' },
+        { __kind: 'TransferFeeAmount', withheldAmount: 42n },
+    ];
+    const data = encodeTokenWithUnusedSpace(extensions, freeBytes);
+
+    // When we decode it, then only the real extensions are reported.
+    const decodedData = getTokenDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(some(extensions));
+});
+
+it('decodes the minimal account shape from issue #1448', () => {
+    // Given a bare token account with a single trailing byte of unused space:
+    // 165 base bytes, the account type byte, and one byte that cannot hold a TLV header.
+    const data = new Uint8Array(165 + 1 + 1);
+    data[165] = 2; // AccountType::Account
+
+    // When we decode it, then it does not throw and no extensions are reported.
+    const decodedData = getTokenDecoder().decode(data);
+    expect(decodedData.extensions).toStrictEqual(some([]));
 });

--- a/codama.mjs
+++ b/codama.mjs
@@ -1,6 +1,41 @@
+import * as c from 'codama';
+
 export default {
     idl: 'idl.json',
-    before: [],
+    before: [
+        {
+            // The `extensions` field of the `mint` and `token` accounts is a TLV region that may
+            // be followed by unused space of any size. Codama cannot express "stop at the first
+            // `Uninitialized` header", so the inner extension array is swapped for a hand-written
+            // codec (see `clients/js/src/hooked/extensions.ts`) that mirrors the program's TLV
+            // walk. The surrounding `remainderOption` and `hiddenPrefix` (account type byte)
+            // wrappers stay generated.
+            from: 'codama#bottomUpTransformerVisitor',
+            args: [
+                [
+                    {
+                        select: '[accountNode].[structFieldTypeNode]extensions.[hiddenPrefixTypeNode].[arrayTypeNode]',
+                        transform: () => c.definedTypeLinkNode('extensions'),
+                    },
+                ],
+                {
+                    // Only walk down to the account fields: some enum variants in the IDL wrap
+                    // their struct in a `sizePrefixTypeNode`, which the transformer's node
+                    // constructors reject.
+                    keys: [
+                        'rootNode',
+                        'programNode',
+                        'accountNode',
+                        'structTypeNode',
+                        'structFieldTypeNode',
+                        'remainderOptionTypeNode',
+                        'hiddenPrefixTypeNode',
+                        'arrayTypeNode',
+                    ],
+                },
+            ],
+        },
+    ],
     scripts: {
         js: {
             from: '@codama/renderers-js',
@@ -8,6 +43,9 @@ export default {
                 'clients/js',
                 {
                     kitImportStrategy: 'rootOnly',
+                    linkOverrides: {
+                        definedTypes: { extensions: 'hooked' },
+                    },
                     // The program was historically named `token-2022` in the IDL, which gave the
                     // generated `TOKEN_2022_*` identifiers. Codama normalises names to camelCase
                     // (`token2022`), so the public identifiers are pinned here to keep the API stable.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "devDependencies": {
-        "@codama/renderers-js": "^2.3.0",
+        "@codama/renderers-js": "^2.4.0",
         "@codama/renderers-rust": "^3.1.3",
         "codama": "^1.10.0",
         "typescript": "^7.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@codama/renderers-js':
-        specifier: ^2.3.0
-        version: 2.3.0(typescript@7.0.2)
+        specifier: ^2.4.0
+        version: 2.4.0(typescript@7.0.2)
       '@codama/renderers-rust':
         specifier: ^3.1.3
         version: 3.1.3(typescript@7.0.2)
@@ -31,36 +31,20 @@ packages:
     resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
-  '@codama/errors@1.8.0':
-    resolution: {integrity: sha512-A0FNhbfS1PBSK0nS+g65IR8+OKkifuIJCCnLCUBXb+I/OYMGlJMycMpU4pwAEEGS5GAnue7D/llXE+KpUaMi8w==}
-    hasBin: true
-
-  '@codama/fragments@0.1.1':
-    resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
-
   '@codama/fragments@0.1.3':
     resolution: {integrity: sha512-ITa3UYs74AWx7se/6EZN+YXqV1Vu89L3n2v0/irsQNbPcy8wP26p/GKns/1H4a8vGvAKuzWdIGO535dwcauInw==}
 
   '@codama/node-types@1.10.0':
     resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
 
-  '@codama/node-types@1.8.0':
-    resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
-
   '@codama/nodes@1.10.0':
     resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
-
-  '@codama/nodes@1.8.0':
-    resolution: {integrity: sha512-rl+7BxYatAE6uq5h9b5fEilGLd3YeJaJxqgLDAvdKQ5pspq6ch5ww9NiigkwdvDYli1Yk56PRhMZdLsiZIVgAA==}
 
   '@codama/renderers-core@1.3.11':
     resolution: {integrity: sha512-VSGrfmwPVv5cRAiHitgIq+rc9ktIN/Q9czbUORaqhZCmM+M3Ux5cd5r90PVTbeIt8vI0Zlw74OUFwdKqdEfSNw==}
 
-  '@codama/renderers-core@1.3.9':
-    resolution: {integrity: sha512-DwMxltM+cldAK+rgtE3jVOmrGZuP7fA/ZLu6vgrsQYBp5dkOXCyiGBdpAz0VlhxaN4lB5TzT2Ia+EVv5G4YdGQ==}
-
-  '@codama/renderers-js@2.3.0':
-    resolution: {integrity: sha512-PSvoLATBx7EomzZgCXegPTn5TxaFjA+NIraNUx22vNZ6rxPxu5Tctq8KxeXaaPCnKLpBUKcwmhUPRO4QLNQlvg==}
+  '@codama/renderers-js@2.4.0':
+    resolution: {integrity: sha512-nLmLy8eSaBtnff5OE85SXvdL4rN4QSkCSZfZ4856zwnPndP/UzV/RBNoZOp1+muMj1VIKMZ1gXLzKQjDeYM3EA==}
     engines: {node: '>=20.18.0'}
 
   '@codama/renderers-rust@3.1.3':
@@ -73,35 +57,14 @@ packages:
   '@codama/visitors-core@1.10.0':
     resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
-  '@codama/visitors-core@1.8.0':
-    resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
-
   '@codama/visitors@1.10.0':
     resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
-  '@solana/codecs-core@6.9.0':
-    resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@solana/codecs-core@7.0.0':
     resolution: {integrity: sha512-6HtEisZEtFb6okARUgYqmKdDbn2aHRrSCDgB1/GEwr0s6fK5XNYpafaSjorbs2MEyZV3tCUFTj2j6fk/4nNcLg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@solana/codecs-numbers@6.9.0':
-    resolution: {integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -118,18 +81,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.9.0':
-    resolution: {integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
-      fastestsmallesttextencoderdecoder:
-        optional: true
-      typescript:
-        optional: true
-
   '@solana/codecs-strings@7.0.0':
     resolution: {integrity: sha512-zXE1PE9HkVk6phZ6aqHTXvLZ0qIl5bJNIvG9eMB7LuFO1XBVQywJUtjKS8fE3/xmRCWSMilFSrEXGA+SpOyLrQ==}
     engines: {node: '>=20.18.0'}
@@ -139,16 +90,6 @@ packages:
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
-      typescript:
-        optional: true
-
-  '@solana/errors@6.9.0':
-    resolution: {integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==}
-    engines: {node: '>=20.18.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.4.0'
-    peerDependenciesMeta:
       typescript:
         optional: true
 
@@ -410,11 +351,6 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -449,33 +385,16 @@ snapshots:
       commander: 14.0.3
       picocolors: 1.1.1
 
-  '@codama/errors@1.8.0':
-    dependencies:
-      '@codama/node-types': 1.8.0
-      commander: 14.0.3
-      picocolors: 1.1.1
-
-  '@codama/fragments@0.1.1':
-    dependencies:
-      '@codama/errors': 1.8.0
-
   '@codama/fragments@0.1.3':
     dependencies:
       '@codama/errors': 1.10.0
 
   '@codama/node-types@1.10.0': {}
 
-  '@codama/node-types@1.8.0': {}
-
   '@codama/nodes@1.10.0':
     dependencies:
       '@codama/errors': 1.10.0
       '@codama/node-types': 1.10.0
-
-  '@codama/nodes@1.8.0':
-    dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/node-types': 1.8.0
 
   '@codama/renderers-core@1.3.11':
     dependencies:
@@ -484,22 +403,15 @@ snapshots:
       '@codama/nodes': 1.10.0
       '@codama/visitors-core': 1.10.0
 
-  '@codama/renderers-core@1.3.9':
+  '@codama/renderers-js@2.4.0(typescript@7.0.2)':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/fragments': 0.1.1
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
-
-  '@codama/renderers-js@2.3.0(typescript@7.0.2)':
-    dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/renderers-core': 1.3.9
-      '@codama/visitors-core': 1.8.0
-      '@solana/codecs-strings': 6.9.0(typescript@7.0.2)
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/renderers-core': 1.3.11
+      '@codama/visitors-core': 1.10.0
+      '@solana/codecs-strings': 7.0.0(typescript@7.0.2)
       prettier: 3.8.4
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
@@ -531,12 +443,6 @@ snapshots:
       '@codama/nodes': 1.10.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors-core@1.8.0':
-    dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      json-stable-stringify: 1.3.0
-
   '@codama/visitors@1.10.0':
     dependencies:
       '@codama/errors': 1.10.0
@@ -545,22 +451,9 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
-  '@solana/codecs-core@6.9.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/errors': 6.9.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
   '@solana/codecs-core@7.0.0(typescript@7.0.2)':
     dependencies:
       '@solana/errors': 7.0.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/codecs-numbers@6.9.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@7.0.2)
-      '@solana/errors': 6.9.0(typescript@7.0.2)
     optionalDependencies:
       typescript: 7.0.2
 
@@ -571,26 +464,11 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  '@solana/codecs-strings@6.9.0(typescript@7.0.2)':
-    dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@7.0.2)
-      '@solana/codecs-numbers': 6.9.0(typescript@7.0.2)
-      '@solana/errors': 6.9.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
   '@solana/codecs-strings@7.0.0(typescript@7.0.2)':
     dependencies:
       '@solana/codecs-core': 7.0.0(typescript@7.0.2)
       '@solana/codecs-numbers': 7.0.0(typescript@7.0.2)
       '@solana/errors': 7.0.0(typescript@7.0.2)
-    optionalDependencies:
-      typescript: 7.0.2
-
-  '@solana/errors@6.9.0(typescript@7.0.2)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 14.0.3
     optionalDependencies:
       typescript: 7.0.2
 
@@ -782,8 +660,6 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
-
-  semver@7.8.4: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
This PR fixes `decodeToken` and `decodeMint` throwing on accounts allocated with unused extension space, and stops them reporting `Uninitialized` padding as extensions. It builds on #1450, which made the program node name survive Codama transformer visitors.

The generated `extensions` codec decoded the TLV region as a `remainder` array of `Extension`, so it had to consume every trailing byte as an entry. The program does not work that way: `try_for_each_tlv_extension_type` stops at the first `Uninitialized` (type `0`) header, or when fewer than two bytes remain, and ignores whatever follows. The unused tail can therefore have any length, including the two-byte padding the program adds to avoid colliding with the multisig account size, so a `remainder` array either throws on odd tails (the case in #1448) or surfaces padding as spurious `Uninitialized` entries.

Codama has no node for "stop at a discriminator" (`sentinelTypeNode` scans raw bytes and would match `00 00` inside extension data), so the inner extension array is swapped for a hand-written codec that mirrors the program's TLV walk. A `before` visitor in `codama.mjs` replaces the array with a link to `extensions`, which `linkOverrides` resolves to `clients/js/src/hooked/extensions.ts`. The surrounding `remainderOption` and `hiddenPrefix` wrappers, the IDL, and the `Extension` codec itself are unchanged, so `Uninitialized` still encodes as two bytes and `getTokenSize`/`getMintSize` are unaffected. Decoded `extensions` no longer contain `Uninitialized` entries, matching the program and `@solana/spl-token`.

`@codama/renderers-js` is bumped to 2.4.0 because 2.3.0 bundled `@codama/nodes` 1.8.0, whose `getAllAccounts` crashes on programs without accounts once a visitor has rebuilt the tree. The bump also makes the associated token instructions forward the configured program address to `findAssociatedTokenPda`.

Regression tests cover both accounts with 1, 2, 5, 6 and 8 bytes of unused space, with and without real extensions preceding it, plus the minimal shape from the issue. All of them fail on `main`.

Fixes #1448.